### PR TITLE
feat(setup-commands): multi-layer setup command management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ plan-dist-manifest.json
 .idea/
 .vscode/
 *.code-workspace
+.wsp.yaml.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ Product: binary `wsp`, metadata `.wsp.yaml`, env `WSP_SHELL`, shell vars `wsp_bi
 - Read-only commands get `[read-only]` in `.about()`. Every flag accepting known values needs an `ArgValueCandidates` completer.
 - Clap dispatch: only match primary command name (e.g., `Some(("ls", m))` — not aliases).
 - **Boolean "mode" flags + positional args**: `ArgGroup` only enforces mutual exclusion among named flags — it does not cover positional args. If a mode flag (e.g. `--empty`) is incompatible with positionals (e.g. repo args), add an explicit early bail in `run()` or use `.conflicts_with("repos")` on the flag's `Arg` definition.
+- **Destructive confirmation prompts**: any command that destroys data must prompt `[y/N]` when stdin is a TTY. Use `--yes` / `-y` (short) to skip the prompt — this is the project-wide convention (matches `gh`, `npm`, `apt`). Non-TTY callers without `--yes` must get a clear error telling them to pass `--yes`. Never silently skip or silently proceed. Pattern: check `std::io::stdin().is_terminal()`, bail with `"pass --yes to confirm: wsp <cmd> --yes"` if not interactive and `--yes` not set.
 - When a feature ships, close the corresponding GitHub issue and remove its section from `docs/roadmap.md` entirely (don't check boxes).
 
 ## Gotchas

--- a/crates/wsp-core/src/agentmd.rs
+++ b/crates/wsp-core/src/agentmd.rs
@@ -298,6 +298,7 @@ mod tests {
             created_from: None,
             dirs: BTreeMap::new(),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         }
     }
 

--- a/crates/wsp-core/src/config.rs
+++ b/crates/wsp-core/src/config.rs
@@ -21,6 +21,8 @@ fn is_current_version(v: &u32) -> bool {
 pub struct RepoEntry {
     pub url: String,
     pub added: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub setup_commands: Option<Vec<String>>,
 }
 
 /// Value for an experimental feature: either a boolean toggle or a string mode.
@@ -440,6 +442,7 @@ mod tests {
             RepoEntry {
                 url: "git@github.com:user/repo-a.git".into(),
                 added: now,
+                setup_commands: None,
             },
         );
         cfg.repos.insert(
@@ -447,6 +450,7 @@ mod tests {
             RepoEntry {
                 url: "git@github.com:user/repo-b.git".into(),
                 added: now,
+                setup_commands: None,
             },
         );
 

--- a/crates/wsp-core/src/filelock.rs
+++ b/crates/wsp-core/src/filelock.rs
@@ -155,6 +155,19 @@ where
     Ok(tmpl)
 }
 
+/// Acquire an exclusive lock on a repo's `.wsp.yaml`, load its `setup_commands`,
+/// call `f` to modify them, then write back (preserving unknown fields).
+/// Creates the file if it does not exist.
+pub fn with_repo_wsp_yaml<F>(wsp_yaml_path: &Path, f: F) -> Result<()>
+where
+    F: FnOnce(&mut Vec<String>) -> Result<()>,
+{
+    let _lock = FileLock::acquire(wsp_yaml_path, DEFAULT_TIMEOUT)?;
+    let mut commands = template::read_setup_commands(wsp_yaml_path).unwrap_or_default();
+    f(&mut commands)?;
+    template::write_setup_commands(wsp_yaml_path, &commands)
+}
+
 /// Acquire an exclusive lock, load the metadata, and return a snapshot.
 /// Does not write back. Use this when you only need to read the current state
 /// under the lock (e.g., for phase 1 of a 3-phase lock pattern).
@@ -261,6 +274,7 @@ mod tests {
             created_from: None,
             dirs: BTreeMap::new(),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         };
         save_metadata(ws_dir, &meta).unwrap();
 
@@ -296,6 +310,7 @@ mod tests {
             wsp_version: None,
             repos: vec![template::TemplateRepo {
                 url: "git@github.com:acme/api.git".into(),
+                setup_commands: None,
             }],
             config: None,
             agent_md: None,

--- a/crates/wsp-core/src/gc.rs
+++ b/crates/wsp-core/src/gc.rs
@@ -473,6 +473,7 @@ mod tests {
             created_from: None,
             dirs: std::collections::BTreeMap::new(),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         };
         let yaml = serde_yaml_ng::to_string(&meta).unwrap();
         fs::write(ws_dir.join(".wsp.yaml"), yaml).unwrap();
@@ -775,6 +776,7 @@ mod tests {
             created_from: None,
             dirs: std::collections::BTreeMap::new(),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         };
         let yaml = serde_yaml_ng::to_string(&meta).unwrap();
         fs::write(ws_dir.join(".wsp.yaml"), yaml).unwrap();

--- a/crates/wsp-core/src/lang/go.rs
+++ b/crates/wsp-core/src/lang/go.rs
@@ -413,6 +413,7 @@ mod tests {
             created_from: None,
             dirs: BTreeMap::new(),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         }
     }
 
@@ -445,6 +446,7 @@ mod tests {
             created_from: None,
             dirs: BTreeMap::new(),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         }
     }
 

--- a/crates/wsp-core/src/lang/mod.rs
+++ b/crates/wsp-core/src/lang/mod.rs
@@ -80,6 +80,7 @@ mod tests {
             created_from: None,
             dirs: BTreeMap::new(),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         }
     }
 

--- a/crates/wsp-core/src/lib.rs
+++ b/crates/wsp-core/src/lib.rs
@@ -72,6 +72,7 @@ pub mod giturl;
 pub mod lang;
 pub mod mirror;
 pub mod output;
+pub mod setup_commands;
 pub mod setup_runner;
 pub mod template;
 pub(crate) mod util;

--- a/crates/wsp-core/src/output.rs
+++ b/crates/wsp-core/src/output.rs
@@ -847,6 +847,22 @@ impl DoctorOutput {
 }
 
 // ---------------------------------------------------------------------------
+// Setup commands output
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+pub struct SetupCommandsOutput {
+    pub repo: String,
+    pub commands: Vec<SetupCommandEntry>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SetupCommandEntry {
+    pub command: String,
+    pub source: String,
+}
+
+// ---------------------------------------------------------------------------
 // Output enum — returned by all command handlers
 // ---------------------------------------------------------------------------
 
@@ -871,5 +887,6 @@ pub enum Output {
     RecoverShow(RecoverShowOutput),
     Path(PathOutput),
     Doctor(DoctorOutput),
+    SetupCommands(SetupCommandsOutput),
     None,
 }

--- a/crates/wsp-core/src/setup_commands.rs
+++ b/crates/wsp-core/src/setup_commands.rs
@@ -1,0 +1,578 @@
+//! Multi-layer setup command resolution.
+//!
+//! Setup commands can be declared at four levels. When a repo is cloned into a
+//! workspace, all layers are gathered and concatenated in this order:
+//!
+//! 1. **Registry** — personal per-repo commands in `~/.local/share/wsp/config.yaml`
+//! 2. **Template** — per-repo commands declared on a `TemplateRepo`
+//! 3. **Repo**     — committed `setup_commands` in the repo's own `.wsp.yaml`
+//! 4. **Workspace** — per-repo overrides in workspace metadata
+//!
+//! All commands from all layers are included — no deduplication. Setup commands
+//! are expected to be idempotent (e.g. `just setup`, `npm install`), so running
+//! the same command from two layers is safe and intentional. The final list is
+//! what the user approves; its content hash determines whether re-approval is needed.
+
+use std::path::Path;
+
+use crate::config;
+use crate::template::{self, Template};
+use crate::workspace;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// A single layer contributing setup commands.
+#[derive(Debug, Clone)]
+pub struct SetupSource {
+    /// Human-readable label for display: `"registry"`, `"template"`, `"repo"`, `"workspace"`.
+    pub label: &'static str,
+    /// Commands from this layer.
+    pub commands: Vec<String>,
+}
+
+/// The merged result of resolving setup commands across all layers.
+#[derive(Debug, Clone)]
+pub struct ResolvedSetup {
+    /// Final command list, in layer order (all layers, no deduplication).
+    pub commands: Vec<String>,
+    /// Provenance: each entry is `(command, source_label)` in the same order as `commands`.
+    pub provenance: Vec<(String, &'static str)>,
+}
+
+impl ResolvedSetup {
+    /// Returns `true` if there are no commands after resolution.
+    pub fn is_empty(&self) -> bool {
+        self.commands.is_empty()
+    }
+
+    /// Return a new `ResolvedSetup` with duplicate commands removed, keeping
+    /// the first occurrence (and its provenance label).
+    ///
+    /// This is the default behavior for the approval/run flow. Pass the
+    /// original (undeduped) value when `--all` is requested.
+    pub fn dedup(&self) -> Self {
+        use std::collections::HashSet;
+        let mut seen = HashSet::new();
+        let mut commands = Vec::new();
+        let mut provenance = Vec::new();
+        for (cmd, label) in &self.provenance {
+            if seen.insert(cmd.clone()) {
+                commands.push(cmd.clone());
+                provenance.push((cmd.clone(), *label));
+            }
+        }
+        Self {
+            commands,
+            provenance,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+/// Resolve setup commands from multiple layers into a single list.
+///
+/// Sources are consumed in order; all commands from all layers are included.
+/// No deduplication is performed — setup commands are expected to be idempotent.
+pub fn resolve(sources: Vec<SetupSource>) -> ResolvedSetup {
+    let mut commands = Vec::new();
+    let mut provenance = Vec::new();
+
+    for source in sources {
+        for cmd in source.commands {
+            provenance.push((cmd.clone(), source.label));
+            commands.push(cmd);
+        }
+    }
+
+    ResolvedSetup {
+        commands,
+        provenance,
+    }
+}
+
+/// Gather setup commands from all four layers for a single repo and resolve.
+///
+/// - `cfg`: global config (for registry-level commands on `RepoEntry`)
+/// - `tmpl`: the template used to create this workspace (if any)
+/// - `meta`: workspace metadata (for workspace-level overrides)
+/// - `identity`: the repo identity string
+/// - `clone_dir`: the repo's clone directory (to read committed `.wsp.yaml`)
+pub fn resolve_for_repo(
+    cfg: &config::Config,
+    tmpl: Option<&Template>,
+    meta: Option<&workspace::Metadata>,
+    identity: &str,
+    clone_dir: Option<&Path>,
+) -> ResolvedSetup {
+    let mut sources = Vec::new();
+
+    // 1. Registry
+    if let Some(entry) = cfg.repos.get(identity)
+        && let Some(ref cmds) = entry.setup_commands
+        && !cmds.is_empty()
+    {
+        sources.push(SetupSource {
+            label: "registry",
+            commands: cmds.clone(),
+        });
+    }
+
+    // 2. Template (per-repo)
+    if let Some(tmpl) = tmpl {
+        for repo in &tmpl.repos {
+            if let Some(ref cmds) = repo.setup_commands {
+                // Match template repo to this identity by parsing its URL.
+                let repo_identity = crate::giturl::parse(&repo.url)
+                    .map(|p| p.identity())
+                    .unwrap_or_default();
+                if repo_identity == identity && !cmds.is_empty() {
+                    sources.push(SetupSource {
+                        label: "template",
+                        commands: cmds.clone(),
+                    });
+                    break;
+                }
+            }
+        }
+    }
+
+    // 3. Repo committed .wsp.yaml (only available when we have a clone dir)
+    if let Some(dir) = clone_dir
+        && let Some(cmds) = template::read_setup_commands(&dir.join(".wsp.yaml"))
+    {
+        sources.push(SetupSource {
+            label: "repo",
+            commands: cmds,
+        });
+    }
+
+    // 4. Workspace overrides (only available when we have workspace metadata)
+    if let Some(meta) = meta
+        && let Some(cmds) = meta.setup_commands.get(identity)
+        && !cmds.is_empty()
+    {
+        sources.push(SetupSource {
+            label: "workspace",
+            commands: cmds.clone(),
+        });
+    }
+
+    resolve(sources)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_sources() {
+        let resolved = resolve(vec![]);
+        assert!(resolved.is_empty());
+        assert!(resolved.provenance.is_empty());
+    }
+
+    #[test]
+    fn single_source() {
+        let resolved = resolve(vec![SetupSource {
+            label: "repo",
+            commands: vec!["make deps".into(), "npm install".into()],
+        }]);
+        assert_eq!(resolved.commands, vec!["make deps", "npm install"]);
+        assert_eq!(
+            resolved.provenance,
+            vec![("make deps".into(), "repo"), ("npm install".into(), "repo"),]
+        );
+    }
+
+    #[test]
+    fn multiple_sources_concatenated_in_order() {
+        let resolved = resolve(vec![
+            SetupSource {
+                label: "registry",
+                commands: vec!["lefthook install".into()],
+            },
+            SetupSource {
+                label: "template",
+                commands: vec!["npm install".into()],
+            },
+            SetupSource {
+                label: "repo",
+                commands: vec!["make deps".into()],
+            },
+            SetupSource {
+                label: "workspace",
+                commands: vec!["./extra-setup.sh".into()],
+            },
+        ]);
+        assert_eq!(
+            resolved.commands,
+            vec![
+                "lefthook install",
+                "npm install",
+                "make deps",
+                "./extra-setup.sh"
+            ]
+        );
+        assert_eq!(
+            resolved.provenance[0],
+            ("lefthook install".into(), "registry")
+        );
+        assert_eq!(resolved.provenance[1], ("npm install".into(), "template"));
+        assert_eq!(resolved.provenance[2], ("make deps".into(), "repo"));
+        assert_eq!(
+            resolved.provenance[3],
+            ("./extra-setup.sh".into(), "workspace")
+        );
+    }
+
+    #[test]
+    fn same_command_in_multiple_layers_runs_twice() {
+        let resolved = resolve(vec![
+            SetupSource {
+                label: "registry",
+                commands: vec!["make deps".into(), "lefthook install".into()],
+            },
+            SetupSource {
+                label: "repo",
+                commands: vec!["make deps".into(), "npm install".into()],
+            },
+        ]);
+        // "make deps" appears in both layers — no dedup, runs twice.
+        assert_eq!(
+            resolved.commands,
+            vec!["make deps", "lefthook install", "make deps", "npm install"]
+        );
+        assert_eq!(resolved.provenance[0], ("make deps".into(), "registry"));
+        assert_eq!(
+            resolved.provenance[1],
+            ("lefthook install".into(), "registry")
+        );
+        assert_eq!(resolved.provenance[2], ("make deps".into(), "repo"));
+        assert_eq!(resolved.provenance[3], ("npm install".into(), "repo"));
+    }
+
+    #[test]
+    fn empty_sources_skipped() {
+        let resolved = resolve(vec![
+            SetupSource {
+                label: "registry",
+                commands: vec![],
+            },
+            SetupSource {
+                label: "repo",
+                commands: vec!["make deps".into()],
+            },
+            SetupSource {
+                label: "workspace",
+                commands: vec![],
+            },
+        ]);
+        assert_eq!(resolved.commands, vec!["make deps"]);
+        assert_eq!(resolved.provenance, vec![("make deps".into(), "repo")]);
+    }
+
+    #[test]
+    fn same_command_in_all_layers_runs_four_times() {
+        let resolved = resolve(vec![
+            SetupSource {
+                label: "registry",
+                commands: vec!["npm install".into()],
+            },
+            SetupSource {
+                label: "template",
+                commands: vec!["npm install".into()],
+            },
+            SetupSource {
+                label: "repo",
+                commands: vec!["npm install".into()],
+            },
+            SetupSource {
+                label: "workspace",
+                commands: vec!["npm install".into()],
+            },
+        ]);
+        assert_eq!(
+            resolved.commands,
+            vec!["npm install", "npm install", "npm install", "npm install"]
+        );
+        assert_eq!(resolved.provenance[0], ("npm install".into(), "registry"));
+        assert_eq!(resolved.provenance[1], ("npm install".into(), "template"));
+        assert_eq!(resolved.provenance[2], ("npm install".into(), "repo"));
+        assert_eq!(resolved.provenance[3], ("npm install".into(), "workspace"));
+    }
+
+    // -----------------------------------------------------------------------
+    // resolve_for_repo tests
+    // -----------------------------------------------------------------------
+
+    use std::collections::BTreeMap;
+
+    use crate::config::{Config, RepoEntry};
+    use crate::template::{Template, TemplateRepo};
+    use crate::workspace::Metadata;
+
+    fn make_config(identity: &str, cmds: Option<Vec<String>>) -> Config {
+        let mut repos = BTreeMap::new();
+        repos.insert(
+            identity.to_string(),
+            RepoEntry {
+                url: format!(
+                    "git@test.local:user/{}.git",
+                    identity.split('/').last().unwrap()
+                ),
+                added: chrono::Utc::now(),
+                setup_commands: cmds,
+            },
+        );
+        Config {
+            repos,
+            ..Default::default()
+        }
+    }
+
+    fn make_metadata(identity: &str, cmds: Option<Vec<String>>) -> Metadata {
+        let mut repos = BTreeMap::new();
+        repos.insert(identity.to_string(), None);
+        let mut setup_commands = BTreeMap::new();
+        if let Some(cmds) = cmds {
+            setup_commands.insert(identity.to_string(), cmds);
+        }
+        Metadata {
+            version: 0,
+            name: "test".into(),
+            branch: "test/test".into(),
+            repos,
+            created: chrono::Utc::now(),
+            description: None,
+            last_used: None,
+            created_from: None,
+            dirs: BTreeMap::new(),
+            config: None,
+            setup_commands,
+        }
+    }
+
+    fn make_template(url: &str, cmds: Option<Vec<String>>) -> Template {
+        Template {
+            repos: vec![TemplateRepo {
+                url: url.to_string(),
+                setup_commands: cmds,
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn resolve_for_repo_registry_only() {
+        let identity = "test.local/user/repo";
+        let cfg = make_config(identity, Some(vec!["make deps".into()]));
+        let meta = make_metadata(identity, None);
+        let dir = std::path::PathBuf::from("/nonexistent");
+
+        let resolved = resolve_for_repo(&cfg, None, Some(&meta), identity, Some(&dir));
+        assert_eq!(resolved.commands, vec!["make deps"]);
+        assert_eq!(resolved.provenance[0].1, "registry");
+    }
+
+    #[test]
+    fn resolve_for_repo_workspace_only() {
+        let identity = "test.local/user/repo";
+        let cfg = make_config(identity, None);
+        let meta = make_metadata(identity, Some(vec!["./setup.sh".into()]));
+        let dir = std::path::PathBuf::from("/nonexistent");
+
+        let resolved = resolve_for_repo(&cfg, None, Some(&meta), identity, Some(&dir));
+        assert_eq!(resolved.commands, vec!["./setup.sh"]);
+        assert_eq!(resolved.provenance[0].1, "workspace");
+    }
+
+    #[test]
+    fn resolve_for_repo_template_only() {
+        let identity = "test.local/user/repo";
+        let cfg = make_config(identity, None);
+        let meta = make_metadata(identity, None);
+        let tmpl = make_template(
+            "git@test.local:user/repo.git",
+            Some(vec!["npm install".into()]),
+        );
+        let dir = std::path::PathBuf::from("/nonexistent");
+
+        let resolved = resolve_for_repo(&cfg, Some(&tmpl), Some(&meta), identity, Some(&dir));
+        assert_eq!(resolved.commands, vec!["npm install"]);
+        assert_eq!(resolved.provenance[0].1, "template");
+    }
+
+    #[test]
+    fn resolve_for_repo_all_layers() {
+        let identity = "test.local/user/repo";
+        let cfg = make_config(identity, Some(vec!["registry-cmd".into()]));
+        let meta = make_metadata(identity, Some(vec!["workspace-cmd".into()]));
+        let tmpl = make_template(
+            "git@test.local:user/repo.git",
+            Some(vec!["template-cmd".into()]),
+        );
+        // No committed .wsp.yaml (nonexistent dir), so repo layer is empty.
+        let dir = std::path::PathBuf::from("/nonexistent");
+
+        let resolved = resolve_for_repo(&cfg, Some(&tmpl), Some(&meta), identity, Some(&dir));
+        assert_eq!(
+            resolved.commands,
+            vec!["registry-cmd", "template-cmd", "workspace-cmd"]
+        );
+        assert_eq!(resolved.provenance[0], ("registry-cmd".into(), "registry"));
+        assert_eq!(resolved.provenance[1], ("template-cmd".into(), "template"));
+        assert_eq!(
+            resolved.provenance[2],
+            ("workspace-cmd".into(), "workspace")
+        );
+    }
+
+    #[test]
+    fn resolve_for_repo_same_command_across_layers_runs_twice() {
+        let identity = "test.local/user/repo";
+        let cfg = make_config(identity, Some(vec!["npm install".into()]));
+        let meta = make_metadata(identity, Some(vec!["npm install".into(), "extra".into()]));
+        let dir = std::path::PathBuf::from("/nonexistent");
+
+        let resolved = resolve_for_repo(&cfg, None, Some(&meta), identity, Some(&dir));
+        // "npm install" in both registry and workspace — no dedup, runs from both.
+        assert_eq!(
+            resolved.commands,
+            vec!["npm install", "npm install", "extra"]
+        );
+        assert_eq!(resolved.provenance[0], ("npm install".into(), "registry"));
+        assert_eq!(resolved.provenance[1], ("npm install".into(), "workspace"));
+        assert_eq!(resolved.provenance[2], ("extra".into(), "workspace"));
+    }
+
+    #[test]
+    fn resolve_for_repo_empty_all_layers() {
+        let identity = "test.local/user/repo";
+        let cfg = make_config(identity, None);
+        let meta = make_metadata(identity, None);
+        let dir = std::path::PathBuf::from("/nonexistent");
+
+        let resolved = resolve_for_repo(&cfg, None, Some(&meta), identity, Some(&dir));
+        assert!(resolved.is_empty());
+    }
+
+    #[test]
+    fn resolve_for_repo_template_url_mismatch_ignored() {
+        let identity = "test.local/user/repo";
+        let cfg = make_config(identity, None);
+        let meta = make_metadata(identity, None);
+        // Template has commands for a different repo.
+        let tmpl = make_template(
+            "git@test.local:user/other-repo.git",
+            Some(vec!["should-not-appear".into()]),
+        );
+        let dir = std::path::PathBuf::from("/nonexistent");
+
+        let resolved = resolve_for_repo(&cfg, Some(&tmpl), Some(&meta), identity, Some(&dir));
+        assert!(resolved.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // YAML round-trip tests for new struct fields
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn repo_entry_setup_commands_yaml_roundtrip() {
+        let entry = RepoEntry {
+            url: "git@test.local:user/repo.git".into(),
+            added: chrono::Utc::now(),
+            setup_commands: Some(vec!["make deps".into(), "npm install".into()]),
+        };
+        let yaml = serde_yaml_ng::to_string(&entry).unwrap();
+        assert!(yaml.contains("setup_commands"));
+        assert!(yaml.contains("make deps"));
+
+        let parsed: RepoEntry = serde_yaml_ng::from_str(&yaml).unwrap();
+        assert_eq!(parsed.setup_commands, entry.setup_commands);
+    }
+
+    #[test]
+    fn repo_entry_no_setup_commands_omitted() {
+        let entry = RepoEntry {
+            url: "git@test.local:user/repo.git".into(),
+            added: chrono::Utc::now(),
+            setup_commands: None,
+        };
+        let yaml = serde_yaml_ng::to_string(&entry).unwrap();
+        assert!(!yaml.contains("setup_commands"));
+
+        // And it can parse YAML without the field.
+        let yaml_without = "url: git@test.local:user/repo.git\nadded: 2026-01-01T00:00:00Z\n";
+        let parsed: RepoEntry = serde_yaml_ng::from_str(yaml_without).unwrap();
+        assert_eq!(parsed.setup_commands, None);
+    }
+
+    #[test]
+    fn template_repo_setup_commands_yaml_roundtrip() {
+        let repo = TemplateRepo {
+            url: "git@test.local:user/repo.git".into(),
+            setup_commands: Some(vec!["task setup".into()]),
+        };
+        let yaml = serde_yaml_ng::to_string(&repo).unwrap();
+        assert!(yaml.contains("setup_commands"));
+
+        let parsed: TemplateRepo = serde_yaml_ng::from_str(&yaml).unwrap();
+        assert_eq!(parsed.setup_commands, repo.setup_commands);
+    }
+
+    #[test]
+    fn metadata_setup_commands_yaml_roundtrip() {
+        let mut setup_commands = BTreeMap::new();
+        setup_commands.insert(
+            "test.local/user/repo".to_string(),
+            vec!["./setup.sh".into()],
+        );
+        let meta = Metadata {
+            version: 0,
+            name: "test".into(),
+            branch: "test/test".into(),
+            repos: BTreeMap::new(),
+            created: chrono::Utc::now(),
+            description: None,
+            last_used: None,
+            created_from: None,
+            dirs: BTreeMap::new(),
+            config: None,
+            setup_commands,
+        };
+        let yaml = serde_yaml_ng::to_string(&meta).unwrap();
+        assert!(yaml.contains("setup_commands"));
+        assert!(yaml.contains("./setup.sh"));
+
+        let parsed: Metadata = serde_yaml_ng::from_str(&yaml).unwrap();
+        assert_eq!(parsed.setup_commands, meta.setup_commands);
+    }
+
+    #[test]
+    fn metadata_empty_setup_commands_omitted() {
+        let meta = Metadata {
+            version: 0,
+            name: "test".into(),
+            branch: "test/test".into(),
+            repos: BTreeMap::new(),
+            created: chrono::Utc::now(),
+            description: None,
+            last_used: None,
+            created_from: None,
+            dirs: BTreeMap::new(),
+            config: None,
+            setup_commands: BTreeMap::new(),
+        };
+        let yaml = serde_yaml_ng::to_string(&meta).unwrap();
+        assert!(!yaml.contains("setup_commands"));
+    }
+}

--- a/crates/wsp-core/src/setup_commands.rs
+++ b/crates/wsp-core/src/setup_commands.rs
@@ -465,6 +465,96 @@ mod tests {
         assert!(resolved.is_empty());
     }
 
+    // -----------------------------------------------------------------------
+    // ResolvedSetup::dedup tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn dedup_empty() {
+        let r = resolve(vec![]);
+        assert!(r.dedup().is_empty());
+    }
+
+    #[test]
+    fn dedup_no_duplicates_unchanged() {
+        let r = resolve(vec![
+            SetupSource {
+                label: "registry",
+                commands: vec!["make deps".into()],
+            },
+            SetupSource {
+                label: "repo",
+                commands: vec!["npm install".into()],
+            },
+        ]);
+        let d = r.dedup();
+        assert_eq!(d.commands, vec!["make deps", "npm install"]);
+        assert_eq!(d.provenance[0], ("make deps".into(), "registry"));
+        assert_eq!(d.provenance[1], ("npm install".into(), "repo"));
+    }
+
+    #[test]
+    fn dedup_keeps_first_occurrence() {
+        let r = resolve(vec![
+            SetupSource {
+                label: "registry",
+                commands: vec!["npm install".into(), "make deps".into()],
+            },
+            SetupSource {
+                label: "repo",
+                commands: vec!["npm install".into(), "extra".into()],
+            },
+        ]);
+        let d = r.dedup();
+        // "npm install" from registry is kept; repo occurrence dropped.
+        assert_eq!(d.commands, vec!["npm install", "make deps", "extra"]);
+        assert_eq!(d.provenance[0], ("npm install".into(), "registry"));
+        assert_eq!(d.provenance[1], ("make deps".into(), "registry"));
+        assert_eq!(d.provenance[2], ("extra".into(), "repo"));
+    }
+
+    #[test]
+    fn dedup_all_duplicates_collapsed_to_one() {
+        let r = resolve(vec![
+            SetupSource {
+                label: "registry",
+                commands: vec!["npm install".into()],
+            },
+            SetupSource {
+                label: "template",
+                commands: vec!["npm install".into()],
+            },
+            SetupSource {
+                label: "repo",
+                commands: vec!["npm install".into()],
+            },
+            SetupSource {
+                label: "workspace",
+                commands: vec!["npm install".into()],
+            },
+        ]);
+        let d = r.dedup();
+        assert_eq!(d.commands, vec!["npm install"]);
+        assert_eq!(d.provenance[0], ("npm install".into(), "registry"));
+    }
+
+    #[test]
+    fn dedup_does_not_modify_original() {
+        let r = resolve(vec![
+            SetupSource {
+                label: "registry",
+                commands: vec!["cmd".into()],
+            },
+            SetupSource {
+                label: "repo",
+                commands: vec!["cmd".into()],
+            },
+        ]);
+        let _d = r.dedup();
+        // Original should still have 2 occurrences.
+        assert_eq!(r.commands.len(), 2);
+    }
+
     #[test]
     fn resolve_for_repo_template_url_mismatch_ignored() {
         let identity = "test.local/user/repo";

--- a/crates/wsp-core/src/setup_runner.rs
+++ b/crates/wsp-core/src/setup_runner.rs
@@ -32,7 +32,7 @@ use crate::setup_commands::ResolvedSetup;
 /// Behaviour:
 /// - **Approved** (in store): runs without prompting.
 /// - **Non-interactive** (stdin is not a tty): prints a notice and skips.
-/// - **Interactive**: shows commands with provenance labels, prompts `[y/N]`:
+/// - **Interactive**: shows the command list, prompts `[y/N]`:
 ///   - `y` → record approval + run
 ///   - anything else / empty → skip
 ///
@@ -139,7 +139,7 @@ fn read_line() -> Result<String> {
 }
 
 /// Run each command in `clone_dir`. Non-zero exits are printed as warnings.
-fn run_commands(clone_dir: &Path, commands: &[String]) {
+pub(crate) fn run_commands(clone_dir: &Path, commands: &[String]) {
     for cmd in commands {
         match std::process::Command::new("sh")
             .arg("-c")
@@ -161,5 +161,122 @@ fn run_commands(clone_dir: &Path, commands: &[String]) {
                 eprintln!("  warning: could not run {:?}: {}", cmd, e);
             }
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::setup_commands::{ResolvedSetup, SetupSource};
+    use tempfile::TempDir;
+
+    fn make_resolved(commands: Vec<&str>) -> ResolvedSetup {
+        crate::setup_commands::resolve(vec![SetupSource {
+            label: "repo",
+            commands: commands.into_iter().map(|s| s.to_string()).collect(),
+        }])
+    }
+
+    fn make_temp_dir() -> TempDir {
+        tempfile::tempdir().expect("tmpdir")
+    }
+
+    // -----------------------------------------------------------------------
+    // maybe_run_resolved — non-interactive path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn empty_resolved_returns_false() {
+        let tmp = make_temp_dir();
+        let resolved = make_resolved(vec![]);
+        let result = maybe_run_resolved(tmp.path(), tmp.path(), "test/repo", &resolved);
+        assert_eq!(result.unwrap(), false);
+    }
+
+    #[test]
+    fn non_interactive_skips_and_returns_false() {
+        // stdin is not a tty in tests — always exercises the non-interactive branch.
+        let tmp = make_temp_dir();
+        let resolved = make_resolved(vec!["echo hello"]);
+        let result = maybe_run_resolved(tmp.path(), tmp.path(), "test/repo", &resolved);
+        // Should skip (non-interactive), not error.
+        assert_eq!(result.unwrap(), false);
+    }
+
+    // -----------------------------------------------------------------------
+    // run_commands — success and failure paths
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn run_commands_success_produces_no_warning() {
+        let tmp = make_temp_dir();
+        // Can't capture stderr without fork tricks; just assert it doesn't panic.
+        run_commands(tmp.path(), &["true".to_string()]);
+    }
+
+    #[test]
+    fn run_commands_nonzero_exit_does_not_panic() {
+        let tmp = make_temp_dir();
+        // "false" exits with code 1 — should print a warning but not panic.
+        run_commands(tmp.path(), &["false".to_string()]);
+    }
+
+    #[test]
+    fn run_commands_bad_command_does_not_panic() {
+        let tmp = make_temp_dir();
+        // Nonexistent program inside sh -c results in exit 127 (shell not-found).
+        run_commands(
+            tmp.path(),
+            &["__wsp_nonexistent_cmd_for_testing__".to_string()],
+        );
+    }
+
+    #[test]
+    fn run_commands_multiple_commands_all_run() {
+        let tmp = make_temp_dir();
+        let sentinel = tmp.path().join("ran");
+        run_commands(
+            tmp.path(),
+            &[format!("touch {}", sentinel.display()), "true".to_string()],
+        );
+        assert!(sentinel.exists(), "sentinel file should have been created");
+    }
+
+    #[test]
+    fn run_commands_continues_after_failure() {
+        let tmp = make_temp_dir();
+        let sentinel = tmp.path().join("after_failure");
+        // First command fails; second should still run.
+        run_commands(
+            tmp.path(),
+            &["false".to_string(), format!("touch {}", sentinel.display())],
+        );
+        assert!(
+            sentinel.exists(),
+            "second command should run even after first fails"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Pre-approved path (store hit)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn pre_approved_commands_run_without_prompt() {
+        let tmp = make_temp_dir();
+        let sentinel = tmp.path().join("setup_ran");
+        let resolved = make_resolved(vec![&format!("touch {}", sentinel.display())]);
+
+        // Record approval so maybe_run_resolved skips the prompt.
+        let hash = crate::approvals::commands_hash(&resolved.commands);
+        crate::approvals::record_always(tmp.path(), "test/repo", &hash).unwrap();
+
+        let result = maybe_run_resolved(tmp.path(), tmp.path(), "test/repo", &resolved);
+        assert_eq!(result.unwrap(), true);
+        assert!(sentinel.exists(), "pre-approved command should have run");
     }
 }

--- a/crates/wsp-core/src/setup_runner.rs
+++ b/crates/wsp-core/src/setup_runner.rs
@@ -5,6 +5,10 @@
 //! before anything runs. Approvals are stored by content hash so wsp only
 //! re-prompts when the commands change — the same model direnv uses.
 //!
+//! By default the runner deduplicates the resolved command list (first
+//! occurrence wins) before showing the prompt. Pass the undeduped
+//! `ResolvedSetup` when `--all` is requested.
+//!
 //! # Security note
 //! `setup_commands` intentionally allows arbitrary shell execution (that is the
 //! point — `task setup`, `npm install`, etc.). Never auto-run without user
@@ -17,17 +21,18 @@ use std::path::Path;
 use anyhow::Result;
 
 use crate::approvals;
+use crate::setup_commands::ResolvedSetup;
 
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
-/// Run setup commands for a single repo clone, with the approval flow.
+/// Run resolved setup commands for a single repo clone, with the approval flow.
 ///
 /// Behaviour:
 /// - **Approved** (in store): runs without prompting.
 /// - **Non-interactive** (stdin is not a tty): prints a notice and skips.
-/// - **Interactive**: shows commands, prompts `[y/N]`:
+/// - **Interactive**: shows commands with provenance labels, prompts `[y/N]`:
 ///   - `y` → record approval + run
 ///   - anything else / empty → skip
 ///
@@ -38,22 +43,22 @@ use crate::approvals;
 /// Returns `Ok(true)` if commands were run, `Ok(false)` if skipped.
 /// A non-zero exit from a command is printed as a warning but does not
 /// return an error — setup failures are not fatal to workspace creation.
-pub fn maybe_run_setup(
+pub fn maybe_run_resolved(
     data_dir: &Path,
     clone_dir: &Path,
     identity: &str,
-    commands: &[String],
+    resolved: &ResolvedSetup,
 ) -> Result<bool> {
-    if commands.is_empty() {
+    if resolved.is_empty() {
         return Ok(false);
     }
 
-    let hash = approvals::commands_hash(commands);
+    let hash = approvals::commands_hash(&resolved.commands);
     let store = approvals::load(data_dir)?;
 
     if approvals::is_approved(&store, identity, &hash) {
-        eprintln!("Running approved setup for {}...", identity);
-        run_commands(clone_dir, commands);
+        eprintln!("Running pre-approved setup for {}...", identity);
+        run_commands(clone_dir, &resolved.commands);
         return Ok(true);
     }
 
@@ -65,18 +70,18 @@ pub fn maybe_run_setup(
         return Ok(false);
     }
 
-    prompt_and_run(data_dir, clone_dir, identity, commands, &hash)
+    prompt_and_run_resolved(data_dir, clone_dir, identity, resolved, &hash)
 }
 
-/// Like [`maybe_run_setup`] but always prompts, ignoring any existing approval.
+/// Like [`maybe_run_resolved`] but always prompts, ignoring any existing approval.
 /// Used by `wsp repo setup --force` and `wsp doctor --fix`.
-pub fn prompt_and_run_setup(
+pub fn prompt_and_run_resolved_setup(
     data_dir: &Path,
     clone_dir: &Path,
     identity: &str,
-    commands: &[String],
+    resolved: &ResolvedSetup,
 ) -> Result<bool> {
-    if commands.is_empty() {
+    if resolved.is_empty() {
         return Ok(false);
     }
     if !std::io::stdin().is_terminal() {
@@ -86,23 +91,23 @@ pub fn prompt_and_run_setup(
         );
         return Ok(false);
     }
-    let hash = approvals::commands_hash(commands);
-    prompt_and_run(data_dir, clone_dir, identity, commands, &hash)
+    let hash = approvals::commands_hash(&resolved.commands);
+    prompt_and_run_resolved(data_dir, clone_dir, identity, resolved, &hash)
 }
 
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-fn prompt_and_run(
+fn prompt_and_run_resolved(
     data_dir: &Path,
     clone_dir: &Path,
     identity: &str,
-    commands: &[String],
+    resolved: &ResolvedSetup,
     hash: &str,
 ) -> Result<bool> {
     eprintln!("\nSetup commands for {}:", identity);
-    for cmd in commands {
+    for cmd in &resolved.commands {
         eprintln!("  {}", cmd);
     }
     eprint!("Run these commands? [y/N] ");
@@ -112,7 +117,7 @@ fn prompt_and_run(
     match line.trim().to_lowercase().as_str() {
         "y" | "yes" => {
             approvals::record_always(data_dir, identity, hash)?;
-            run_commands(clone_dir, commands);
+            run_commands(clone_dir, &resolved.commands);
             Ok(true)
         }
         _ => {
@@ -136,7 +141,6 @@ fn read_line() -> Result<String> {
 /// Run each command in `clone_dir`. Non-zero exits are printed as warnings.
 fn run_commands(clone_dir: &Path, commands: &[String]) {
     for cmd in commands {
-        eprintln!("  $ {}", cmd);
         match std::process::Command::new("sh")
             .arg("-c")
             .arg(cmd)

--- a/crates/wsp-core/src/template.rs
+++ b/crates/wsp-core/src/template.rs
@@ -56,6 +56,8 @@ pub struct TemplateConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TemplateRepo {
     pub url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub setup_commands: Option<Vec<String>>,
 }
 
 impl Template {
@@ -394,7 +396,10 @@ fn template_from_metadata(meta: &workspace::Metadata) -> Result<Template> {
                     identity
                 )
             })?;
-        repos.push(TemplateRepo { url });
+        repos.push(TemplateRepo {
+            url,
+            setup_commands: None,
+        });
     }
     if repos.is_empty() {
         bail!("no repos in .wsp.yaml");
@@ -419,6 +424,70 @@ pub fn read_setup_commands(path: &Path) -> Option<Vec<String>> {
     let content = std::fs::read_to_string(path).ok()?;
     let tmpl: Template = serde_yaml_ng::from_str(&content).ok()?;
     tmpl.setup_commands.filter(|v| !v.is_empty())
+}
+
+/// Write `setup_commands` into a `.wsp.yaml` file, preserving any unknown fields.
+///
+/// Uses `serde_yaml_ng::Value` merge and atomic rename to avoid clobbering
+/// fields added by future wsp versions. Creates the file if it does not exist.
+pub fn write_setup_commands(path: &Path, commands: &[String]) -> Result<()> {
+    let mut doc: serde_yaml_ng::Value = if path.exists() {
+        let content = std::fs::read_to_string(path)?;
+        serde_yaml_ng::from_str(&content)?
+    } else {
+        serde_yaml_ng::Value::Mapping(serde_yaml_ng::Mapping::new())
+    };
+
+    let mapping = doc.as_mapping_mut().ok_or_else(|| {
+        anyhow::anyhow!(".wsp.yaml is not a YAML mapping; cannot update it safely")
+    })?;
+
+    if commands.is_empty() {
+        mapping.remove("setup_commands");
+    } else {
+        let cmds_value = serde_yaml_ng::Value::Sequence(
+            commands
+                .iter()
+                .map(|s| serde_yaml_ng::Value::String(s.clone()))
+                .collect(),
+        );
+        mapping.insert(
+            serde_yaml_ng::Value::String("setup_commands".to_string()),
+            cmds_value,
+        );
+    }
+
+    let yaml_str = serde_yaml_ng::to_string(&doc)?;
+    let parent = path.parent().unwrap_or(Path::new("."));
+    let mut tmp = tempfile::NamedTempFile::new_in(parent)?;
+    tmp.write_all(yaml_str.as_bytes())?;
+    tmp.persist(path)?;
+    Ok(())
+}
+
+/// Ensure `.wsp.yaml.lock` is listed in `.gitignore`. Creates the file if needed.
+pub fn ensure_gitignore(repo_root: &Path) -> Result<()> {
+    let gitignore = repo_root.join(".gitignore");
+    let pattern = ".wsp.yaml.lock";
+
+    if gitignore.exists() {
+        let content = std::fs::read_to_string(&gitignore)?;
+        if content.lines().any(|line| line.trim() == pattern) {
+            return Ok(());
+        }
+        let prefix = if content.ends_with('\n') || content.is_empty() {
+            ""
+        } else {
+            "\n"
+        };
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&gitignore)?
+            .write_all(format!("{}{}\n", prefix, pattern).as_bytes())?;
+    } else {
+        std::fs::write(&gitignore, format!("{}\n", pattern))?;
+    }
+    Ok(())
 }
 
 /// Serialize a template to YAML string.
@@ -502,6 +571,11 @@ pub fn derive_name_from_file(path: &Path, template: &Template) -> String {
 
 /// Create a template from an existing workspace's repo set.
 /// Uses URLs from .wsp.yaml if available, falls back to registry.
+///
+/// Workspace-level setup commands are intentionally not propagated to the
+/// template: they are local overrides specific to one workspace. Users should
+/// re-add per-repo setup commands via `wsp template setup-commands` after
+/// exporting.
 pub fn from_workspace(paths: &Paths, ws_name: &str) -> Result<Template> {
     workspace::validate_name(ws_name)?;
     let ws_dir = workspace::dir(&paths.workspaces_dir, ws_name);
@@ -519,7 +593,10 @@ pub fn from_workspace(paths: &Paths, ws_name: &str) -> Result<Template> {
             .ok_or_else(|| {
                 anyhow::anyhow!("repo {:?} has no URL in .wsp.yaml or registry", identity)
             })?;
-        repos.push(TemplateRepo { url });
+        repos.push(TemplateRepo {
+            url,
+            setup_commands: None,
+        });
     }
 
     if repos.is_empty() {
@@ -591,6 +668,7 @@ pub fn auto_register(tmpl: &Template, cfg: &mut config::Config, paths: &Paths) -
                     RepoEntry {
                         url: url.clone(),
                         added: Utc::now(),
+                        setup_commands: None,
                     },
                 );
             }
@@ -605,6 +683,7 @@ pub fn auto_register(tmpl: &Template, cfg: &mut config::Config, paths: &Paths) -
             RepoEntry {
                 url,
                 added: Utc::now(),
+                setup_commands: None,
             },
         );
     }
@@ -674,7 +753,10 @@ pub fn add_repos(template: &mut Template, urls: Vec<String>) -> Result<Vec<Strin
         if existing_identities.contains(&parsed.identity()) {
             skipped.push(url);
         } else {
-            template.repos.push(TemplateRepo { url });
+            template.repos.push(TemplateRepo {
+                url,
+                setup_commands: None,
+            });
         }
     }
     Ok(skipped)
@@ -830,9 +912,11 @@ mod tests {
             repos: vec![
                 TemplateRepo {
                     url: "git@github.com:acme/api-gateway.git".into(),
+                    setup_commands: None,
                 },
                 TemplateRepo {
                     url: "git@github.com:acme/user-service.git".into(),
+                    setup_commands: None,
                 },
             ],
             config: None,
@@ -1205,6 +1289,7 @@ created: 2026-03-07T10:00:00Z
             wsp_version: None,
             repos: vec![TemplateRepo {
                 url: "git@github.com:acme/api.git".into(),
+                setup_commands: None,
             }],
             config: Some(TemplateConfig {
                 language_integrations: Some(BTreeMap::from([("go".into(), true)])),
@@ -1226,15 +1311,12 @@ created: 2026-03-07T10:00:00Z
     #[test]
     fn agent_md_round_trip_yaml() {
         let tmpl = Template {
-            name: None,
-            description: None,
-            wsp_version: None,
             repos: vec![TemplateRepo {
                 url: "git@github.com:acme/api.git".into(),
+                setup_commands: None,
             }],
-            config: None,
             agent_md: Some("# Project Rules\n\nAlways use table-driven tests.".into()),
-            setup_commands: None,
+            ..Default::default()
         };
 
         let yaml = to_yaml(&tmpl).unwrap();
@@ -1254,6 +1336,7 @@ created: 2026-03-07T10:00:00Z
             wsp_version: None,
             repos: vec![TemplateRepo {
                 url: "git@github.com:acme/api.git".into(),
+                setup_commands: None,
             }],
             config: None,
             agent_md: None,
@@ -1329,15 +1412,12 @@ created: 2026-03-07T10:00:00Z
 
         // Create a template with agent_md
         let tmpl = Template {
-            name: None,
-            description: None,
-            wsp_version: None,
             repos: vec![TemplateRepo {
                 url: "git@github.com:acme/api.git".into(),
+                setup_commands: None,
             }],
-            config: None,
             agent_md: Some("# Project Rules\n\nAlways use table-driven tests.".into()),
-            setup_commands: None,
+            ..Default::default()
         };
 
         // Save and reload
@@ -1411,6 +1491,7 @@ created: 2026-03-07T10:00:00Z
             wsp_version: None,
             repos: vec![TemplateRepo {
                 url: "git@github.com:acme/api.git".into(),
+                setup_commands: None,
             }],
             config: Some(TemplateConfig {
                 language_integrations: None,
@@ -1450,13 +1531,8 @@ created: 2026-03-07T10:00:00Z
             Case {
                 name: "with agent_md",
                 tmpl: Template {
-                    name: None,
-                    description: None,
-                    wsp_version: None,
-                    repos: vec![],
-                    config: None,
                     agent_md: Some("# Rules".into()),
-                    setup_commands: None,
+                    ..Default::default()
                 },
                 expected: true,
             },
@@ -1596,9 +1672,11 @@ created: 2026-03-07T10:00:00Z
             repos: vec![
                 TemplateRepo {
                     url: "git@github.com:team-a/utils.git".into(),
+                    setup_commands: None,
                 },
                 TemplateRepo {
                     url: "git@github.com:team-b/utils.git".into(),
+                    setup_commands: None,
                 },
             ],
             config: None,
@@ -1617,6 +1695,7 @@ created: 2026-03-07T10:00:00Z
             wsp_version: None,
             repos: vec![TemplateRepo {
                 url: "git@gitlab.company.com:team/service.git".into(),
+                setup_commands: None,
             }],
             config: None,
             agent_md: None,
@@ -1782,6 +1861,7 @@ created: 2026-03-07T10:00:00Z
             wsp_version: None,
             repos: vec![TemplateRepo {
                 url: "git@github.com:acme/api.git".into(),
+                setup_commands: None,
             }],
             config: Some(TemplateConfig {
                 language_integrations: Some(BTreeMap::from([("go".into(), true)])),
@@ -1983,6 +2063,7 @@ created: 2026-03-07T10:00:00Z
             wsp_version: Some("0.8.0".into()),
             repos: vec![TemplateRepo {
                 url: "git@github.com:acme/api.git".into(),
+                setup_commands: None,
             }],
             config: None,
             agent_md: None,

--- a/crates/wsp-core/src/workspace.rs
+++ b/crates/wsp-core/src/workspace.rs
@@ -56,6 +56,9 @@ pub struct Metadata {
     pub dirs: BTreeMap<String, String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub config: Option<crate::template::TemplateConfig>,
+    /// Per-repo setup command overrides for this workspace, keyed by repo identity.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub setup_commands: BTreeMap<String, Vec<String>>,
 }
 
 impl Metadata {
@@ -218,6 +221,30 @@ pub fn detect(start_dir: &Path) -> Result<PathBuf> {
     }
 }
 
+/// Identify which repo the current working directory belongs to.
+///
+/// Walks `cwd` against each repo's clone directory and returns the identity
+/// of the repo whose directory contains `cwd`, or `None` if not found.
+///
+/// Uses `Metadata::dir_name()` so it works even on older workspaces where
+/// `meta.dirs` is empty (falls back to the repo component of the identity).
+pub fn repo_from_cwd(ws_dir: &Path, meta: &Metadata, cwd: &Path) -> Option<String> {
+    let cwd = cwd.canonicalize().ok()?;
+    let ws_dir = ws_dir.canonicalize().ok()?;
+    for identity in meta.repos.keys() {
+        // Skip unparseable identities rather than aborting the whole search.
+        let dir_name = match meta.dir_name(identity) {
+            Ok(d) => d,
+            Err(_) => continue,
+        };
+        let repo_dir = ws_dir.join(&dir_name);
+        if cwd.starts_with(&repo_dir) {
+            return Some(identity.clone());
+        }
+    }
+    None
+}
+
 /// Check whether a `.wsp.yaml` file is workspace metadata rather than a
 /// per-repo config or template that happens to share the same filename.
 /// Workspace metadata always contains required `name` and `branch` keys;
@@ -342,6 +369,7 @@ fn create_inner(opts: &CreateInnerOpts) -> Result<()> {
         created_from: opts.created_from.map(|s| s.to_string()),
         dirs: dirs.clone(),
         config: None,
+        setup_commands: std::collections::BTreeMap::new(),
     };
 
     for identity in opts.repo_refs.keys() {
@@ -3167,6 +3195,7 @@ mod tests {
             created_from: None,
             dirs: BTreeMap::new(),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         };
 
         save_metadata(tmp.path(), &meta).unwrap();
@@ -3210,6 +3239,7 @@ mod tests {
             created_from: None,
             dirs: BTreeMap::new(),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         };
 
         save_metadata(tmp.path(), &meta).unwrap();
@@ -3248,6 +3278,7 @@ mod tests {
             created_from: Some("backend".into()),
             dirs: BTreeMap::new(),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         };
 
         save_metadata(tmp.path(), &meta).unwrap();
@@ -3531,6 +3562,7 @@ mod tests {
             created_from: None,
             dirs: BTreeMap::from([("github.com/acme/utils".into(), "acme-utils".into())]),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         };
         assert_eq!(
             meta.dir_name("github.com/acme/utils").unwrap(),
@@ -3551,6 +3583,7 @@ mod tests {
             created_from: None,
             dirs: BTreeMap::new(),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         };
         assert_eq!(meta.dir_name("github.com/acme/utils").unwrap(), "utils");
     }
@@ -4603,6 +4636,7 @@ mod tests {
             created_from: None,
             dirs: BTreeMap::new(),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         };
 
         save_metadata(tmp.path(), &meta).unwrap();
@@ -4657,6 +4691,7 @@ mod tests {
             created_from: None,
             dirs: BTreeMap::new(),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         }
     }
 
@@ -5848,6 +5883,7 @@ mod tests {
             created_from: None,
             dirs: BTreeMap::new(),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         };
 
         // clone_dir's parent is the ws_dir; dir_name falls back to parsed.repo = "repo"
@@ -5885,6 +5921,7 @@ mod tests {
             created_from: None,
             dirs: BTreeMap::new(),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         };
 
         let ws_dir = clone_dir.parent().unwrap();
@@ -5921,6 +5958,7 @@ mod tests {
             created_from: None,
             dirs: BTreeMap::new(),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         };
 
         let ws_dir = clone_dir.parent().unwrap();

--- a/crates/wsp/src/cli/add.rs
+++ b/crates/wsp/src/cli/add.rs
@@ -161,6 +161,7 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
                 RepoEntry {
                     url: url.clone(),
                     added: Utc::now(),
+                    setup_commands: None,
                 },
             );
             Ok(())
@@ -264,21 +265,29 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
         }
     }
 
-    // Run per-repo setup commands declared in each newly added clone's .wsp.yaml
+    // Run per-repo setup commands resolved from all layers
     if let Ok(ref meta) = meta_result {
         for info in meta.repo_infos(&ws_dir) {
             if !new_ids.contains(&info.identity) || info.error.is_some() {
                 continue;
             }
-            if let Some(cmds) =
-                wsp_core::template::read_setup_commands(&info.clone_dir.join(".wsp.yaml"))
-                && let Err(e) = wsp_core::setup_runner::maybe_run_setup(
-                    paths.data_dir(),
-                    &info.clone_dir,
-                    &info.identity,
-                    &cmds,
-                )
-            {
+            let resolved = wsp_core::setup_commands::resolve_for_repo(
+                &cfg,
+                None, // no template context when adding repos
+                Some(meta),
+                &info.identity,
+                Some(&info.clone_dir),
+            )
+            .dedup();
+            if resolved.is_empty() {
+                continue;
+            }
+            if let Err(e) = wsp_core::setup_runner::maybe_run_resolved(
+                paths.data_dir(),
+                &info.clone_dir,
+                &info.identity,
+                &resolved,
+            ) {
                 eprintln!("warning: setup commands for {}: {}", info.identity, e);
             }
         }

--- a/crates/wsp/src/cli/cfg.rs
+++ b/crates/wsp/src/cli/cfg.rs
@@ -1149,6 +1149,7 @@ mod tests {
             created_from: None,
             dirs: BTreeMap::new(),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         };
         workspace::save_metadata(&ws_dir, &meta).unwrap();
         ws_dir
@@ -1366,6 +1367,7 @@ mod tests {
                 }),
                 language_integrations: None,
             }),
+            setup_commands: std::collections::BTreeMap::new(),
         };
 
         let effective = meta.apply_workspace_config(&global);

--- a/crates/wsp/src/cli/completers.rs
+++ b/crates/wsp/src/cli/completers.rs
@@ -152,6 +152,69 @@ fn repos_to_candidates(identities: Vec<String>) -> Vec<CompletionCandidate> {
         .collect()
 }
 
+/// Complete existing setup commands for a repo (for `repo setup-commands rm`).
+/// Reads the repo arg already on the command line and returns setup commands
+/// from both registry and workspace scopes so the user can pick one to remove.
+pub fn complete_repo_setup_commands() -> Vec<CompletionCandidate> {
+    complete_repo_setup_commands_inner().unwrap_or_default()
+}
+
+fn complete_repo_setup_commands_inner() -> Option<Vec<CompletionCandidate>> {
+    // Command line: wsp repo setup-commands rm <repo> <cmd>
+    // Locate <repo> as the token two positions after "setup-commands".
+    let args: Vec<String> = std::env::args().collect();
+    let pos = args.iter().position(|a| a == "setup-commands")?;
+    let repo_arg = args.get(pos + 2).filter(|a| !a.starts_with('-'))?;
+
+    let paths = Paths::resolve().ok()?;
+    let cfg = Config::load_from(&paths.config_path).ok()?;
+    let identities: Vec<String> = cfg.repos.keys().cloned().collect();
+    let identity =
+        wsp_core::giturl::resolve(wsp_core::giturl::parse_repo_ref(repo_arg), &identities).ok()?;
+
+    let mut cmds: std::collections::HashSet<String> = std::collections::HashSet::new();
+    if let Some(entry) = cfg.repos.get(&identity)
+        && let Some(ref c) = entry.setup_commands
+    {
+        cmds.extend(c.iter().cloned());
+    }
+    if let Ok(cwd) = std::env::current_dir()
+        && let Ok(ws_dir) = workspace::detect(&cwd)
+        && let Ok(meta) = workspace::load_metadata(&ws_dir)
+        && let Some(ws_cmds) = meta.setup_commands.get(&identity)
+    {
+        cmds.extend(ws_cmds.iter().cloned());
+    }
+    Some(cmds.into_iter().map(CompletionCandidate::new).collect())
+}
+
+/// Complete existing setup commands for a repo in a template
+/// (for `template setup-commands rm`).
+pub fn complete_template_repo_setup_commands() -> Vec<CompletionCandidate> {
+    complete_template_repo_setup_commands_inner().unwrap_or_default()
+}
+
+fn complete_template_repo_setup_commands_inner() -> Option<Vec<CompletionCandidate>> {
+    // Command line: wsp template setup-commands rm <name> <repo> <cmd>
+    // Locate <name> as pos+2 and <repo> as pos+3 after "setup-commands".
+    let args: Vec<String> = std::env::args().collect();
+    let pos = args.iter().position(|a| a == "setup-commands")?;
+    let tmpl_name = args.get(pos + 2).filter(|a| !a.starts_with('-'))?;
+    let repo_arg = args.get(pos + 3).filter(|a| !a.starts_with('-'))?;
+
+    let paths = Paths::resolve().ok()?;
+    let tmpl = template::load(&paths.templates_dir, tmpl_name).ok()?;
+    let repo = tmpl.repos.iter().find(|r| {
+        r.url == *repo_arg
+            || wsp_core::giturl::parse(&r.url)
+                .map(|p| p.identity())
+                .unwrap_or_default()
+                == *repo_arg
+    })?;
+    let cmds = repo.setup_commands.as_deref().unwrap_or(&[]);
+    Some(cmds.iter().map(CompletionCandidate::new).collect())
+}
+
 /// Extract the template name from `["template", "repo"|"config"|"agent-md", "add"|"rm"|"set"|"get"|"unset", <name>]`.
 fn template_name_from_args() -> Option<String> {
     let args: Vec<String> = std::env::args().collect();
@@ -428,6 +491,7 @@ mod tests {
             RepoEntry {
                 url: "git@github.com:acme/api.git".into(),
                 added: now,
+                setup_commands: None,
             },
         );
         cfg.repos.insert(
@@ -435,6 +499,7 @@ mod tests {
             RepoEntry {
                 url: "git@github.com:acme/web.git".into(),
                 added: now,
+                setup_commands: None,
             },
         );
         cfg.save_to(&data_dir.join("config.yaml")).unwrap();
@@ -512,6 +577,7 @@ mod tests {
                 created_from: None,
                 dirs: BTreeMap::new(),
                 config: None,
+                setup_commands: std::collections::BTreeMap::new(),
             };
             save_metadata(&ws_dir, &meta).unwrap();
         }
@@ -541,6 +607,117 @@ mod tests {
             values.contains(&"beta".to_string()),
             "should contain 'beta'; got {:?}",
             values
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // complete_repo_setup_commands — reads config + optional workspace state
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn repo_setup_commands_returns_empty_when_no_commands_configured() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("wsp");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        let mut cfg = wsp_core::config::Config::default();
+        cfg.repos.insert(
+            "github.com/acme/api".to_string(),
+            wsp_core::config::RepoEntry {
+                url: "git@github.com:acme/api.git".to_string(),
+                added: chrono::Utc::now(),
+                setup_commands: None,
+            },
+        );
+        cfg.save_to(&data_dir.join("config.yaml")).unwrap();
+
+        // Simulate: wsp repo setup-commands rm github.com/acme/api <cmd>
+        // complete_repo_setup_commands reads args[pos("setup-commands")+2]
+        // We can't easily inject std::env::args in a unit test, so verify the
+        // inner function degrades gracefully when the repo has no commands.
+        unsafe { std::env::set_var("XDG_DATA_HOME", tmp.path()) };
+        let result = complete_repo_setup_commands();
+        unsafe { std::env::remove_var("XDG_DATA_HOME") };
+
+        // No commands configured → should return empty (no panic, no error).
+        assert!(
+            result.is_empty(),
+            "should return empty when no commands configured; got {:?}",
+            candidate_values(&result)
+        );
+    }
+
+    #[test]
+    fn repo_setup_commands_returns_commands_from_registry() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("wsp");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        let mut cfg = wsp_core::config::Config::default();
+        cfg.repos.insert(
+            "github.com/acme/api".to_string(),
+            wsp_core::config::RepoEntry {
+                url: "git@github.com:acme/api.git".to_string(),
+                added: chrono::Utc::now(),
+                setup_commands: Some(vec![
+                    "make setup".to_string(),
+                    "lefthook install".to_string(),
+                ]),
+            },
+        );
+        cfg.save_to(&data_dir.join("config.yaml")).unwrap();
+
+        // complete_repo_setup_commands reads args to find the repo; since
+        // std::env::args() won't have the right args in a unit test, the
+        // inner function returns None (can't find repo arg). Test the inner
+        // helper directly via the exported function — it returns empty when
+        // args aren't set up, which is the safe graceful-degradation path.
+        unsafe { std::env::set_var("XDG_DATA_HOME", tmp.path()) };
+        let result = complete_repo_setup_commands();
+        unsafe { std::env::remove_var("XDG_DATA_HOME") };
+
+        // In a unit test std::env::args() won't contain "setup-commands rm <repo>",
+        // so the function gracefully returns empty. This verifies no panic/crash.
+        assert!(
+            result.is_empty() || candidate_values(&result).iter().all(|v| !v.is_empty()),
+            "should return empty or valid commands; got {:?}",
+            candidate_values(&result)
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // complete_template_repo_setup_commands — reads template from disk
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn template_repo_setup_commands_returns_empty_when_no_commands() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("wsp");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        let tmpl = wsp_core::template::Template {
+            repos: vec![wsp_core::template::TemplateRepo {
+                url: "git@github.com:acme/api.git".to_string(),
+                setup_commands: None,
+            }],
+            ..Default::default()
+        };
+        wsp_core::template::save(&data_dir.join("templates"), "mytemplate", &tmpl).unwrap();
+
+        // complete_template_repo_setup_commands reads std::env::args(); in tests
+        // args won't contain "setup-commands rm mytemplate acme/api", so the
+        // function gracefully returns empty.
+        unsafe { std::env::set_var("XDG_DATA_HOME", tmp.path()) };
+        let result = complete_template_repo_setup_commands();
+        unsafe { std::env::remove_var("XDG_DATA_HOME") };
+
+        assert!(
+            result.is_empty(),
+            "should return empty when no setup commands in template; got {:?}",
+            candidate_values(&result)
         );
     }
 }

--- a/crates/wsp/src/cli/doctor.rs
+++ b/crates/wsp/src/cli/doctor.rs
@@ -385,13 +385,15 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
                 &mut fixed,
             );
 
-            // W15. Unapproved setup commands
+            // W15. Unapproved setup commands (resolved from all layers)
             check_unapproved_setup_commands(
                 &info.clone_dir,
                 &info.identity,
                 &info.dir_name,
                 &scope,
                 paths,
+                &cfg,
+                &meta,
                 fix,
                 &mut checks,
                 &mut fixed,
@@ -1169,6 +1171,7 @@ fn check_unregistered_repos(
                                 config::RepoEntry {
                                     url: url.clone(),
                                     added: chrono::Utc::now(),
+                                    setup_commands: None,
                                 },
                             );
                         }
@@ -1654,6 +1657,7 @@ fn check_template_repos_registered(
                             config::RepoEntry {
                                 url: url.clone(),
                                 added: chrono::Utc::now(),
+                                setup_commands: None,
                             },
                         );
                     }
@@ -2310,6 +2314,9 @@ fn check_git_config_drift(
 
 /// W15. Unapproved setup commands — repo has setup_commands that haven't been approved.
 ///
+/// Resolves commands from all layers (registry, template, repo, workspace) and
+/// checks whether the merged list is approved.
+///
 /// With `--fix`: invokes the interactive approval flow. In non-interactive
 /// environments (no tty) the check remains fixable but the fix is skipped
 /// with a hint to run `wsp repo setup` manually.
@@ -2320,15 +2327,25 @@ fn check_unapproved_setup_commands(
     dir_name: &str,
     scope: &str,
     paths: &wsp_core::config::Paths,
+    cfg: &config::Config,
+    meta: &workspace::Metadata,
     fix: bool,
     checks: &mut Vec<DoctorCheck>,
     fixed: &mut usize,
 ) {
-    let Some(cmds) = wsp_core::template::read_setup_commands(&clone_dir.join(".wsp.yaml")) else {
-        return; // no setup_commands declared
-    };
+    let resolved = wsp_core::setup_commands::resolve_for_repo(
+        cfg,
+        None, // no template context in doctor
+        Some(meta),
+        identity,
+        Some(clone_dir),
+    )
+    .dedup();
+    if resolved.is_empty() {
+        return; // no setup_commands from any layer
+    }
 
-    let hash = wsp_core::approvals::commands_hash(&cmds);
+    let hash = wsp_core::approvals::commands_hash(&resolved.commands);
     let store = match wsp_core::approvals::load(paths.data_dir()) {
         Ok(s) => s,
         Err(e) => {
@@ -2342,11 +2359,11 @@ fn check_unapproved_setup_commands(
     }
 
     if fix {
-        match wsp_core::setup_runner::prompt_and_run_setup(
+        match wsp_core::setup_runner::prompt_and_run_resolved_setup(
             paths.data_dir(),
             clone_dir,
             identity,
-            &cmds,
+            &resolved,
         ) {
             Ok(true) => {
                 *fixed += 1;
@@ -2534,6 +2551,7 @@ mod tests {
             created_from: None,
             dirs: std::collections::BTreeMap::new(),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         }
     }
 
@@ -2728,6 +2746,7 @@ mod tests {
                 config::RepoEntry {
                     url: "git@github.com:acme/kept.git".into(),
                     added: chrono::Utc::now(),
+                    setup_commands: None,
                 },
             )]),
             ..Default::default()
@@ -2769,6 +2788,7 @@ mod tests {
                 config::RepoEntry {
                     url: "git@github.com:acme/repo.git".into(),
                     added: chrono::Utc::now(),
+                    setup_commands: None,
                 },
             )]),
             ..Default::default()
@@ -2861,6 +2881,7 @@ mod tests {
             created_from: None,
             dirs: std::collections::BTreeMap::new(),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         };
         let cfg = config::Config {
             repos: std::collections::BTreeMap::from([(
@@ -2868,6 +2889,7 @@ mod tests {
                 config::RepoEntry {
                     url: "git@github.com:acme/known.git".into(),
                     added: chrono::Utc::now(),
+                    setup_commands: None,
                 },
             )]),
             ..Default::default()
@@ -2911,6 +2933,7 @@ mod tests {
             created_from: None,
             dirs: std::collections::BTreeMap::new(),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         };
 
         let mut checks = Vec::new();
@@ -2952,6 +2975,7 @@ mod tests {
             created_from: None,
             dirs: std::collections::BTreeMap::new(),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         };
 
         let mut checks = Vec::new();
@@ -2985,6 +3009,7 @@ mod tests {
                 ("github.com/acme/removed".into(), "removed".into()),
             ]),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         };
 
         let mut checks = Vec::new();
@@ -3019,6 +3044,7 @@ mod tests {
                 "repo".into(),
             )]),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         };
 
         let mut checks = Vec::new();
@@ -3397,6 +3423,7 @@ mod tests {
             created_from: None,
             dirs: std::collections::BTreeMap::new(),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         };
         create_workspace_on_disk(&ws_dir, &meta);
 
@@ -3447,6 +3474,7 @@ mod tests {
                 ("github.com/acme/removed".into(), "removed".into()),
             ]),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         };
         create_workspace_on_disk(&ws_dir, &meta);
 
@@ -3643,6 +3671,7 @@ mod tests {
                 config::RepoEntry {
                     url: "git@github.com:acme/repo.git".into(),
                     added: chrono::Utc::now(),
+                    setup_commands: None,
                 },
             )]),
             ..Default::default()
@@ -3861,6 +3890,7 @@ mod tests {
             wsp_version: None,
             repos: vec![template::TemplateRepo {
                 url: "git@github.com:acme/repo.git".into(),
+                setup_commands: None,
             }],
             config: None,
             agent_md: None,
@@ -3888,6 +3918,7 @@ mod tests {
             wsp_version: None,
             repos: vec![template::TemplateRepo {
                 url: "not-a-valid-url".into(),
+                setup_commands: None,
             }],
             config: None,
             agent_md: None,
@@ -3919,6 +3950,7 @@ mod tests {
             wsp_version: None,
             repos: vec![template::TemplateRepo {
                 url: "git@github.com:acme/repo.git".into(),
+                setup_commands: None,
             }],
             config: None,
             agent_md: None,
@@ -3932,6 +3964,7 @@ mod tests {
                 config::RepoEntry {
                     url: "git@github.com:acme/repo.git".into(),
                     added: chrono::Utc::now(),
+                    setup_commands: None,
                 },
             )]),
             ..Default::default()
@@ -3957,6 +3990,7 @@ mod tests {
             wsp_version: None,
             repos: vec![template::TemplateRepo {
                 url: "git@github.com:acme/repo.git".into(),
+                setup_commands: None,
             }],
             config: None,
             agent_md: None,
@@ -3999,6 +4033,7 @@ mod tests {
             created_from: None,
             dirs: std::collections::BTreeMap::new(),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         };
         create_workspace_on_disk(&ws_dir, &meta);
 
@@ -4036,6 +4071,7 @@ mod tests {
             created_from: None,
             dirs: std::collections::BTreeMap::new(), // Missing collision entries!
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         };
         create_workspace_on_disk(&ws_dir, &meta);
 
@@ -4074,6 +4110,7 @@ mod tests {
             created_from: None,
             dirs: std::collections::BTreeMap::new(),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         };
         create_workspace_on_disk(&ws_dir, &meta);
 
@@ -4119,6 +4156,7 @@ mod tests {
                 ("github.com/org2/shared".into(), "wrong-name-2".into()),
             ]),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         };
         create_workspace_on_disk(&ws_dir, &meta);
 

--- a/crates/wsp/src/cli/help.rs
+++ b/crates/wsp/src/cli/help.rs
@@ -211,13 +211,45 @@ EXAMPLES
     ),
     (
         "wsp.yaml",
-        "Per-repo .wsp.yaml and setup_commands",
+        "Setup commands: layers, approval, and management",
         "\
-wsp.yaml — per-repo .wsp.yaml and setup_commands
+wsp.yaml — setup commands
 
-Individual repos can declare post-clone setup commands in their own .wsp.yaml,
-committed to the repo root. When wsp clones a repo into a workspace, it reads
-this file and offers to run the listed commands.
+Setup commands can be declared at four layers. When wsp clones a repo, all
+layers are gathered and concatenated in order. The merged list is what the
+user approves; its hash determines whether re-approval is needed.
+
+LAYERS (in resolution order)
+
+  1. Registry     Per-repo commands in ~/.local/share/wsp/config.yaml
+  2. Template     Per-repo commands on a TemplateRepo
+  3. Repo         Committed setup_commands in the repo's own .wsp.yaml
+  4. Workspace    Per-repo overrides in workspace .wsp.yaml metadata
+
+  Commands are not deduplicated at resolution time — setup commands are
+  expected to be idempotent. Use `wsp repo setup --all` to run every
+  occurrence; by default, exact duplicates are removed before prompting
+  (first occurrence wins).
+
+DECLARING SETUP COMMANDS
+
+  Repo .wsp.yaml (committed to git):
+
+    setup_commands:
+      - task setup
+      - lefthook install
+
+  Registry (personal, not committed):
+
+    wsp repo setup-commands add <repo> 'npm install' --registry
+
+  Template (per-repo):
+
+    wsp template setup-commands add <template> <repo> 'make deps'
+
+  Workspace (local override):
+
+    wsp repo setup-commands add <repo> './extra.sh' --workspace
 
 SCAFFOLDING
 
@@ -225,27 +257,44 @@ SCAFFOLDING
                                in the current git repo.
   wsp init --print-sample      Print a commented sample .wsp.yaml to stdout.
 
-SETUP_COMMANDS
-
-  The setup_commands field holds a list of shell commands to run after cloning:
-
-    setup_commands:
-      - task setup
-      - lefthook install
+APPROVAL FLOW
 
   wsp prompts before running (like direnv):
 
     Setup commands for github.com/acme/api-gateway:
-      task setup
       lefthook install
+      task setup
+      ./extra.sh
     Run these commands? [y/N]
 
   y        Allow and run. Future runs skip the prompt automatically.
   N/Enter  Skip.
 
-  Approvals are stored by SHA-256 hash of the command list in
-  ~/.local/share/wsp/approvals.yaml. Changing the command list invalidates
-  the approval and triggers a fresh prompt.
+  Approvals are stored by SHA-256 hash of the merged command list in
+  ~/.local/share/wsp/approvals.yaml. Any change at any layer triggers a
+  fresh prompt.
+
+MANAGING SETUP COMMANDS
+
+  wsp repo setup-commands ls    <repo>            List merged commands with provenance.
+  wsp repo setup-commands add   <repo> <cmd>      Add (default scope: workspace or registry).
+  wsp repo setup-commands rm    <repo> <cmd>      Remove from a scope.
+  wsp repo setup-commands clear <repo>            Clear all commands at a scope.
+
+  Scope flags: --registry, --workspace, --repo. Default: --repo if CWD is
+  inside a repo clone, --workspace if inside a workspace, --registry
+  otherwise.
+
+    --registry   Personal override; runs in every workspace for this repo.
+    --workspace  Local to the current workspace only.
+    --repo       Writes to the repo's committed .wsp.yaml (all clones).
+
+  For templates:
+
+  wsp template setup-commands ls    <tmpl> <repo>        List.
+  wsp template setup-commands add   <tmpl> <repo> <cmd>  Add.
+  wsp template setup-commands rm    <tmpl> <repo> <cmd>  Remove.
+  wsp template setup-commands clear <tmpl> <repo>        Clear.
 
 RUNNING SETUP MANUALLY
 
@@ -254,7 +303,7 @@ RUNNING SETUP MANUALLY
   wsp repo setup <repo>        Run for a specific repo.
   wsp repo setup --force       Re-prompt even if previously approved.
 
-  wsp doctor (W15) warns when a repo has setup_commands that haven't been approved.
+  wsp doctor (W15) warns when a repo has unapproved setup commands.
   wsp doctor --fix invokes the interactive approval flow.
 ",
     ),

--- a/crates/wsp/src/cli/help.rs
+++ b/crates/wsp/src/cli/help.rs
@@ -301,7 +301,6 @@ RUNNING SETUP MANUALLY
   wsp repo setup               Run setup commands for all repos in the current
                                workspace (prompts for any unapproved).
   wsp repo setup <repo>        Run for a specific repo.
-  wsp repo setup --force       Re-prompt even if previously approved.
 
   wsp doctor (W15) warns when a repo has unapproved setup commands.
   wsp doctor --fix invokes the interactive approval flow.

--- a/crates/wsp/src/cli/help.rs
+++ b/crates/wsp/src/cli/help.rs
@@ -279,7 +279,7 @@ MANAGING SETUP COMMANDS
   wsp repo setup-commands ls    <repo>            List merged commands with provenance.
   wsp repo setup-commands add   <repo> <cmd>      Add (default scope: workspace or registry).
   wsp repo setup-commands rm    <repo> <cmd>      Remove from a scope.
-  wsp repo setup-commands clear <repo>            Clear all commands at a scope.
+  wsp repo setup-commands clear <repo>            Clear all commands at a scope (prompts; use --yes to skip).
 
   Scope flags: --registry, --workspace, --repo. Default: --repo if CWD is
   inside a repo clone, --workspace if inside a workspace, --registry

--- a/crates/wsp/src/cli/help.rs
+++ b/crates/wsp/src/cli/help.rs
@@ -192,7 +192,7 @@ HINTS
                         Default: true
 
   advice.<key>          Boolean. Suppress a specific hint by key.
-                        Keys: branchPrefix, setupCommands
+                        Keys: branchPrefix, setupCommands, registrySetupCommands
                         Example: `wsp config set advice.branchPrefix false`
                         Default: true (hint enabled)
 

--- a/crates/wsp/src/cli/init.rs
+++ b/crates/wsp/src/cli/init.rs
@@ -48,8 +48,8 @@ pub fn run(matches: &ArgMatches, _paths: &Paths) -> Result<Output> {
         wsp_core::template::read_setup_commands(&cwd.join(".wsp.yaml")).unwrap_or_default();
     let commands = prompt_for_commands(&existing)?;
 
-    write_setup_commands(&cwd.join(".wsp.yaml"), &commands)?;
-    ensure_gitignore(&cwd)?;
+    wsp_core::template::write_setup_commands(&cwd.join(".wsp.yaml"), &commands)?;
+    wsp_core::template::ensure_gitignore(&cwd)?;
 
     eprintln!("Wrote .wsp.yaml");
     eprintln!("Run `wsp repo setup` inside a workspace to execute these commands.");
@@ -148,70 +148,6 @@ fn read_prompt() -> Result<String> {
     Ok(line)
 }
 
-/// Write `setup_commands` into `.wsp.yaml`, preserving any unknown fields.
-/// Uses `serde_yaml_ng::Value` merge + atomic rename to avoid clobbering
-/// fields added by future wsp versions.
-fn write_setup_commands(path: &Path, commands: &[String]) -> Result<()> {
-    let mut doc: serde_yaml_ng::Value = if path.exists() {
-        let content = std::fs::read_to_string(path)?;
-        serde_yaml_ng::from_str(&content)?
-    } else {
-        serde_yaml_ng::Value::Mapping(serde_yaml_ng::Mapping::new())
-    };
-
-    let mapping = doc.as_mapping_mut().ok_or_else(|| {
-        anyhow::anyhow!(".wsp.yaml is not a YAML mapping; cannot update it safely")
-    })?;
-
-    if commands.is_empty() {
-        mapping.remove("setup_commands");
-    } else {
-        let cmds_value = serde_yaml_ng::Value::Sequence(
-            commands
-                .iter()
-                .map(|s| serde_yaml_ng::Value::String(s.clone()))
-                .collect(),
-        );
-        mapping.insert(
-            serde_yaml_ng::Value::String("setup_commands".to_string()),
-            cmds_value,
-        );
-    }
-
-    let yaml_str = serde_yaml_ng::to_string(&doc)?;
-    let parent = path.parent().unwrap_or(Path::new("."));
-    let mut tmp = tempfile::NamedTempFile::new_in(parent)?;
-    tmp.write_all(yaml_str.as_bytes())?;
-    tmp.persist(path)?;
-    Ok(())
-}
-
-/// Ensure `.wsp.yaml.lock` is in `.gitignore`. Creates the file if needed.
-fn ensure_gitignore(repo_root: &Path) -> Result<()> {
-    let gitignore = repo_root.join(".gitignore");
-    let pattern = ".wsp.yaml.lock";
-
-    if gitignore.exists() {
-        let content = std::fs::read_to_string(&gitignore)?;
-        if content.lines().any(|line| line.trim() == pattern) {
-            return Ok(());
-        }
-        // Append with a newline guard — avoid joining onto an unterminated last line
-        let prefix = if content.ends_with('\n') || content.is_empty() {
-            ""
-        } else {
-            "\n"
-        };
-        std::fs::OpenOptions::new()
-            .append(true)
-            .open(&gitignore)?
-            .write_all(format!("{}{}\n", prefix, pattern).as_bytes())?;
-    } else {
-        std::fs::write(&gitignore, format!("{}\n", pattern))?;
-    }
-    Ok(())
-}
-
 fn print_sample() {
     print!(
         "# .wsp.yaml - per-repo setup commands\n\
@@ -232,16 +168,16 @@ setup_commands: []\n"
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use wsp_core::template;
 
     #[test]
     fn write_creates_file() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(".wsp.yaml");
         let cmds = vec!["task setup".to_string(), "lefthook install".to_string()];
-        write_setup_commands(&path, &cmds).unwrap();
+        template::write_setup_commands(&path, &cmds).unwrap();
         assert!(path.exists());
-        let back = wsp_core::template::read_setup_commands(&path).unwrap_or_default();
+        let back = template::read_setup_commands(&path).unwrap_or_default();
         assert_eq!(back, cmds);
     }
 
@@ -250,7 +186,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(".wsp.yaml");
         std::fs::write(&path, "some_future_key: value\n").unwrap();
-        write_setup_commands(&path, &["task setup".to_string()]).unwrap();
+        template::write_setup_commands(&path, &["task setup".to_string()]).unwrap();
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(
             content.contains("some_future_key"),
@@ -266,9 +202,9 @@ mod tests {
     fn write_replaces_existing() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(".wsp.yaml");
-        write_setup_commands(&path, &["old".to_string()]).unwrap();
-        write_setup_commands(&path, &["new".to_string()]).unwrap();
-        let back = wsp_core::template::read_setup_commands(&path).unwrap_or_default();
+        template::write_setup_commands(&path, &["old".to_string()]).unwrap();
+        template::write_setup_commands(&path, &["new".to_string()]).unwrap();
+        let back = template::read_setup_commands(&path).unwrap_or_default();
         assert_eq!(back, vec!["new".to_string()]);
     }
 
@@ -276,8 +212,8 @@ mod tests {
     fn write_empty_removes_key() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(".wsp.yaml");
-        write_setup_commands(&path, &["task setup".to_string()]).unwrap();
-        write_setup_commands(&path, &[]).unwrap();
+        template::write_setup_commands(&path, &["task setup".to_string()]).unwrap();
+        template::write_setup_commands(&path, &[]).unwrap();
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(
             !content.contains("setup_commands"),
@@ -290,7 +226,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(".wsp.yaml");
         std::fs::write(&path, "- item1\n- item2\n").unwrap();
-        let err = write_setup_commands(&path, &["task setup".to_string()]).unwrap_err();
+        let err = template::write_setup_commands(&path, &["task setup".to_string()]).unwrap_err();
         assert!(
             err.to_string().contains("not a YAML mapping"),
             "unexpected error: {err}"
@@ -300,7 +236,7 @@ mod tests {
     #[test]
     fn ensure_gitignore_creates_file() {
         let dir = tempfile::tempdir().unwrap();
-        ensure_gitignore(dir.path()).unwrap();
+        template::ensure_gitignore(dir.path()).unwrap();
         let content = std::fs::read_to_string(dir.path().join(".gitignore")).unwrap();
         assert_eq!(content, ".wsp.yaml.lock\n");
     }
@@ -309,7 +245,7 @@ mod tests {
     fn ensure_gitignore_appends_to_existing() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join(".gitignore"), "target/\n").unwrap();
-        ensure_gitignore(dir.path()).unwrap();
+        template::ensure_gitignore(dir.path()).unwrap();
         let content = std::fs::read_to_string(dir.path().join(".gitignore")).unwrap();
         assert_eq!(content, "target/\n.wsp.yaml.lock\n");
     }
@@ -318,7 +254,7 @@ mod tests {
     fn ensure_gitignore_appends_with_missing_newline() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join(".gitignore"), "target/").unwrap();
-        ensure_gitignore(dir.path()).unwrap();
+        template::ensure_gitignore(dir.path()).unwrap();
         let content = std::fs::read_to_string(dir.path().join(".gitignore")).unwrap();
         assert_eq!(content, "target/\n.wsp.yaml.lock\n");
     }
@@ -327,7 +263,7 @@ mod tests {
     fn ensure_gitignore_idempotent() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join(".gitignore"), ".wsp.yaml.lock\nother\n").unwrap();
-        ensure_gitignore(dir.path()).unwrap();
+        template::ensure_gitignore(dir.path()).unwrap();
         let content = std::fs::read_to_string(dir.path().join(".gitignore")).unwrap();
         assert_eq!(content, ".wsp.yaml.lock\nother\n");
     }

--- a/crates/wsp/src/cli/mod.rs
+++ b/crates/wsp/src/cli/mod.rs
@@ -21,6 +21,7 @@ pub mod rename;
 pub mod repo;
 pub mod repo_list;
 pub mod repo_setup;
+pub mod repo_setup_commands;
 pub mod setup;
 pub mod skill;
 pub mod status;
@@ -70,7 +71,8 @@ pub fn build_cli() -> Command {
         .subcommand(remove::cmd())
         .subcommand(fetch::cmd())
         .subcommand(repo_list::cmd())
-        .subcommand(repo_setup::cmd());
+        .subcommand(repo_setup::cmd())
+        .subcommand(repo_setup_commands::cmd());
 
     #[allow(unused_mut)]
     let mut cli = Command::new("wsp")
@@ -171,6 +173,7 @@ pub fn dispatch(matches: &ArgMatches, paths: &Paths) -> anyhow::Result<Output> {
             Some(("fetch", m)) => fetch::run(m, paths),
             Some(("ls", m)) => repo_list::run(m, paths),
             Some(("setup", m)) => repo_setup::run(m, paths),
+            Some(("setup-commands", m)) => repo_setup_commands::run(m, paths),
             None => repo_list::run(sub, paths),
             _ => unreachable!(),
         },

--- a/crates/wsp/src/cli/new.rs
+++ b/crates/wsp/src/cli/new.rs
@@ -460,21 +460,30 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
         }
     }
 
-    // Run per-repo setup commands declared in each clone's own .wsp.yaml
+    // Run per-repo setup commands resolved from all layers:
+    //   registry → template → repo .wsp.yaml → workspace
     if let Ok(ref meta) = meta_result {
         for info in meta.repo_infos(&ws_dir) {
             if info.error.is_some() {
                 continue;
             }
-            if let Some(cmds) =
-                wsp_core::template::read_setup_commands(&info.clone_dir.join(".wsp.yaml"))
-                && let Err(e) = wsp_core::setup_runner::maybe_run_setup(
-                    paths.data_dir(),
-                    &info.clone_dir,
-                    &info.identity,
-                    &cmds,
-                )
-            {
+            let resolved = wsp_core::setup_commands::resolve_for_repo(
+                &cfg,
+                loaded_template.as_ref(),
+                Some(meta),
+                &info.identity,
+                Some(&info.clone_dir),
+            )
+            .dedup();
+            if resolved.is_empty() {
+                continue;
+            }
+            if let Err(e) = wsp_core::setup_runner::maybe_run_resolved(
+                paths.data_dir(),
+                &info.clone_dir,
+                &info.identity,
+                &resolved,
+            ) {
                 eprintln!("warning: setup commands for {}: {}", info.identity, e);
             }
         }

--- a/crates/wsp/src/cli/rename.rs
+++ b/crates/wsp/src/cli/rename.rs
@@ -92,6 +92,7 @@ mod tests {
             created_from: None,
             dirs: std::collections::BTreeMap::new(),
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         };
         wsp_core::workspace::save_metadata(&ws_dir, &meta).unwrap();
         ws_dir

--- a/crates/wsp/src/cli/repo.rs
+++ b/crates/wsp/src/cli/repo.rs
@@ -140,6 +140,7 @@ pub fn run_add(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
             RepoEntry {
                 url: store_url.clone(),
                 added: Utc::now(),
+                setup_commands: None,
             },
         );
         Ok(())
@@ -297,6 +298,7 @@ fn import_repos(
                     RepoEntry {
                         url: cr.url.clone(),
                         added: Utc::now(),
+                        setup_commands: None,
                     },
                 );
                 registered.push(cr.identity.clone());

--- a/crates/wsp/src/cli/repo_setup.rs
+++ b/crates/wsp/src/cli/repo_setup.rs
@@ -5,7 +5,6 @@ use clap_complete::engine::ArgValueCandidates;
 use wsp_core::config::Paths;
 use wsp_core::giturl;
 use wsp_core::output::{MutationOutput, Output};
-use wsp_core::template;
 use wsp_core::workspace;
 
 use super::completers;
@@ -15,11 +14,11 @@ pub fn cmd() -> Command {
         .about("Run setup commands for repos in the current workspace")
         .long_about(
             "Run setup commands for repos in the current workspace.\n\n\
-             Repos can declare setup_commands in their .wsp.yaml to run after cloning \
-             (e.g. installing git hooks, generating files). This command re-runs those \
-             commands, prompting for approval if not already approved.\n\n\
-             Filters to the given repos if specified; otherwise runs for all repos that \
-             have setup_commands. Use --force to re-prompt even for already-approved repos.",
+             Commands are resolved from up to four layers (registry, template, repo \
+             .wsp.yaml, workspace overrides) and concatenated. By default, exact \
+             duplicates are removed before prompting (use --all to run every \
+             occurrence). Use --force to re-prompt even for already-approved repos.\n\n\
+             Use `wsp repo setup-commands ls` to see the full list with provenance labels.",
         )
         .arg(
             Arg::new("repos")
@@ -32,6 +31,12 @@ pub fn cmd() -> Command {
                 .action(clap::ArgAction::SetTrue)
                 .help("Re-prompt even if commands are already approved"),
         )
+        .arg(
+            Arg::new("all")
+                .long("all")
+                .action(clap::ArgAction::SetTrue)
+                .help("Run all commands including duplicates across layers"),
+        )
 }
 
 pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
@@ -40,6 +45,7 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
         .map(|v| v.collect())
         .unwrap_or_default();
     let force = matches.get_flag("force");
+    let all = matches.get_flag("all");
 
     let cwd = std::env::current_dir()?;
     let ws_dir = workspace::detect(&cwd)?;
@@ -65,23 +71,33 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
             continue;
         }
 
-        let Some(cmds) = template::read_setup_commands(&info.clone_dir.join(".wsp.yaml")) else {
-            continue;
+        let resolved = {
+            let r = wsp_core::setup_commands::resolve_for_repo(
+                &cfg,
+                None, // no template context for manual re-run
+                Some(&meta),
+                &info.identity,
+                Some(&info.clone_dir),
+            );
+            if all { r } else { r.dedup() }
         };
+        if resolved.is_empty() {
+            continue;
+        }
 
         let result = if force {
-            wsp_core::setup_runner::prompt_and_run_setup(
+            wsp_core::setup_runner::prompt_and_run_resolved_setup(
                 paths.data_dir(),
                 &info.clone_dir,
                 &info.identity,
-                &cmds,
+                &resolved,
             )
         } else {
-            wsp_core::setup_runner::maybe_run_setup(
+            wsp_core::setup_runner::maybe_run_resolved(
                 paths.data_dir(),
                 &info.clone_dir,
                 &info.identity,
-                &cmds,
+                &resolved,
             )
         };
 

--- a/crates/wsp/src/cli/repo_setup.rs
+++ b/crates/wsp/src/cli/repo_setup.rs
@@ -17,19 +17,13 @@ pub fn cmd() -> Command {
              Commands are resolved from up to four layers (registry, template, repo \
              .wsp.yaml, workspace overrides) and concatenated. By default, exact \
              duplicates are removed before prompting (use --all to run every \
-             occurrence). Use --force to re-prompt even for already-approved repos.\n\n\
+             occurrence).\n\n\
              Use `wsp repo setup-commands ls` to see the full list with provenance labels.",
         )
         .arg(
             Arg::new("repos")
                 .num_args(0..)
                 .add(ArgValueCandidates::new(completers::complete_repos)),
-        )
-        .arg(
-            Arg::new("force")
-                .long("force")
-                .action(clap::ArgAction::SetTrue)
-                .help("Re-prompt even if commands are already approved"),
         )
         .arg(
             Arg::new("all")
@@ -44,7 +38,6 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
         .get_many::<String>("repos")
         .map(|v| v.collect())
         .unwrap_or_default();
-    let force = matches.get_flag("force");
     let all = matches.get_flag("all");
 
     let cwd = std::env::current_dir()?;
@@ -85,23 +78,12 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
             continue;
         }
 
-        let result = if force {
-            wsp_core::setup_runner::prompt_and_run_resolved_setup(
-                paths.data_dir(),
-                &info.clone_dir,
-                &info.identity,
-                &resolved,
-            )
-        } else {
-            wsp_core::setup_runner::maybe_run_resolved(
-                paths.data_dir(),
-                &info.clone_dir,
-                &info.identity,
-                &resolved,
-            )
-        };
-
-        match result {
+        match wsp_core::setup_runner::maybe_run_resolved(
+            paths.data_dir(),
+            &info.clone_dir,
+            &info.identity,
+            &resolved,
+        ) {
             Ok(true) => ran += 1,
             Ok(false) => skipped += 1,
             Err(e) => eprintln!("warning: setup for {}: {}", info.identity, e),

--- a/crates/wsp/src/cli/repo_setup_commands.rs
+++ b/crates/wsp/src/cli/repo_setup_commands.rs
@@ -1,3 +1,4 @@
+use std::io::{BufRead as _, IsTerminal as _};
 use std::path::Path;
 
 use anyhow::{Result, bail};
@@ -105,6 +106,13 @@ fn clear_cmd() -> Command {
         .arg(scope_registry_arg())
         .arg(scope_workspace_arg())
         .arg(scope_repo_arg())
+        .arg(
+            Arg::new("yes")
+                .long("yes")
+                .short('y')
+                .action(clap::ArgAction::SetTrue)
+                .help("Skip confirmation prompt (required when stdin is not a terminal)"),
+        )
 }
 
 fn scope_registry_arg() -> Arg {
@@ -268,13 +276,80 @@ fn run_rm(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
 
 fn run_clear(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
     let repo_arg = matches.get_one::<String>("repo");
+    let yes = matches.get_flag("yes");
     let cwd = std::env::current_dir()?;
     let identity = resolve_repo(repo_arg, paths)?;
+    let scope = resolve_scope(matches, repo_arg.is_none(), &cwd)?;
 
-    match resolve_scope(matches, repo_arg.is_none(), &cwd)? {
+    // Read current commands so we can show them and detect no-op before clearing.
+    let current = read_commands_for_scope(&scope, paths, &identity, &cwd)?;
+    if current.is_empty() {
+        bail!("no setup commands to clear for {}", identity);
+    }
+
+    if !yes {
+        if !std::io::stdin().is_terminal() {
+            bail!(
+                "stdin is not a terminal; pass --yes to confirm: \
+                 wsp repo setup-commands clear {} --yes",
+                identity
+            );
+        }
+        eprintln!("Setup commands that will be removed for {}:", identity);
+        for cmd in &current {
+            eprintln!("  {}", cmd);
+        }
+        eprint!("Clear these commands? [y/N] ");
+        let mut line = String::new();
+        std::io::stdin().lock().read_line(&mut line)?;
+        if line.is_empty() {
+            bail!("aborted");
+        }
+        if !matches!(line.trim().to_lowercase().as_str(), "y" | "yes") {
+            bail!("aborted");
+        }
+    }
+
+    match scope {
         Scope::Registry => run_registry_clear(paths, &identity),
         Scope::Workspace => run_workspace_clear(paths, &identity),
         Scope::Repo => run_repo_clear(&identity, &cwd),
+    }
+}
+
+/// Read the current commands for a scope without mutating anything.
+fn read_commands_for_scope(
+    scope: &Scope,
+    paths: &Paths,
+    identity: &str,
+    cwd: &Path,
+) -> Result<Vec<String>> {
+    match scope {
+        Scope::Registry => {
+            let cfg = config::Config::load_from(&paths.config_path)
+                .map_err(|e| anyhow::anyhow!("loading config: {}", e))?;
+            Ok(cfg
+                .repos
+                .get(identity)
+                .and_then(|e| e.setup_commands.clone())
+                .unwrap_or_default())
+        }
+        Scope::Workspace => {
+            let ws_dir = workspace::detect(cwd)?;
+            let meta = workspace::load_metadata(&ws_dir)?;
+            Ok(meta
+                .setup_commands
+                .get(identity)
+                .cloned()
+                .unwrap_or_default())
+        }
+        Scope::Repo => {
+            let clone_dir = clone_dir_for(identity, cwd)?;
+            Ok(
+                wsp_core::template::read_setup_commands(&clone_dir.join(".wsp.yaml"))
+                    .unwrap_or_default(),
+            )
+        }
     }
 }
 

--- a/crates/wsp/src/cli/repo_setup_commands.rs
+++ b/crates/wsp/src/cli/repo_setup_commands.rs
@@ -1,0 +1,540 @@
+use std::path::Path;
+
+use anyhow::{Result, bail};
+use clap::{Arg, ArgMatches, Command};
+use clap_complete::engine::ArgValueCandidates;
+
+use wsp_core::config::{self, Paths};
+use wsp_core::filelock;
+use wsp_core::giturl;
+use wsp_core::output::{MutationOutput, Output, SetupCommandEntry, SetupCommandsOutput};
+use wsp_core::workspace;
+
+use super::completers;
+
+pub fn cmd() -> Command {
+    Command::new("setup-commands")
+        .about("Manage per-repo setup commands")
+        .long_about(
+            "View or manage setup commands for a repo.\n\n\
+             `ls` shows the merged commands from all layers (registry, template, repo \
+             .wsp.yaml, workspace) with provenance labels.\n\n\
+             `add`, `rm`, and `clear` target a specific scope. Scope flags: --registry, \
+             --workspace, --repo. Default: repo scope (.wsp.yaml) when inside a repo clone, \
+             workspace scope when inside a workspace but not a clone, registry otherwise.",
+        )
+        .subcommand_required(true)
+        .arg_required_else_help(true)
+        .subcommand(ls_cmd())
+        .subcommand(add_cmd())
+        .subcommand(rm_cmd())
+        .subcommand(clear_cmd())
+}
+
+fn ls_cmd() -> Command {
+    Command::new("ls")
+        .visible_alias("list")
+        .about("List merged setup commands with provenance [read-only]")
+        .arg(
+            Arg::new("repo")
+                .required(false)
+                .help("Repo identity, URL, or shortname (inferred from cwd if omitted)")
+                .add(ArgValueCandidates::new(completers::complete_repos)),
+        )
+}
+
+fn add_cmd() -> Command {
+    Command::new("add")
+        .about("Add a setup command for a repo")
+        .arg(
+            Arg::new("repo")
+                .required(false)
+                .help("Repo identity, URL, or shortname (inferred from cwd if omitted)")
+                .add(ArgValueCandidates::new(completers::complete_repos)),
+        )
+        .arg(
+            Arg::new("cmd")
+                .required(true)
+                .num_args(1..)
+                .last(true)
+                .allow_hyphen_values(true)
+                .help(
+                    "Shell command to add; use -- to pass multi-word commands: add -- npm install",
+                ),
+        )
+        .arg(scope_registry_arg())
+        .arg(scope_workspace_arg())
+        .arg(scope_repo_arg())
+}
+
+fn rm_cmd() -> Command {
+    Command::new("rm")
+        .visible_alias("remove")
+        .about("Remove a setup command for a repo")
+        .arg(
+            Arg::new("repo")
+                .required(false)
+                .help("Repo identity, URL, or shortname (inferred from cwd if omitted)")
+                .add(ArgValueCandidates::new(completers::complete_repos)),
+        )
+        .arg(
+            Arg::new("cmd")
+                .required(true)
+                .num_args(1..)
+                .last(true)
+                .allow_hyphen_values(true)
+                .help("Shell command to remove; use -- to pass multi-word commands: rm -- npm install")
+                .add(ArgValueCandidates::new(
+                    completers::complete_repo_setup_commands,
+                )),
+        )
+        .arg(scope_registry_arg())
+        .arg(scope_workspace_arg())
+        .arg(scope_repo_arg())
+}
+
+fn clear_cmd() -> Command {
+    Command::new("clear")
+        .about("Clear all setup commands for a repo at a scope")
+        .arg(
+            Arg::new("repo")
+                .required(false)
+                .help("Repo identity, URL, or shortname (inferred from cwd if omitted)")
+                .add(ArgValueCandidates::new(completers::complete_repos)),
+        )
+        .arg(scope_registry_arg())
+        .arg(scope_workspace_arg())
+        .arg(scope_repo_arg())
+}
+
+fn scope_registry_arg() -> Arg {
+    Arg::new("registry")
+        .long("registry")
+        .action(clap::ArgAction::SetTrue)
+        .help("Target the global registry scope")
+        .conflicts_with("workspace")
+        .conflicts_with("repo-scope")
+}
+
+fn scope_workspace_arg() -> Arg {
+    Arg::new("workspace")
+        .long("workspace")
+        .action(clap::ArgAction::SetTrue)
+        .help("Target the current workspace scope")
+        .conflicts_with("repo-scope")
+}
+
+fn scope_repo_arg() -> Arg {
+    Arg::new("repo-scope")
+        .long("repo")
+        .action(clap::ArgAction::SetTrue)
+        .help("Target the repo scope (writes to .wsp.yaml in the clone directory)")
+}
+
+pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
+    match matches.subcommand() {
+        Some(("ls", m)) => run_ls(m, paths),
+        Some(("add", m)) => run_add(m, paths),
+        Some(("rm", m)) => run_rm(m, paths),
+        Some(("clear", m)) => run_clear(m, paths),
+        _ => unreachable!(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Repo resolution (explicit arg or CWD inference)
+// ---------------------------------------------------------------------------
+
+/// Resolve a repo identity from an explicit arg, or fall back to CWD detection.
+/// Accepts a pre-loaded config to avoid redundant I/O when the caller already has one.
+fn resolve_repo(repo_arg: Option<&String>, paths: &Paths) -> Result<String> {
+    let cfg = config::Config::load_from(&paths.config_path)
+        .map_err(|e| anyhow::anyhow!("loading config: {}", e))?;
+    resolve_repo_with_cfg(repo_arg, &cfg)
+}
+
+fn resolve_repo_with_cfg(repo_arg: Option<&String>, cfg: &config::Config) -> Result<String> {
+    let identities: Vec<String> = cfg.repos.keys().cloned().collect();
+
+    if let Some(arg) = repo_arg {
+        return giturl::resolve(giturl::parse_repo_ref(arg), &identities);
+    }
+
+    // No explicit repo — try to infer from CWD.
+    let cwd = std::env::current_dir()?;
+    let ws_dir = workspace::detect(&cwd)
+        .map_err(|_| anyhow::anyhow!("not in a workspace; specify a repo name"))?;
+    let meta = workspace::load_metadata(&ws_dir)?;
+    workspace::repo_from_cwd(&ws_dir, &meta, &cwd).ok_or_else(|| {
+        anyhow::anyhow!("could not detect repo from current directory; specify a repo name")
+    })
+}
+
+// ---------------------------------------------------------------------------
+// ls
+// ---------------------------------------------------------------------------
+
+fn run_ls(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
+    let repo_arg = matches.get_one::<String>("repo");
+    let cfg = config::Config::load_from(&paths.config_path)
+        .map_err(|e| anyhow::anyhow!("loading config: {}", e))?;
+    let identity = resolve_repo_with_cfg(repo_arg, &cfg)?;
+    run_list(&cfg, &identity)
+}
+
+fn run_list(cfg: &config::Config, identity: &str) -> Result<Output> {
+    let cwd = std::env::current_dir()?;
+    let (meta, ws_dir) = match workspace::detect(&cwd) {
+        Ok(ws_dir) => (Some(workspace::load_metadata(&ws_dir)?), Some(ws_dir)),
+        Err(_) => (None, None),
+    };
+
+    let clone_dir = ws_dir.as_ref().and_then(|ws| {
+        meta.as_ref()
+            .and_then(|m| m.dir_name(identity).ok())
+            .map(|d| ws.join(d))
+    });
+
+    let resolved = wsp_core::setup_commands::resolve_for_repo(
+        cfg,
+        None, // no template context in list mode
+        meta.as_ref(),
+        identity,
+        clone_dir.as_deref(),
+    );
+
+    let commands = resolved
+        .provenance
+        .into_iter()
+        .map(|(command, source)| SetupCommandEntry {
+            command,
+            source: source.to_string(),
+        })
+        .collect();
+
+    Ok(Output::SetupCommands(SetupCommandsOutput {
+        repo: identity.to_string(),
+        commands,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// add
+// ---------------------------------------------------------------------------
+
+fn run_add(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
+    let repo_arg = matches.get_one::<String>("repo");
+    let cmd = matches
+        .get_many::<String>("cmd")
+        .unwrap()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join(" ");
+    let cwd = std::env::current_dir()?;
+    let identity = resolve_repo(repo_arg, paths)?;
+
+    match resolve_scope(matches, repo_arg.is_none(), &cwd)? {
+        Scope::Registry => run_registry_add(paths, &identity, &cmd),
+        Scope::Workspace => run_workspace_add(paths, &identity, &cmd),
+        Scope::Repo => run_repo_add(&identity, &cmd, &cwd),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// rm
+// ---------------------------------------------------------------------------
+
+fn run_rm(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
+    let repo_arg = matches.get_one::<String>("repo");
+    let cmd = matches
+        .get_many::<String>("cmd")
+        .unwrap()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join(" ");
+    let cwd = std::env::current_dir()?;
+    let identity = resolve_repo(repo_arg, paths)?;
+
+    match resolve_scope(matches, repo_arg.is_none(), &cwd)? {
+        Scope::Registry => run_registry_rm(paths, &identity, &cmd),
+        Scope::Workspace => run_workspace_rm(paths, &identity, &cmd),
+        Scope::Repo => run_repo_rm(&identity, &cmd, &cwd),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// clear
+// ---------------------------------------------------------------------------
+
+fn run_clear(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
+    let repo_arg = matches.get_one::<String>("repo");
+    let cwd = std::env::current_dir()?;
+    let identity = resolve_repo(repo_arg, paths)?;
+
+    match resolve_scope(matches, repo_arg.is_none(), &cwd)? {
+        Scope::Registry => run_registry_clear(paths, &identity),
+        Scope::Workspace => run_workspace_clear(paths, &identity),
+        Scope::Repo => run_repo_clear(&identity, &cwd),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scope resolution
+// ---------------------------------------------------------------------------
+
+enum Scope {
+    Registry,
+    Workspace,
+    /// Write to the repo's own `.wsp.yaml` (committed to source control).
+    Repo,
+}
+
+/// Resolve the target scope for a mutation.
+///
+/// Priority order:
+/// 1. Explicit `--registry` / `--workspace` / `--repo` flags
+/// 2. Smart default when `repo_inferred` is true (no explicit `<repo>` arg):
+///    - CWD is inside a repo clone in a workspace → `Scope::Repo`
+///    - CWD is inside a workspace (but not a specific clone) → `Scope::Workspace`
+/// 3. CWD is inside a workspace (explicit repo arg) → `Scope::Workspace`
+/// 4. Outside a workspace → `Scope::Registry`
+fn resolve_scope(matches: &ArgMatches, repo_inferred: bool, cwd: &Path) -> Result<Scope> {
+    let registry_flag = matches.get_flag("registry");
+    let workspace_flag = matches.get_flag("workspace");
+    let repo_flag = matches.get_flag("repo-scope");
+
+    if registry_flag {
+        return Ok(Scope::Registry);
+    }
+    if workspace_flag {
+        return Ok(Scope::Workspace);
+    }
+    if repo_flag {
+        return Ok(Scope::Repo);
+    }
+
+    match workspace::detect(cwd) {
+        Ok(ws_dir) => {
+            // When repo was inferred from CWD, check if we're inside a specific clone.
+            // If so, default to repo scope so the command writes to the repo's .wsp.yaml.
+            if repo_inferred
+                && let Ok(meta) = workspace::load_metadata(&ws_dir)
+                && workspace::repo_from_cwd(&ws_dir, &meta, cwd).is_some()
+            {
+                return Ok(Scope::Repo);
+            }
+            Ok(Scope::Workspace)
+        }
+        Err(_) => Ok(Scope::Registry),
+    }
+}
+
+fn clone_dir_for(identity: &str, cwd: &Path) -> Result<std::path::PathBuf> {
+    let ws_dir = workspace::detect(cwd)?;
+    let meta = workspace::load_metadata(&ws_dir)?;
+    let dir_name = meta
+        .dir_name(identity)
+        .map_err(|_| anyhow::anyhow!("repo {:?} not in workspace metadata", identity))?;
+    Ok(ws_dir.join(dir_name))
+}
+
+// ---------------------------------------------------------------------------
+// Registry mutations
+// ---------------------------------------------------------------------------
+
+fn validate_command(cmd: &str) -> Result<()> {
+    if cmd.trim().is_empty() {
+        bail!("setup command cannot be empty or whitespace-only");
+    }
+    Ok(())
+}
+
+fn run_registry_add(paths: &Paths, identity: &str, cmd: &str) -> Result<Output> {
+    validate_command(cmd)?;
+    filelock::with_config(&paths.config_path, |cfg| {
+        let entry = cfg
+            .repos
+            .get_mut(identity)
+            .ok_or_else(|| anyhow::anyhow!("repo {:?} not in registry", identity))?;
+        let cmds = entry.setup_commands.get_or_insert_with(Vec::new);
+        if cmds.contains(&cmd.to_string()) {
+            bail!("command already exists: {:?}", cmd);
+        }
+        cmds.push(cmd.to_string());
+        Ok(())
+    })?;
+
+    Ok(Output::Mutation(MutationOutput::new(format!(
+        "registry: added setup command for {}",
+        identity
+    ))))
+}
+
+fn run_registry_rm(paths: &Paths, identity: &str, cmd: &str) -> Result<Output> {
+    filelock::with_config(&paths.config_path, |cfg| {
+        let entry = cfg
+            .repos
+            .get_mut(identity)
+            .ok_or_else(|| anyhow::anyhow!("repo {:?} not in registry", identity))?;
+        let cmds = entry.setup_commands.get_or_insert_with(Vec::new);
+        let before = cmds.len();
+        cmds.retain(|c| c != cmd);
+        if cmds.len() == before {
+            bail!("command not found: {:?}", cmd);
+        }
+        if cmds.is_empty() {
+            entry.setup_commands = None;
+        }
+        Ok(())
+    })?;
+
+    Ok(Output::Mutation(MutationOutput::new(format!(
+        "registry: removed setup command for {}",
+        identity
+    ))))
+}
+
+fn run_registry_clear(paths: &Paths, identity: &str) -> Result<Output> {
+    filelock::with_config(&paths.config_path, |cfg| {
+        let entry = cfg
+            .repos
+            .get_mut(identity)
+            .ok_or_else(|| anyhow::anyhow!("repo {:?} not in registry", identity))?;
+        entry.setup_commands = None;
+        Ok(())
+    })?;
+
+    Ok(Output::Mutation(MutationOutput::new(format!(
+        "registry: cleared setup commands for {}",
+        identity
+    ))))
+}
+
+// ---------------------------------------------------------------------------
+// Workspace mutations
+// ---------------------------------------------------------------------------
+
+fn run_workspace_add(_paths: &Paths, identity: &str, cmd: &str) -> Result<Output> {
+    validate_command(cmd)?;
+    let cwd = std::env::current_dir()?;
+    let ws_dir = workspace::detect(&cwd)?;
+
+    filelock::with_metadata(&ws_dir, |meta| {
+        if !meta.repos.contains_key(identity) {
+            bail!("repo {:?} not in this workspace", identity);
+        }
+        let cmds = meta.setup_commands.entry(identity.to_string()).or_default();
+        if cmds.contains(&cmd.to_string()) {
+            bail!("command already exists: {:?}", cmd);
+        }
+        cmds.push(cmd.to_string());
+        Ok(())
+    })?;
+
+    Ok(Output::Mutation(MutationOutput::new(format!(
+        "workspace: added setup command for {}",
+        identity
+    ))))
+}
+
+fn run_workspace_rm(_paths: &Paths, identity: &str, cmd: &str) -> Result<Output> {
+    let cwd = std::env::current_dir()?;
+    let ws_dir = workspace::detect(&cwd)?;
+
+    filelock::with_metadata(&ws_dir, |meta| {
+        let cmds = meta
+            .setup_commands
+            .get_mut(identity)
+            .ok_or_else(|| anyhow::anyhow!("no workspace setup commands for {:?}", identity))?;
+        let before = cmds.len();
+        cmds.retain(|c| c != cmd);
+        if cmds.len() == before {
+            bail!("command not found: {:?}", cmd);
+        }
+        if cmds.is_empty() {
+            meta.setup_commands.remove(identity);
+        }
+        Ok(())
+    })?;
+
+    Ok(Output::Mutation(MutationOutput::new(format!(
+        "workspace: removed setup command for {}",
+        identity
+    ))))
+}
+
+fn run_workspace_clear(_paths: &Paths, identity: &str) -> Result<Output> {
+    let cwd = std::env::current_dir()?;
+    let ws_dir = workspace::detect(&cwd)?;
+
+    filelock::with_metadata(&ws_dir, |meta| {
+        meta.setup_commands.remove(identity);
+        Ok(())
+    })?;
+
+    Ok(Output::Mutation(MutationOutput::new(format!(
+        "workspace: cleared setup commands for {}",
+        identity
+    ))))
+}
+
+// ---------------------------------------------------------------------------
+// Repo (.wsp.yaml) mutations
+// ---------------------------------------------------------------------------
+
+fn run_repo_add(identity: &str, cmd: &str, cwd: &Path) -> Result<Output> {
+    validate_command(cmd)?;
+    let clone_dir = clone_dir_for(identity, cwd)?;
+    let wsp_yaml = clone_dir.join(".wsp.yaml");
+
+    filelock::with_repo_wsp_yaml(&wsp_yaml, |commands| {
+        if commands.contains(&cmd.to_string()) {
+            bail!("command already exists: {:?}", cmd);
+        }
+        commands.push(cmd.to_string());
+        Ok(())
+    })?;
+    wsp_core::template::ensure_gitignore(&clone_dir)?;
+
+    Ok(Output::Mutation(MutationOutput::new(format!(
+        "repo: added setup command for {}",
+        identity
+    ))))
+}
+
+fn run_repo_rm(identity: &str, cmd: &str, cwd: &Path) -> Result<Output> {
+    let clone_dir = clone_dir_for(identity, cwd)?;
+    let wsp_yaml = clone_dir.join(".wsp.yaml");
+
+    filelock::with_repo_wsp_yaml(&wsp_yaml, |commands| {
+        if commands.is_empty() {
+            bail!("no repo setup commands for {:?}", identity);
+        }
+        let before = commands.len();
+        commands.retain(|c| c != cmd);
+        if commands.len() == before {
+            bail!("command not found: {:?}", cmd);
+        }
+        Ok(())
+    })?;
+
+    Ok(Output::Mutation(MutationOutput::new(format!(
+        "repo: removed setup command for {}",
+        identity
+    ))))
+}
+
+fn run_repo_clear(identity: &str, cwd: &Path) -> Result<Output> {
+    let clone_dir = clone_dir_for(identity, cwd)?;
+    let wsp_yaml = clone_dir.join(".wsp.yaml");
+
+    filelock::with_repo_wsp_yaml(&wsp_yaml, |commands| {
+        commands.clear();
+        Ok(())
+    })?;
+
+    Ok(Output::Mutation(MutationOutput::new(format!(
+        "repo: cleared setup commands for {}",
+        identity
+    ))))
+}

--- a/crates/wsp/src/cli/status.rs
+++ b/crates/wsp/src/cli/status.rs
@@ -62,6 +62,7 @@ mod tests {
             created_from: None,
             dirs,
             config: None,
+            setup_commands: std::collections::BTreeMap::new(),
         }
     }
 

--- a/crates/wsp/src/cli/template.rs
+++ b/crates/wsp/src/cli/template.rs
@@ -35,6 +35,7 @@ pub fn cmd() -> Command {
         .subcommand(repo_cmd())
         .subcommand(config_cmd())
         .subcommand(agent_md_cmd())
+        .subcommand(setup_commands_cmd())
 }
 
 pub fn dispatch(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
@@ -49,6 +50,7 @@ pub fn dispatch(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
         Some(("repo", m)) => dispatch_repo(m, paths),
         Some(("config", m)) => dispatch_config(m, paths),
         Some(("agent-md", m)) => dispatch_agent_md(m, paths),
+        Some(("setup-commands", m)) => dispatch_setup_commands(m, paths),
         None => run_list(matches, paths),
         _ => unreachable!(),
     }
@@ -307,7 +309,10 @@ fn run_new(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
             wsp_version: None,
             repos: repo_urls
                 .into_iter()
-                .map(|url| tmpl::TemplateRepo { url })
+                .map(|url| tmpl::TemplateRepo {
+                    url,
+                    setup_commands: None,
+                })
                 .collect(),
             config: None,
             agent_md: None,
@@ -748,6 +753,246 @@ fn run_agent_md_unset(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
         "template {:?}: agent-md unset",
         name
     ))))
+}
+
+// ---------------------------------------------------------------------------
+// template setup-commands ls/add/rm/clear
+// ---------------------------------------------------------------------------
+
+fn setup_commands_cmd() -> Command {
+    Command::new("setup-commands")
+        .about("Manage per-repo setup commands in a template")
+        .long_about(
+            "Manage per-repo setup commands in a template.\n\n\
+             The <tmpl> argument is the template name; <repo> must match a repo URL or \
+             identity already in that template.",
+        )
+        .subcommand_required(true)
+        .arg_required_else_help(true)
+        .subcommand(
+            Command::new("ls")
+                .visible_alias("list")
+                .about("List setup commands for a repo in a template [read-only]")
+                .arg(
+                    Arg::new("name")
+                        .required(true)
+                        .help("Template name")
+                        .add(ArgValueCandidates::new(completers::complete_templates)),
+                )
+                .arg(
+                    Arg::new("repo")
+                        .required(true)
+                        .help("Repo URL or identity within the template")
+                        .add(ArgValueCandidates::new(completers::complete_template_repos)),
+                ),
+        )
+        .subcommand(
+            Command::new("add")
+                .about("Add a setup command for a repo in a template")
+                .arg(
+                    Arg::new("name")
+                        .required(true)
+                        .help("Template name")
+                        .add(ArgValueCandidates::new(completers::complete_templates)),
+                )
+                .arg(
+                    Arg::new("repo")
+                        .required(true)
+                        .help("Repo URL or identity within the template")
+                        .add(ArgValueCandidates::new(completers::complete_template_repos)),
+                )
+                .arg(
+                    Arg::new("cmd")
+                        .required(true)
+                        .num_args(1..)
+                        .last(true)
+                        .allow_hyphen_values(true)
+                        .help("Shell command to add; use -- to pass multi-word commands"),
+                ),
+        )
+        .subcommand(
+            Command::new("rm")
+                .visible_alias("remove")
+                .about("Remove a setup command for a repo in a template")
+                .arg(
+                    Arg::new("name")
+                        .required(true)
+                        .help("Template name")
+                        .add(ArgValueCandidates::new(completers::complete_templates)),
+                )
+                .arg(
+                    Arg::new("repo")
+                        .required(true)
+                        .help("Repo URL or identity within the template")
+                        .add(ArgValueCandidates::new(completers::complete_template_repos)),
+                )
+                .arg(
+                    Arg::new("cmd")
+                        .required(true)
+                        .num_args(1..)
+                        .last(true)
+                        .allow_hyphen_values(true)
+                        .help("Shell command to remove; use -- to pass multi-word commands")
+                        .add(ArgValueCandidates::new(
+                            completers::complete_template_repo_setup_commands,
+                        )),
+                ),
+        )
+        .subcommand(
+            Command::new("clear")
+                .about("Clear all setup commands for a repo in a template")
+                .arg(
+                    Arg::new("name")
+                        .required(true)
+                        .help("Template name")
+                        .add(ArgValueCandidates::new(completers::complete_templates)),
+                )
+                .arg(
+                    Arg::new("repo")
+                        .required(true)
+                        .help("Repo URL or identity within the template")
+                        .add(ArgValueCandidates::new(completers::complete_template_repos)),
+                ),
+        )
+}
+
+fn dispatch_setup_commands(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
+    match matches.subcommand() {
+        Some(("ls", m)) => run_setup_commands_ls(m, paths),
+        Some(("add", m)) => run_setup_commands_add_cmd(m, paths),
+        Some(("rm", m)) => run_setup_commands_rm_cmd(m, paths),
+        Some(("clear", m)) => run_setup_commands_clear_cmd(m, paths),
+        _ => unreachable!(),
+    }
+}
+
+fn run_setup_commands_ls(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
+    let name = matches.get_one::<String>("name").unwrap();
+    let repo_arg = matches.get_one::<String>("repo").unwrap();
+    let template = tmpl::load(&paths.templates_dir, name)?;
+    let repo = find_template_repo(&template, repo_arg)?;
+    let cmds = repo.setup_commands.as_deref().unwrap_or(&[]);
+    let commands = cmds
+        .iter()
+        .map(|c| wsp_core::output::SetupCommandEntry {
+            command: c.clone(),
+            source: "template".to_string(),
+        })
+        .collect();
+    let identity = giturl::parse(&repo.url)
+        .map(|p| p.identity())
+        .unwrap_or_else(|_| repo.url.clone());
+    Ok(Output::SetupCommands(
+        wsp_core::output::SetupCommandsOutput {
+            repo: identity,
+            commands,
+        },
+    ))
+}
+
+fn run_setup_commands_add_cmd(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
+    let name = matches.get_one::<String>("name").unwrap();
+    let repo_arg = matches.get_one::<String>("repo").unwrap();
+    let cmd = matches
+        .get_many::<String>("cmd")
+        .unwrap()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join(" ");
+    if cmd.trim().is_empty() {
+        anyhow::bail!("setup command cannot be empty or whitespace-only");
+    }
+    filelock::with_template(&paths.templates_dir, name, |tmpl| {
+        let repo = find_template_repo_mut(tmpl, repo_arg)?;
+        let cmds = repo.setup_commands.get_or_insert_with(Vec::new);
+        if cmds.contains(&cmd) {
+            anyhow::bail!("command already exists: {:?}", cmd);
+        }
+        cmds.push(cmd.clone());
+        Ok(())
+    })?;
+    Ok(Output::Mutation(MutationOutput::new(format!(
+        "template {:?}: added setup command for {}",
+        name, repo_arg
+    ))))
+}
+
+fn run_setup_commands_rm_cmd(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
+    let name = matches.get_one::<String>("name").unwrap();
+    let repo_arg = matches.get_one::<String>("repo").unwrap();
+    let cmd = matches
+        .get_many::<String>("cmd")
+        .unwrap()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join(" ");
+    filelock::with_template(&paths.templates_dir, name, |tmpl| {
+        let repo = find_template_repo_mut(tmpl, repo_arg)?;
+        let cmds = repo.setup_commands.get_or_insert_with(Vec::new);
+        let before = cmds.len();
+        cmds.retain(|c| *c != cmd);
+        if cmds.len() == before {
+            anyhow::bail!("command not found: {:?}", cmd);
+        }
+        if cmds.is_empty() {
+            repo.setup_commands = None;
+        }
+        Ok(())
+    })?;
+    Ok(Output::Mutation(MutationOutput::new(format!(
+        "template {:?}: removed setup command for {}",
+        name, repo_arg
+    ))))
+}
+
+fn run_setup_commands_clear_cmd(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
+    let name = matches.get_one::<String>("name").unwrap();
+    let repo_arg = matches.get_one::<String>("repo").unwrap();
+    filelock::with_template(&paths.templates_dir, name, |tmpl| {
+        let repo = find_template_repo_mut(tmpl, repo_arg)?;
+        repo.setup_commands = None;
+        Ok(())
+    })?;
+    Ok(Output::Mutation(MutationOutput::new(format!(
+        "template {:?}: cleared setup commands for {}",
+        name, repo_arg
+    ))))
+}
+
+/// Find a TemplateRepo by URL or identity (immutable).
+fn find_template_repo<'a>(
+    template: &'a tmpl::Template,
+    repo_arg: &str,
+) -> Result<&'a tmpl::TemplateRepo> {
+    template
+        .repos
+        .iter()
+        .find(|r| {
+            r.url == repo_arg
+                || giturl::parse(&r.url)
+                    .map(|p| p.identity())
+                    .unwrap_or_default()
+                    == repo_arg
+        })
+        .ok_or_else(|| anyhow::anyhow!("repo {:?} not found in template", repo_arg))
+}
+
+/// Find a TemplateRepo by URL or identity (mutable).
+fn find_template_repo_mut<'a>(
+    template: &'a mut tmpl::Template,
+    repo_arg: &str,
+) -> Result<&'a mut tmpl::TemplateRepo> {
+    template
+        .repos
+        .iter_mut()
+        .find(|r| {
+            r.url == repo_arg
+                || giturl::parse(&r.url)
+                    .map(|p| p.identity())
+                    .unwrap_or_default()
+                    == repo_arg
+        })
+        .ok_or_else(|| anyhow::anyhow!("repo {:?} not found in template", repo_arg))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/wsp/src/hints.rs
+++ b/crates/wsp/src/hints.rs
@@ -7,7 +7,7 @@
 use wsp_core::config::Config;
 
 /// All known `advice.*` keys. Used to validate user input in `wsp config set advice.<key>`.
-pub const KNOWN_ADVICE_KEYS: &[&str] = &["branchPrefix", "setupCommands"];
+pub const KNOWN_ADVICE_KEYS: &[&str] = &["branchPrefix", "setupCommands", "registrySetupCommands"];
 
 /// Evaluate contextual hints for the completed command.
 ///
@@ -35,6 +35,26 @@ pub fn evaluate(command: &str, cfg: &Config) -> Vec<&'static str> {
             "hint: repos can declare post-clone setup commands via .wsp.yaml.\n  \
              Run `wsp init` in a repo root to configure them. See `wsp help wsp.yaml`.\n  \
              (suppress: wsp config set advice.setupCommands false)",
+        );
+    }
+
+    // registrySetupCommands: after `wsp repo setup-commands add` to registry scope,
+    // warn when the registry has setup commands (they affect all workspaces, past and future).
+    // The command path has a scope suffix when an explicit flag was used; skip the hint
+    // for --workspace and --repo to avoid false positives when the user already scoped narrowly.
+    if matches!(
+        command,
+        "repo/setup-commands/add" | "repo/setup-commands/add/registry"
+    ) && cfg
+        .repos
+        .values()
+        .any(|e| e.setup_commands.as_ref().is_some_and(|v| !v.is_empty()))
+        && hint_enabled(cfg, "registrySetupCommands")
+    {
+        hints.push(
+            "hint: registry setup commands run in every workspace that contains this repo.\n  \
+             Use --workspace to limit commands to the current workspace only.\n  \
+             (suppress: wsp config set advice.registrySetupCommands false)",
         );
     }
 
@@ -138,5 +158,112 @@ mod tests {
         let cfg = Config::default();
         let hints = evaluate("ls", &cfg);
         assert!(hints.is_empty(), "ls should produce no hints");
+    }
+
+    // -----------------------------------------------------------------------
+    // registrySetupCommands hint
+    // -----------------------------------------------------------------------
+
+    use wsp_core::config::RepoEntry;
+
+    fn cfg_with_registry_setup(identity: &str) -> Config {
+        let mut repos = BTreeMap::new();
+        repos.insert(
+            identity.to_string(),
+            RepoEntry {
+                url: format!("git@test.local:user/{identity}.git"),
+                added: chrono::Utc::now(),
+                setup_commands: Some(vec!["make deps".into()]),
+            },
+        );
+        Config {
+            repos,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn registry_setup_hint_fires_after_inferred_add_when_registry_has_commands() {
+        let cfg = cfg_with_registry_setup("myrepo");
+        let hints = evaluate("repo/setup-commands/add", &cfg);
+        assert!(
+            hints.iter().any(|h| h.contains("registrySetupCommands")),
+            "expected registrySetupCommands hint for inferred add, got: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn registry_setup_hint_fires_after_explicit_registry_add() {
+        let cfg = cfg_with_registry_setup("myrepo");
+        let hints = evaluate("repo/setup-commands/add/registry", &cfg);
+        assert!(
+            hints.iter().any(|h| h.contains("registrySetupCommands")),
+            "expected registrySetupCommands hint for explicit --registry add, got: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn registry_setup_hint_does_not_fire_for_workspace_or_repo_scope() {
+        let cfg = cfg_with_registry_setup("myrepo");
+        for cmd in &[
+            "repo/setup-commands/add/workspace",
+            "repo/setup-commands/add/repo",
+        ] {
+            let hints = evaluate(cmd, &cfg);
+            assert!(
+                !hints.iter().any(|h| h.contains("registrySetupCommands")),
+                "registrySetupCommands hint should not fire for {cmd:?}, got: {hints:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn registry_setup_hint_does_not_fire_on_other_commands() {
+        let cfg = cfg_with_registry_setup("myrepo");
+        for cmd in &["repo/setup-commands/rm", "repo/setup-commands/ls", "new"] {
+            let hints = evaluate(cmd, &cfg);
+            assert!(
+                !hints.iter().any(|h| h.contains("registrySetupCommands")),
+                "registrySetupCommands hint should not fire for {cmd:?}, got: {hints:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn registry_setup_hint_does_not_fire_when_registry_empty() {
+        // Registry has the repo entry but no setup_commands.
+        let mut repos = BTreeMap::new();
+        repos.insert(
+            "myrepo".to_string(),
+            RepoEntry {
+                url: "git@test.local:user/myrepo.git".into(),
+                added: chrono::Utc::now(),
+                setup_commands: None,
+            },
+        );
+        let cfg = Config {
+            repos,
+            ..Default::default()
+        };
+        let hints = evaluate("repo/setup-commands/add", &cfg);
+        assert!(
+            !hints.iter().any(|h| h.contains("registrySetupCommands")),
+            "hint should not fire when registry has no setup commands"
+        );
+    }
+
+    #[test]
+    fn registry_setup_hint_suppressed_via_advice() {
+        let mut cfg = cfg_with_registry_setup("myrepo");
+        cfg.advice = Some({
+            let mut m = BTreeMap::new();
+            m.insert("registrySetupCommands".into(), false);
+            m
+        });
+        let hints = evaluate("repo/setup-commands/add", &cfg);
+        assert!(
+            !hints.iter().any(|h| h.contains("registrySetupCommands")),
+            "registrySetupCommands hint should be suppressed by advice key"
+        );
     }
 }

--- a/crates/wsp/src/main.rs
+++ b/crates/wsp/src/main.rs
@@ -43,10 +43,31 @@ fn main() {
         }
     };
 
-    // Resolve effective command path before consuming matches
+    // Resolve effective command path before consuming matches.
+    // Goes up to three levels for nested subcommands (e.g. repo/setup-commands/add).
+    // For `setup-commands add`, explicit scope flags are encoded as a suffix
+    // (e.g. /registry, /workspace, /repo) so hints can avoid false positives.
     let command = match matches.subcommand() {
-        Some(("repo", sub)) => match sub.subcommand_name() {
-            Some(name) => format!("repo/{}", name),
+        Some(("repo", sub)) => match sub.subcommand() {
+            Some((name, sub2)) => match sub2.subcommand() {
+                Some((leaf, leaf_m)) => {
+                    let scope_tag = if name == "setup-commands" && leaf == "add" {
+                        if leaf_m.get_flag("registry") {
+                            "/registry"
+                        } else if leaf_m.get_flag("workspace") {
+                            "/workspace"
+                        } else if leaf_m.get_flag("repo-scope") {
+                            "/repo"
+                        } else {
+                            ""
+                        }
+                    } else {
+                        ""
+                    };
+                    format!("repo/{}/{}{}", name, leaf, scope_tag)
+                }
+                None => format!("repo/{}", name),
+            },
             None => "repo".to_string(),
         },
         Some((name, _)) => name.to_string(),

--- a/crates/wsp/src/output.rs
+++ b/crates/wsp/src/output.rs
@@ -108,6 +108,7 @@ pub fn render(output: Output, json: bool) -> Result<()> {
             Output::RecoverShow(v) => print_json(&v),
             Output::Path(v) => print_json(&v),
             Output::Doctor(v) => print_json(&v),
+            Output::SetupCommands(v) => print_json(&v),
         };
     }
     match output {
@@ -132,6 +133,7 @@ pub fn render(output: Output, json: bool) -> Result<()> {
         Output::RecoverShow(v) => render_recover_show_text(v),
         Output::Path(v) => render_path_text(v),
         Output::Doctor(_) => Ok(()), // text output handled inline during run
+        Output::SetupCommands(v) => render_setup_commands_text(v),
     }
 }
 
@@ -489,6 +491,24 @@ fn render_mutation_text(v: MutationOutput) -> Result<()> {
     }
     if let Some(hint) = &v.hint {
         println!("  {}", hint);
+    }
+    Ok(())
+}
+
+fn render_setup_commands_text(v: SetupCommandsOutput) -> Result<()> {
+    if v.commands.is_empty() {
+        println!("No setup commands for {}.", v.repo);
+        return Ok(());
+    }
+    let max_label = v.commands.iter().map(|e| e.source.len()).max().unwrap_or(0);
+    println!("Setup commands for {}:", v.repo);
+    for entry in &v.commands {
+        println!(
+            "  [{:<width$}]  {}",
+            entry.source,
+            entry.command,
+            width = max_label
+        );
     }
     Ok(())
 }

--- a/crates/wsp/tests/gc_warning.rs
+++ b/crates/wsp/tests/gc_warning.rs
@@ -37,6 +37,7 @@ fn setup_gcd_workspace(paths: &Paths, name: &str) -> std::path::PathBuf {
         created_from: None,
         dirs: std::collections::BTreeMap::new(),
         config: None,
+        setup_commands: std::collections::BTreeMap::new(),
     };
     workspace::save_metadata(&ws_dir, &meta).unwrap();
 

--- a/skills/wsp-manage/SKILL.md
+++ b/skills/wsp-manage/SKILL.md
@@ -54,7 +54,7 @@ wsp repo add [<repos>]... [-t <template>] [-b] [--no-discover] # Add repos to cu
 wsp repo rm <repos>... [-f]                     # Remove repo(s) from the current workspace (alias: remove)
 wsp repo fetch [--all] [--prune]                # Fetch updates for workspace repos
 wsp repo ls                                     # List repos in the current workspace [read-only] (alias: list)
-wsp repo setup [<repos>]... [--force]           # Run setup commands for repos in the current workspace
+wsp repo setup [<repos>]... [--force] [--all]   # Run setup commands for repos in the current workspace
 wsp repo setup-commands                         # Manage per-repo setup commands
 ```
 

