### PR TITLE
feat(new): add --empty flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,8 @@ Product: binary `wsp`, metadata `.wsp.yaml`, env `WSP_SHELL`, shell vars `wsp_bi
 - Git output with tty formatting: pass `--color=always` gated on `stdout().is_terminal() && !is_json`
 - Read-only commands get `[read-only]` in `.about()`. Every flag accepting known values needs an `ArgValueCandidates` completer.
 - Clap dispatch: only match primary command name (e.g., `Some(("ls", m))` — not aliases).
-- When a feature ships, close the corresponding GitHub issue. Do not leave roadmap items open with checked boxes.
+- **Boolean "mode" flags + positional args**: `ArgGroup` only enforces mutual exclusion among named flags — it does not cover positional args. If a mode flag (e.g. `--empty`) is incompatible with positionals (e.g. repo args), add an explicit early bail in `run()` or use `.conflicts_with("repos")` on the flag's `Arg` definition.
+- When a feature ships, close the corresponding GitHub issue and remove its section from `docs/roadmap.md` entirely (don't check boxes).
 
 ## Gotchas
 

--- a/crates/wsp-core/src/workspace.rs
+++ b/crates/wsp-core/src/workspace.rs
@@ -5905,4 +5905,47 @@ mod tests {
         assert!(!is_dangerous_git_config_key("commit.gpgsign"));
         assert!(!is_dangerous_git_config_key("push.default"));
     }
+
+    #[test]
+    fn test_create_with_zero_repos() {
+        // `wsp new --empty` passes an empty repo map; workspace and metadata
+        // must be created successfully with no clone directories.
+        use crate::testutil;
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = testutil::make_test_paths(&tmp);
+
+        let empty_refs: BTreeMap<String, String> = BTreeMap::new();
+        let empty_upstreams: BTreeMap<String, String> = BTreeMap::new();
+
+        create(
+            &paths,
+            "myws",
+            &empty_refs,
+            None,
+            None,
+            &empty_upstreams,
+            Some("empty workspace"),
+            None,
+        )
+        .unwrap();
+
+        let ws_dir = dir(&paths.workspaces_dir, "myws");
+        assert!(ws_dir.exists());
+
+        let meta = load_metadata(&ws_dir).unwrap();
+        assert_eq!(meta.name, "myws");
+        assert!(meta.repos.is_empty(), "expected zero repos in metadata");
+
+        // Only .wsp.yaml should exist in the workspace root — no clone dirs.
+        let entries: Vec<_> = fs::read_dir(&ws_dir).unwrap().collect();
+        assert_eq!(
+            entries.len(),
+            1,
+            "expected only .wsp.yaml, found: {:?}",
+            entries
+                .iter()
+                .map(|e| e.as_ref().unwrap().file_name())
+                .collect::<Vec<_>>()
+        );
+    }
 }

--- a/crates/wsp/src/cli/new.rs
+++ b/crates/wsp/src/cli/new.rs
@@ -31,7 +31,9 @@ pub fn cmd() -> Command {
              any missing repos are reported together before cloning begins.\n\n\
              When run inside an existing workspace with no repos specified, automatically \
              copies the repo list from the current workspace. This makes it easy to spin up \
-             parallel workspaces for related features.",
+             parallel workspaces for related features.\n\n\
+             Use --empty to create a workspace with no repos and add them later with \
+             `wsp repo add`. --empty suppresses the implicit copy when run inside a workspace.",
         )
         .arg(Arg::new("workspace").required(false))
         .arg(
@@ -66,9 +68,16 @@ pub fn cmd() -> Command {
                 .help("Create from a template file (.yaml)")
                 .value_hint(clap::ValueHint::FilePath),
         )
+        .arg(
+            Arg::new("empty")
+                .long("empty")
+                .action(clap::ArgAction::SetTrue)
+                .conflicts_with("repos")
+                .help("Create workspace with no repos (add them later with `wsp repo add`)"),
+        )
         .group(
             clap::ArgGroup::new("source")
-                .args(["template", "from-workspace", "file"])
+                .args(["template", "from-workspace", "file", "empty"])
                 .required(false),
         )
         .arg(
@@ -129,6 +138,7 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
     let from_workspace = matches.get_one::<String>("from-workspace");
     let from_file = matches.get_one::<String>("file");
     let no_fetch = matches.get_flag("no-fetch");
+    let empty = matches.get_flag("empty");
     let description = matches.get_one::<String>("description");
 
     let mut cfg = config::Config::load_from(&paths.config_path)
@@ -211,12 +221,14 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
         repo_refs.insert(id, String::new());
     }
 
-    // Implicit -w: if no repos specified and we're inside a workspace, copy its repos
+    // Implicit -w: if no repos specified and we're inside a workspace, copy its repos.
+    // Skipped when --empty is given (user explicitly wants zero repos).
     if repo_refs.is_empty()
         && repo_args.is_empty()
         && template_source.is_none()
         && from_workspace.is_none()
         && from_file.is_none()
+        && !empty
     {
         let cwd = std::env::current_dir()?;
         if let Ok(ws_dir) = workspace::detect(&cwd) {
@@ -240,7 +252,7 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
             created_from = Some(format!("workspace:{}", source_name));
             loaded_template = Some(tmpl);
         } else {
-            bail!("no repos specified (use repo args, -t, -w, or -f)");
+            bail!("no repos specified (use repo args, -t, -w, -f, or --empty)");
         }
     }
 
@@ -481,4 +493,41 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
             .with_duration(duration_ms)
             .with_workspace(ws_name, ws_dir.display().to_string(), branch),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_conflicts_with_repos() {
+        let err = cmd()
+            .try_get_matches_from(["new", "myws", "--empty", "some/repo"])
+            .unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn test_empty_conflicts_with_template() {
+        let err = cmd()
+            .try_get_matches_from(["new", "myws", "--empty", "-t", "mytmpl"])
+            .unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn test_empty_conflicts_with_from_workspace() {
+        let err = cmd()
+            .try_get_matches_from(["new", "myws", "--empty", "-w", "otherws"])
+            .unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn test_empty_conflicts_with_file() {
+        let err = cmd()
+            .try_get_matches_from(["new", "myws", "--empty", "-f", "foo.yaml"])
+            .unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
 }

--- a/skills/wsp-manage/SKILL.md
+++ b/skills/wsp-manage/SKILL.md
@@ -38,7 +38,7 @@ wsp template agent-md                           # Manage template AGENTS.md cont
 ### Workspaces
 
 ```bash
