### PR TITLE
fix(setup): correct post-setup guide to use wsp registry add

### DIFF
--- a/crates/wsp/src/cli/add.rs
+++ b/crates/wsp/src/cli/add.rs
@@ -67,7 +67,24 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
     let branch_tracks_remote = matches.get_flag("branch");
 
     let cwd = std::env::current_dir()?;
-    let ws_dir = workspace::detect(&cwd)?;
+    let ws_dir = workspace::detect(&cwd).map_err(|e| {
+        // If the user passed a URL, they likely meant `wsp registry add`.
+        let looks_like_url = repo_args.iter().any(|a| {
+            a.starts_with("http")
+                || a.starts_with("git@")
+                || a.starts_with("ssh://")
+                || a.contains("github.com")
+                || a.ends_with(".git")
+        });
+        if looks_like_url {
+            anyhow::anyhow!(
+                "{}\n\nTo register a repo globally, use:\n  wsp registry add <url>",
+                e
+            )
+        } else {
+            e
+        }
+    })?;
     gc::check_workspace(&ws_dir, /* read_only */ false)?;
 
     let mut cfg = config::Config::load_from(&paths.config_path)

--- a/crates/wsp/src/cli/setup.rs
+++ b/crates/wsp/src/cli/setup.rs
@@ -250,18 +250,23 @@ fn print_next_steps() {
     );
     eprintln!();
     eprintln!("  1. Register repos you work with:");
-    eprintln!("     wsp repo add https://github.com/jganoff/wsp.git");
+    eprintln!("     wsp registry add https://github.com/jganoff/wsp.git");
     eprintln!();
     eprintln!("  2. Create your first workspace:");
     eprintln!("     wsp new my-feature wsp");
     eprintln!();
-    eprintln!("  3. Work normally, then clean up:");
+    eprintln!("  3. Add more repos to the workspace (optional):");
+    eprintln!("     wsp repo add <name>");
+    eprintln!();
+    eprintln!("  4. Work normally, then clean up:");
     eprintln!("     wsp st                        # status across repos");
     eprintln!("     wsp diff                      # review changes");
     eprintln!("     git push                      # push for PR");
     eprintln!("     wsp rm my-feature             # clean up after merge");
     eprintln!();
-    eprintln!("  Tip: bulk-import from GitHub with `wsp repo add --from github.com/<org> --all`");
+    eprintln!(
+        "  Tip: bulk-import from GitHub with `wsp registry add --from github.com/<org> --all`"
+    );
 }
 
 /// Non-interactive mode: print what needs to be done without prompting.
@@ -293,7 +298,7 @@ fn print_non_interactive_guide(paths: &Paths) -> Result<()> {
         }
     }
 
-    eprintln!("  wsp repo add https://github.com/jganoff/wsp.git");
+    eprintln!("  wsp registry add https://github.com/jganoff/wsp.git");
     eprintln!("  wsp new my-feature");
 
     Ok(())


### PR DESCRIPTION
## Summary

- `wsp repo add` is workspace-scoped and fails with "not in a workspace" when run after `wsp setup` (before any workspace exists)
- Post-setup "What's next" guide now uses `wsp registry add` for global registration, with `wsp repo add <name>` in a separate step for workspace use
- Bulk-import tip corrected from `wsp repo add --from` to `wsp registry add --from`
- `wsp repo add` now detects URL-shaped args (http, git@, ssh://, .git suffix, github.com) when run outside a workspace and augments the error: "To register a repo globally, use: wsp registry add <url>"

Closes #54

## Test plan

- [ ] Run `wsp setup` on a fresh install, follow "What's next" — steps should succeed in order
- [ ] Run `wsp repo add https://github.com/foo/bar.git` outside a workspace — error should include the registry hint
- [ ] Run `wsp repo add git@github.com:foo/bar.git` outside a workspace — SSH URLs should also trigger the hint
- [ ] Run `wsp repo add myrepo` outside a workspace — no hint (not a URL)
- [ ] `just ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)