### PR TITLE
feat(init): add wsp init to scaffold per-repo .wsp.yaml

### DIFF
--- a/crates/wsp/src/cli/help.rs
+++ b/crates/wsp/src/cli/help.rs
@@ -122,7 +122,7 @@ Outside a workspace, commands always use global config.
 
 Workspace-scoped keys: sync-strategy, git.*, lang.*
 Global-only keys: branch-prefix, workspaces-dir, gc.retention-days, agent-md,
-                  shell.tmux, shell.prompt
+                  hints, advice.*, shell.tmux, shell.prompt
 
 Config hierarchy (top wins): workspace → global → built-in defaults.
 
@@ -185,6 +185,17 @@ LANGUAGE INTEGRATIONS
                         Available: go (generates go.work for multi-module repos).
                         Default: false
 
+HINTS
+
+  hints                 Boolean. Master switch for all contextual hints.
+                        Set to false to silence all hints globally.
+                        Default: true
+
+  advice.<key>          Boolean. Suppress a specific hint by key.
+                        Keys: branchPrefix, setupCommands
+                        Example: `wsp config set advice.branchPrefix false`
+                        Default: true (hint enabled)
+
 EXAMPLES
 
   wsp config ls                                   # show all settings (workspace-aware)
@@ -196,6 +207,56 @@ EXAMPLES
   wsp config set shell.prompt true                      # enable prompt variable (global)
   wsp config unset sync-strategy                  # unset workspace override
   wsp config unset --global branch-prefix         # revert global to default
+",
+    ),
+    (
+        "wsp.yaml",
+        "Per-repo .wsp.yaml and setup_commands",
+        "\
+wsp.yaml — per-repo .wsp.yaml and setup_commands
+
+Individual repos can declare post-clone setup commands in their own .wsp.yaml,
+committed to the repo root. When wsp clones a repo into a workspace, it reads
+this file and offers to run the listed commands.
+
+SCAFFOLDING
+
+  wsp init                     Interactive wizard: creates or updates .wsp.yaml
+                               in the current git repo.
+  wsp init --print-sample      Print a commented sample .wsp.yaml to stdout.
+
+SETUP_COMMANDS
+
+  The setup_commands field holds a list of shell commands to run after cloning:
+
+    setup_commands:
+      - task setup
+      - lefthook install
+
+  wsp always prompts before running:
+
+    Setup commands for github.com/acme/api-gateway:
+      task setup
+      lefthook install
+    Run these commands? [y/always/N]
+
+  y        Run once; prompt again next time.
+  always   Run automatically; re-prompts only if the command list changes.
+  N/Enter  Skip.
+
+  'always' decisions are stored by SHA-256 hash of the command list in
+  ~/.local/share/wsp/approvals.yaml. Changing the command list triggers a
+  fresh prompt automatically.
+
+RUNNING SETUP MANUALLY
+
+  wsp repo setup               Run setup commands for all repos in the current
+                               workspace (prompts for any unapproved).
+  wsp repo setup <repo>        Run for a specific repo.
+  wsp repo setup --force       Re-prompt even if previously approved.
+
+  wsp doctor (W15) warns when a repo has setup_commands with no Always approval.
+  wsp doctor --fix invokes the interactive approval flow.
 ",
     ),
 ];