-wsp new [<workspace>] [-b <branch>] [<repos>]... [-t <template>] [-w <from-workspace>] [-f <file>] [--no-fetch] [-d <description>] [--no-discover] # Create a new workspace
+wsp new [<workspace>] [-b <branch>] [<repos>]... [-t <template>] [-w <from-workspace>] [-f <file>] [--empty] [--no-fetch] [-d <description>] [--no-discover] # Create a new workspace
 wsp ls [-t] [-U] [-r]                           # List active workspaces [read-only] (alias: list)
 wsp st [<workspace>] [-v]                       # Git status across workspace repos [read-only] (alias: status)
 wsp diff [<workspace>] [<args>]...              # Show git diff across workspace repos [read-only]


### PR DESCRIPTION
## Summary

- Adds `--empty` to `wsp new` to create a workspace with zero repos
- Mutually exclusive with repo args, `-t`, `-w`, and `-f` (enforced by clap)
- Suppresses implicit repo-copy when run inside an existing workspace
- Updates error message to mention `--empty` as a valid option

## Tests added

- `workspace::tests::test_create_with_zero_repos` — `create` with empty repo map produces valid metadata and no clone dirs
- `new::tests::test_empty_conflicts_with_repos` — clap rejects `--empty` + positional repo args
- `new::tests::test_empty_conflicts_with_template` — clap rejects `--empty -t`
- `new::tests::test_empty_conflicts_with_from_workspace` — clap rejects `--empty -w`
- `new::tests::test_empty_conflicts_with_file` — clap rejects `--empty -f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)