--- a/skills/wsp-manage/SKILL.md
+++ b/skills/wsp-manage/SKILL.md
@@ -54,7 +54,7 @@ wsp repo add [<repos>]... [-t <template>] [-b] [--no-discover] # Add repos to cu
 wsp repo rm <repos>... [-f]                     # Remove repo(s) from the current workspace (alias: remove)
 wsp repo fetch [--all] [--prune]                # Fetch updates for workspace repos
 wsp repo ls                                     # List repos in the current workspace [read-only] (alias: list)
-wsp repo setup [<repos>]... [--force] [--all]   # Run setup commands for repos in the current workspace
+wsp repo setup [<repos>]... [--all]             # Run setup commands for repos in the current workspace
 wsp repo setup-commands                         # Manage per-repo setup commands
 ```
 

--- a/skills/wsp-manage/SKILL.md
+++ b/skills/wsp-manage/SKILL.md
@@ -33,6 +33,7 @@ wsp template export <name> [--stdout]           # Export a template to a file or
 wsp template repo                               # Add or remove repos in a template
 wsp template config                             # Manage template config overrides
 wsp template agent-md                           # Manage template AGENTS.md content
+wsp template setup-commands                     # Manage per-repo setup commands in a template
 ```
 
 ### Workspaces
@@ -54,6 +55,7 @@ wsp repo rm <repos>... [-f]                     # Remove repo(s) from the curren
 wsp repo fetch [--all] [--prune]                # Fetch updates for workspace repos
 wsp repo ls                                     # List repos in the current workspace [read-only] (alias: list)
 wsp repo setup [<repos>]... [--force]           # Run setup commands for repos in the current workspace
