### PR TITLE
fix(completion): remove leading comment that breaks eval $(...) without quotes

### DIFF
--- a/crates/wsp/src/cli/completion.rs
+++ b/crates/wsp/src/cli/completion.rs
@@ -135,11 +135,14 @@ fn write_posix(
     let bin_esc = posix_escape(bin_str);
     let root_esc = posix_escape(wsp_root);
 
+    // IMPORTANT: do NOT add a leading comment here.
+    // `eval $(wsp completion zsh)` (without quotes) is a common mistake; a `#`
+    // at the start triggers word-splitting re-evaluation of anything on that
+    // line (e.g. the embedded `$(wsp completion zsh)` in the comment text),
+    // causing an infinite loop or confusing errors. Start with executable code.
     write!(
         w,
-        "# wsp shell integration \u{2014} source with: eval \"$(wsp completion {shell})\"\n\
-         \n\
-         wsp() {{\n\
+        "wsp() {{\n\
          \x20 local wsp_bin='{bin_esc}'\n\
          \x20 local wsp_root='{root_esc}'\n\
          \n\
@@ -674,7 +677,8 @@ mod tests {
     }
 
     #[test]
-    fn test_posix_shell_name_in_header() {
+    fn test_posix_shell_name_in_source_line() {
+        // Shell name must appear in the COMPLETE=<shell> source line.
         let bash = output(|w| {
             write_posix(
                 w,
@@ -684,7 +688,10 @@ mod tests {
                 ShellHookOpts::default(),
             )
         });
-        assert!(bash.contains("eval \"$(wsp completion bash)\""));
+        assert!(
+            bash.contains("COMPLETE=bash"),
+            "bash source line must contain shell name"
+        );
 
         let zsh = output(|w| {
             write_posix(
@@ -695,7 +702,33 @@ mod tests {
                 ShellHookOpts::default(),
             )
         });
-        assert!(zsh.contains("eval \"$(wsp completion zsh)\""));
+        assert!(
+            zsh.contains("COMPLETE=zsh"),
+            "zsh source line must contain shell name"
+        );
+    }
+
+    // Regression test for https://github.com/jganoff/wsp/issues/51:
+    // `eval $(wsp completion zsh)` (without quotes) word-splits the output and
+    // re-evaluates tokens; a leading `#` comment containing `$(wsp ...)` causes
+    // an infinite loop. The script must start with executable code, never a comment.
+    #[test]
+    fn test_posix_output_does_not_start_with_comment() {
+        for shell in ["zsh", "bash"] {
+            let out = output(|w| {
+                write_posix(
+                    w,
+                    "/usr/bin/wsp",
+                    "/home/user/dev",
+                    shell,
+                    ShellHookOpts::default(),
+                )
+            });
+            assert!(
+                !out.trim_start().starts_with('#'),
+                "{shell} completion output must not start with a '#' comment (breaks eval $(...) without quotes)"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Removes the `# wsp shell integration — ...` comment from the top of the generated POSIX completion script
- Adds a Rust code comment explaining the invariant so it isn't re-introduced
- Adds regression test `test_posix_output_does_not_start_with_comment` for both zsh and bash
- Updates stale `test_posix_shell_name_in_header` → `test_posix_shell_name_in_source_line`

Fixes #51

## Why the comment was dangerous

`eval $(wsp completion zsh)` (unquoted) word-splits the captured output before passing it to `eval`. The old leading comment:

```
# wsp shell integration — source with: eval "$(wsp completion zsh)"
```

contained a `$(wsp completion zsh)` token which, after word-splitting, was re-evaluated as a command substitution — causing an infinite loop.

## Unquoted `eval $(...)` still cannot work

Removing the comment fixes the infinite loop, but `eval $(wsp completion zsh)` (unquoted) remains broken for a different reason: word-splitting also triggers glob expansion, so `*)` in the `case` statement is split into `*` (expanded to filenames) and `)`, producing a parse error.

**The only supported form is the quoted one:**

```zsh
eval "$(wsp completion zsh)"
```

This is already what `.long_about()` documents. The unquoted form is not something we can make work for a full shell script.

## Test plan

- [x] `just test` passes (320 tests)
- [x] `eval "$(wsp completion zsh)"` (quoted, canonical form) works

🤖 Generated with [Claude Code](https://claude.com/claude-code)