--- a/crates/wsp/src/cli/init.rs
+++ b/crates/wsp/src/cli/init.rs
@@ -1,0 +1,272 @@
+//! `wsp init` — scaffold or update a per-repo `.wsp.yaml` with `setup_commands`.
+
+use std::io::Write as _;
+use std::path::Path;
+
+use anyhow::Result;
+use clap::{Arg, ArgMatches, Command};
+
+use wsp_core::config::Paths;
+use wsp_core::output::{MutationOutput, Output};
+
+pub fn cmd() -> Command {
+    Command::new("init")
+        .about("Create or update .wsp.yaml in the current repo")
+        .long_about(
+            "Create or update .wsp.yaml in the current repo.\n\n\
+             Must be run from the root of a git repo. Interactively prompts for \
+             setup_commands (post-clone hooks such as 'task setup' or 'lefthook install'). \
+             If .wsp.yaml already exists, shows existing commands and lets you add or \
+             replace them.\n\n\
+             Use --print-sample to print a commented sample .wsp.yaml to stdout and exit.",
+        )
+        .arg(
+            Arg::new("print-sample")
+                .long("print-sample")
+                .action(clap::ArgAction::SetTrue)
+                .help("Print a commented sample .wsp.yaml to stdout and exit"),
+        )
+}
+
+pub fn run(matches: &ArgMatches, _paths: &Paths) -> Result<Output> {
+    if matches.get_flag("print-sample") {
+        print_sample();
+        return Ok(Output::None);
+    }
+
+    if !std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+        anyhow::bail!(
+            "wsp init requires an interactive terminal.\n\
+             To generate a sample .wsp.yaml without prompts, run: wsp init --print-sample"
+        );
+    }
+
+    let cwd = std::env::current_dir()?;
+    check_git_repo(&cwd)?;
+
+    let existing =
+        wsp_core::template::read_setup_commands(&cwd.join(".wsp.yaml")).unwrap_or_default();
+    let commands = prompt_for_commands(&existing)?;
+
+    write_setup_commands(&cwd.join(".wsp.yaml"), &commands)?;
+
+    eprintln!("Wrote .wsp.yaml");
+    eprintln!("Run `wsp repo setup` inside a workspace to execute these commands.");
+
+    Ok(Output::Mutation(MutationOutput::new(
+        "Wrote .wsp.yaml with setup_commands.",
+    )))
+}
+
+fn check_git_repo(dir: &Path) -> Result<()> {
+    // Use --show-toplevel to verify dir is the repo root, not just inside one.
+    // Running `wsp init` from a subdirectory would write .wsp.yaml there, which
+    // wsp cannot discover when cloning.
+    let out = std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(dir)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()?;
+    if !out.status.success() {
+        anyhow::bail!(
+            "not a git repository: {}\n\
+             wsp init must be run from the root of a git repo.",
+            dir.display()
+        );
+    }
+    let toplevel = std::path::Path::new(std::str::from_utf8(&out.stdout)?.trim());
+    // Canonicalize both sides — macOS /var -> /private/var symlink can cause mismatches.
+    if dir.canonicalize()? != toplevel.canonicalize()? {
+        anyhow::bail!(
+            "not at repo root: {}\n\
+             wsp init must be run from the repo root, not a subdirectory.\n\
+             Try: cd {} && wsp init",
+            dir.display(),
+            toplevel.display()
+        );
+    }
+    Ok(())
+}
+
+fn prompt_for_commands(existing: &[String]) -> Result<Vec<String>> {
+    if existing.is_empty() {
+        eprintln!("Enter setup_commands (e.g. 'task setup', 'lefthook install').");
+        return collect_commands();
+    }
+
+    eprintln!("Existing setup_commands:");
+    for cmd in existing {
+        eprintln!("  - {}", cmd);
+    }
+    eprint!("\nReplace existing commands? [y/N]: ");
+    std::io::stderr().flush()?;
+    let answer = read_prompt()?;
+
+    if matches!(answer.trim().to_lowercase().as_str(), "y" | "yes") {
+        return collect_commands();
+    }
+
+    eprint!("Add more commands? [y/N]: ");
+    std::io::stderr().flush()?;
+    let answer = read_prompt()?;
+
+    if matches!(answer.trim().to_lowercase().as_str(), "y" | "yes") {
+        let mut commands = existing.to_vec();
+        commands.extend(collect_commands()?);
+        return Ok(commands);
+    }
+
+    Ok(existing.to_vec())
+}
+
+fn collect_commands() -> Result<Vec<String>> {
+    eprintln!("Enter one command per line. Empty line to finish.");
+    let mut commands = Vec::new();
+    loop {
+        eprint!("  command {}: ", commands.len() + 1);
+        std::io::stderr().flush()?;
+        let line = read_prompt()?;
+        let trimmed = line.trim().to_string();
+        if trimmed.is_empty() {
+            break;
+        }
+        commands.push(trimmed);
+    }
+    Ok(commands)
+}
+
+/// Read one line from stdin. Per AGENTS.md: EOF returns `""`, Enter returns `"\n"` --
+/// detect EOF before trimming.
+fn read_prompt() -> Result<String> {
+    let mut line = String::new();
+    std::io::stdin().read_line(&mut line)?;
+    if line.is_empty() {
+        anyhow::bail!("aborted");
+    }
+    Ok(line)
+}
+
+/// Write `setup_commands` into `.wsp.yaml`, preserving any unknown fields.
+/// Uses `serde_yaml_ng::Value` merge + atomic rename to avoid clobbering
+/// fields added by future wsp versions.
+fn write_setup_commands(path: &Path, commands: &[String]) -> Result<()> {
+    let mut doc: serde_yaml_ng::Value = if path.exists() {
+        let content = std::fs::read_to_string(path)?;
+        serde_yaml_ng::from_str(&content)?
+    } else {
+        serde_yaml_ng::Value::Mapping(serde_yaml_ng::Mapping::new())
+    };
+
+    let mapping = doc.as_mapping_mut().ok_or_else(|| {
+        anyhow::anyhow!(".wsp.yaml is not a YAML mapping; cannot update it safely")
+    })?;
+
+    if commands.is_empty() {
+        mapping.remove("setup_commands");
+    } else {
+        let cmds_value = serde_yaml_ng::Value::Sequence(
+            commands
+                .iter()
+                .map(|s| serde_yaml_ng::Value::String(s.clone()))
+                .collect(),
+        );
+        mapping.insert(
+            serde_yaml_ng::Value::String("setup_commands".to_string()),
+            cmds_value,
+        );
+    }
+
+    let yaml_str = serde_yaml_ng::to_string(&doc)?;
+    let parent = path.parent().unwrap_or(Path::new("."));
+    let mut tmp = tempfile::NamedTempFile::new_in(parent)?;
+    tmp.write_all(yaml_str.as_bytes())?;
+    tmp.persist(path)?;
+    Ok(())
+}
+
+fn print_sample() {
+    print!(
+        "# .wsp.yaml - per-repo setup commands\n\
+#\n\
+# Declare commands to run after this repo is cloned into a workspace.\n\
+# wsp will show these commands and prompt for approval before running them.\n\
+# Approve once with 'always' to skip the prompt on future clones.\n\
+#\n\
+# Examples:\n\
+#   setup_commands:\n\
+#     - task setup          # install git hooks, generate files, etc.\n\
+#     - lefthook install\n\
+#     - npm install\n\
+#\n\
+setup_commands: []\n"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_creates_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".wsp.yaml");
+        let cmds = vec!["task setup".to_string(), "lefthook install".to_string()];
+        write_setup_commands(&path, &cmds).unwrap();
+        assert!(path.exists());
+        let back = wsp_core::template::read_setup_commands(&path).unwrap_or_default();
+        assert_eq!(back, cmds);
+    }
+
+    #[test]
+    fn write_preserves_unknown_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".wsp.yaml");
+        std::fs::write(&path, "some_future_key: value\n").unwrap();
+        write_setup_commands(&path, &["task setup".to_string()]).unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            content.contains("some_future_key"),
+            "unknown field lost: {content}"
+        );
+        assert!(
+            content.contains("setup_commands"),
+            "setup_commands missing: {content}"
+        );
+    }
+
+    #[test]
+    fn write_replaces_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".wsp.yaml");
+        write_setup_commands(&path, &["old".to_string()]).unwrap();
+        write_setup_commands(&path, &["new".to_string()]).unwrap();
+        let back = wsp_core::template::read_setup_commands(&path).unwrap_or_default();
+        assert_eq!(back, vec!["new".to_string()]);
+    }
+
+    #[test]
+    fn write_empty_removes_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".wsp.yaml");
+        write_setup_commands(&path, &["task setup".to_string()]).unwrap();
+        write_setup_commands(&path, &[]).unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            !content.contains("setup_commands"),
+            "key not removed: {content}"
+        );
+    }
+
+    #[test]
+    fn write_rejects_non_mapping() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".wsp.yaml");
+        std::fs::write(&path, "- item1\n- item2\n").unwrap();
+        let err = write_setup_commands(&path, &["task setup".to_string()]).unwrap_err();
+        assert!(
+            err.to_string().contains("not a YAML mapping"),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/crates/wsp/src/cli/mod.rs
+++ b/crates/wsp/src/cli/mod.rs
@@ -10,6 +10,7 @@ pub mod doctor;
 pub mod exec;
 pub mod fetch;
 pub mod help;
+pub mod init;
 pub mod list;
 pub mod log;
 pub mod new;
@@ -46,6 +47,7 @@ const HELP_CATEGORIES: &[(&str, &[&str])] = &[
         "Admin",
         &[
             "setup",
+            "init",
             "registry",
             "template",
             "config",
@@ -108,6 +110,7 @@ pub fn build_cli() -> Command {
         .subcommand(repo_ws)
         // Admin commands
         .subcommand(setup::cmd())
+        .subcommand(init::cmd())
         .subcommand(registry::cmd())
         .subcommand(template::cmd())
         .subcommand(cfg::cmd())
@@ -193,6 +196,7 @@ pub fn dispatch(matches: &ArgMatches, paths: &Paths) -> anyhow::Result<Output> {
         Some(("doctor", m)) => doctor::run(m, paths),
         Some(("completion", m)) => completion::run(m, paths),
         Some(("setup", m)) => setup::run(m, paths),
+        Some(("init", m)) => init::run(m, paths),
 
         // --- Dev-only codegen ---
         #[cfg(feature = "codegen")]


### PR DESCRIPTION
## Summary

- New `wsp init` command: interactive wizard to create or update `.wsp.yaml` with `setup_commands`
- `wsp init --print-sample` prints a commented template (no prompts, pipe-safe)
- Preserves unknown YAML fields via `serde_yaml_ng::Value` merge — forward-compatible with future `.wsp.yaml` keys
- Atomic write via `NamedTempFile::persist` — no partial writes on crash
- Guards against running in a repo subdirectory (`git rev-parse --show-toplevel` check)
- Adds `wsp help wsp.yaml` guide documenting setup_commands, approval flow, and `wsp repo setup`

## Tests

`cli::init::tests` in `crates/wsp/src/cli/init.rs`:

- `write_creates_file` — creates `.wsp.yaml` with the given commands
- `write_preserves_unknown_fields` — unknown keys survive a write (forward-compat)
- `write_replaces_existing` — re-running overwrites `setup_commands`
- `write_empty_removes_key` — passing empty commands removes the key entirely
- `write_rejects_non_mapping` — errors if `.wsp.yaml` is not a YAML mapping

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)