+wsp repo setup-commands                         # Manage per-repo setup commands
 ```
 
 ### Config


### PR DESCRIPTION
## Summary

Adds full management of per-repo setup commands across four layers, with a direnv-style approval flow and smart scope defaults.

### Four-layer resolution

Commands are gathered from all layers and concatenated in order:

1. **Registry** — personal, per-repo commands in `~/.local/share/wsp/config.yaml`
2. **Template** — per-repo commands on a `TemplateRepo`
3. **Repo** — committed `setup_commands` in the repo's own `.wsp.yaml`
4. **Workspace** — per-repo overrides in workspace metadata

Resolution is additive (no dedup). Before prompting, exact duplicates are removed (first occurrence wins). Use `--all` to run every occurrence.

### Approval flow

Before running, wsp shows the merged command list and prompts once (like direnv). Approval is stored by SHA-256 hash of the command list — any change at any layer triggers a fresh prompt automatically.

### Management commands

```
wsp repo setup-commands ls    [<repo>]           # merged view with provenance labels
wsp repo setup-commands add   [<repo>] -- <cmd>  # add at a scope
wsp repo setup-commands rm    [<repo>] -- <cmd>  # remove from a scope
wsp repo setup-commands clear [<repo>]           # clear all (prompts y/N; --yes for scripts)
```

Scope flags: `--registry`, `--workspace`, `--repo` (writes to `.wsp.yaml`).

Smart default: when CWD is inside a repo clone with no explicit `<repo>` arg, defaults to **repo scope**. Falls back to workspace scope inside a workspace, registry scope outside.

`--` is required before multi-word commands, making `<repo>` before it unambiguous:

```
wsp repo setup-commands add -- just setup          # repo inferred from CWD
wsp repo setup-commands add myrepo -- npm install  # explicit repo
wsp repo setup-commands add --registry wsp -- npm install  # explicit scope + repo
```

### Template management

```
wsp template setup-commands ls/add/rm/clear <tmpl> <repo> [-- <cmd>]
```

### Also included

- `wsp repo setup` runs the approval + execution flow; uses dedup by default, `--all` bypasses it. `--force` removed (the hash model handles re-prompting automatically when commands change).
- `clear` prompts `[y/N]` before destroying data; non-TTY callers must pass `--yes` / `-y` (project-wide convention for destructive confirmation, documented in AGENTS.md)
- `registrySetupCommands` contextual hint warns after adding to registry scope (affects all workspaces); fires only for registry-scope adds, not `--workspace` or `--repo`
- Doctor **W15** validates unapproved setup commands; `--fix` invokes the interactive approval flow
- `wsp help wsp.yaml` documents the full workflow
- File locking (`with_repo_wsp_yaml`) for safe concurrent `.wsp.yaml` mutations
- Auto-creates `.wsp.yaml` and ensures `.wsp.yaml.lock` is gitignored when writing repo scope

Closes #36

## Test plan

- [ ] `wsp repo setup-commands ls` shows merged commands with provenance labels
- [ ] `add/rm/clear` with `--registry` / `--workspace` / `--repo` scope flags
- [ ] `add --registry <repo> -- <cmd>` works (explicit scope + positional repo)
- [ ] Smart scope: from inside a repo clone, `add -- cmd` writes to `.wsp.yaml`
- [ ] `wsp template setup-commands add/rm/clear/ls`
- [ ] Tab completion on `setup-commands rm` (completes existing commands)
- [ ] `clear` prompts y/N interactively; `--yes` skips prompt; non-TTY without `--yes` errors
- [ ] Approval prompt shows plain command list; re-prompts when commands change
- [ ] `wsp repo setup --all` runs duplicates; default deduplicates
- [ ] `registrySetupCommands` hint fires after `--registry` add but not `--repo` or `--workspace`
- [ ] `wsp doctor --fix` W15 check
- [ ] `wsp help wsp.yaml` renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)