### PR TITLE
chore: some top level commands with default `ls` subcommand

### DIFF
--- a/src/cli/cfg.rs
+++ b/src/cli/cfg.rs
@@ -18,7 +18,7 @@ pub fn cmd() -> Command {
              branch-prefix, workspaces-dir, gc.retention-days, git_config.* overrides, \
              and language integration toggles. Use `wsp config ls` to see all current values.",
         )
-        .subcommand_required(true)
+        .subcommand_required(false)
         .subcommand(list_cmd())
         .subcommand(get_cmd())
         .subcommand(set_cmd())
@@ -31,6 +31,7 @@ pub fn dispatch(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
         Some(("get", m)) => run_get(m, paths),
         Some(("set", m)) => run_set(m, paths),
         Some(("unset", m)) => run_unset(m, paths),
+        None => run_list(matches, paths),
         _ => unreachable!(),
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -61,7 +61,7 @@ pub fn build_cli() -> Command {
              Add, remove, list, and fetch repos within the current workspace. Must be run \
              from inside a workspace directory.",
         )
-        .subcommand_required(true)
+        .subcommand_required(false)
         .subcommand(add::cmd())
         .subcommand(remove::cmd())
         .subcommand(fetch::cmd())
@@ -185,6 +185,7 @@ pub fn dispatch(matches: &ArgMatches, paths: &Paths) -> anyhow::Result<Output> {
             Some(("rm", m)) => remove::run(m, paths),
             Some(("fetch", m)) => fetch::run(m, paths),
             Some(("ls", m)) => repo_list::run(m, paths),
+            None => repo_list::run(sub, paths),
             _ => unreachable!(),
         },
 

--- a/src/cli/registry.rs
+++ b/src/cli/registry.rs
@@ -15,7 +15,7 @@ pub fn cmd() -> Command {
              registered before they can be added to workspaces. Registration also creates a \
              local bare mirror used to speed up cloning and fetching.",
         )
-        .subcommand_required(true)
+        .subcommand_required(false)
         .subcommand(repo::add_cmd())
         .subcommand(repo::list_cmd())
         .subcommand(repo::rm_cmd())
@@ -26,6 +26,7 @@ pub fn dispatch(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
         Some(("add", m)) => repo::run_add(m, paths),
         Some(("ls", m)) => repo::run_list(m, paths),
         Some(("rm", m)) => repo::run_remove(m, paths),
+        None => repo::run_list(matches, paths),
         _ => unreachable!(),
     }
 }

--- a/src/cli/template.rs
+++ b/src/cli/template.rs
@@ -25,7 +25,7 @@ pub fn cmd() -> Command {
              config overrides, and optional AGENTS.md content for AI coding assistants. \
              Create workspaces from templates with `wsp new -t <name>`.",
         )
-        .subcommand_required(true)
+        .subcommand_required(false)
         .subcommand(new_cmd())
         .subcommand(import_cmd())
         .subcommand(list_cmd())
@@ -50,6 +50,7 @@ pub fn dispatch(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
         Some(("repo", m)) => dispatch_repo(m, paths),
         Some(("config", m)) => dispatch_config(m, paths),
         Some(("agent-md", m)) => dispatch_agent_md(m, paths),
+        None => run_list(matches, paths),
         _ => unreachable!(),
     }
 }


### PR DESCRIPTION
- wsp repo -> wsp repo ls
- wsp registry -> wsp registry ls
- wsp template -> wsp template ls
- wsp config -> wsp config ls
- wsp recover -> wsp recover ls

<img width="1918" height="918" alt="image" src="https://github.com/user-attachments/assets/c4bc9dcb-83f4-4e9e-a6f2-c615ca5519a2" />