### PR TITLE
fix(hints): add blank line before contextual hints

### DIFF
--- a/crates/wsp/src/main.rs
+++ b/crates/wsp/src/main.rs
@@ -66,7 +66,11 @@ fn main() {
             wsp_core::gc::maybe_run(&paths, cfg.gc_retention_days);
             // Contextual hints (git-style advice.*) -- only on success
             if !json && code == 0 {
-                for hint in hints::evaluate(&command, &cfg) {
+                let hints = hints::evaluate(&command, &cfg);
+                if !hints.is_empty() {
+                    eprintln!();
+                }
+                for hint in hints {
                     eprintln!("{}", hint);
                 }
             }


### PR DESCRIPTION
## Summary

- Add a blank line before the first contextual hint so hints are visually separated from command output

**Before:**
```
Adding 2 repos to workspace...
Done.
hint: repos can declare post-clone setup commands via .wsp.yaml.
```

**After:**
```
Adding 2 repos to workspace...
Done.

hint: repos can declare post-clone setup commands via .wsp.yaml.
```

## Test plan

- [x] `just check` passes (fmt + clippy)
- [x] Run `wsp repo add` or `wsp new` and verify blank line appears before hints
- [x] Verify no blank line is printed when hints are suppressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)