### PR TITLE
feat: add Windows platform support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- *(windows)* Add Windows platform support — `wsp` now builds and passes its full test suite on Windows. Where Windows cannot create symlinks (Developer Mode disabled and the process not elevated), `wsp` degrades gracefully instead of failing: the `CLAUDE.md` link is skipped, `wsp doctor` reports how to resolve it, and `wsp gc` copies the rest of the workspace
+
 ### Bug Fixes
 
 - *(workspace)* Fix `wsp new` and `wsp repo add` failing when a repo's default branch is not `main` (e.g. `master`, `develop`, `release/2.x`)

--- a/Justfile
+++ b/Justfile
@@ -1,3 +1,5 @@
+set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
+
 default: check
 
 # one-time setup after cloning: installs the pre-commit hook
@@ -64,6 +66,7 @@ release-execute level:
     cargo release {{level}} --execute
 
 # install git pre-commit hook
+[unix]
 install-hooks:
     #!/usr/bin/env sh
     hooks_dir="$(git rev-parse --git-common-dir)/hooks"
@@ -74,3 +77,10 @@ install-hooks:
     HOOK
     chmod +x "$hooks_dir/pre-commit"
     echo "pre-commit hook installed to $hooks_dir/pre-commit"
+
+[windows]
+install-hooks:
+    $d = (git rev-parse --git-common-dir).Trim() + "/hooks"
+    New-Item -Force -ItemType Directory -Path $d | Out-Null
+    Set-Content -Path "$d/pre-commit" -Value "#!/usr/bin/env sh`njust check"
+    Write-Host "pre-commit hook installed to $d"

--- a/Justfile
+++ b/Justfile
@@ -80,7 +80,10 @@ install-hooks:
 
 [windows]
 install-hooks:
-    $d = (git rev-parse --git-common-dir).Trim() + "/hooks"
-    New-Item -Force -ItemType Directory -Path $d | Out-Null
-    Set-Content -Path "$d/pre-commit" -Value "#!/usr/bin/env sh`njust check"
-    Write-Host "pre-commit hook installed to $d"
+    $gitDir = (Resolve-Path ((git rev-parse --git-common-dir).Trim())).Path
+    $hooks = Join-Path $gitDir "hooks"
+    New-Item -Force -ItemType Directory -Path $hooks | Out-Null
+    # WriteAllText writes UTF-8 without a BOM; a BOM or CRLF would break the
+    # `#!/usr/bin/env sh` shebang when Git for Windows runs the hook.
+    [System.IO.File]::WriteAllText((Join-Path $hooks "pre-commit"), "#!/usr/bin/env sh`njust check`n")
+    Write-Host "pre-commit hook installed to $hooks"

--- a/crates/wsp-core/src/agentmd.rs
+++ b/crates/wsp-core/src/agentmd.rs
@@ -235,18 +235,28 @@ fn ensure_symlink(ws_dir: &Path) -> Result<()> {
                     return Ok(());
                 }
                 fs::remove_file(&link_path).context("removing stale CLAUDE.md symlink")?;
-                symlink_file("AGENTS.md", &link_path).context("creating CLAUDE.md symlink")?;
+                create_symlink_or_skip("AGENTS.md", &link_path)?;
             }
             // Regular file — leave it alone
         }
         Err(_) => {
             // Path doesn't exist. (Broken symlinks are handled above since
             // symlink_metadata succeeds for broken symlinks and reports is_symlink=true.)
-            symlink_file("AGENTS.md", &link_path).context("creating CLAUDE.md symlink")?;
+            create_symlink_or_skip("AGENTS.md", &link_path)?;
         }
     }
 
     Ok(())
+}
+
+fn create_symlink_or_skip(original: &str, link: &Path) -> Result<()> {
+    match symlink_file(original, link) {
+        Ok(()) => Ok(()),
+        // ERROR_PRIVILEGE_NOT_HELD (1314): Developer Mode not enabled on Windows; skip.
+        #[cfg(windows)]
+        Err(e) if e.raw_os_error() == Some(1314) => Ok(()),
+        Err(e) => Err(e).context("creating CLAUDE.md symlink"),
+    }
 }
 
 #[cfg(unix)]
@@ -286,6 +296,13 @@ mod tests {
     use chrono::Utc;
 
     use crate::workspace::{Metadata, WorkspaceRepoRef};
+
+    fn symlinks_available(dir: &Path) -> bool {
+        let probe = dir.join(".symlink_probe");
+        let ok = symlink_file(".", &probe).is_ok() && fs::symlink_metadata(&probe).is_ok();
+        let _ = fs::remove_file(&probe);
+        ok
+    }
 
     fn make_metadata(name: &str, branch: &str, repos: &[(&str, Option<&str>)]) -> Metadata {
         let mut map = BTreeMap::new();
@@ -557,11 +574,13 @@ mod tests {
         assert!(content.contains(MARKER_BEGIN));
         assert!(content.contains("| github.com/acme/api | api |"));
 
-        // CLAUDE.md is a symlink to AGENTS.md
-        let link_meta = fs::symlink_metadata(ws_dir.join("CLAUDE.md")).unwrap();
-        assert!(link_meta.file_type().is_symlink());
-        let target = fs::read_link(ws_dir.join("CLAUDE.md")).unwrap();
-        assert_eq!(target.to_str().unwrap(), "AGENTS.md");
+        // CLAUDE.md is a symlink to AGENTS.md (skip if OS doesn't support symlinks)
+        if symlinks_available(ws_dir) {
+            let link_meta = fs::symlink_metadata(ws_dir.join("CLAUDE.md")).unwrap();
+            assert!(link_meta.file_type().is_symlink());
+            let target = fs::read_link(ws_dir.join("CLAUDE.md")).unwrap();
+            assert_eq!(target.to_str().unwrap(), "AGENTS.md");
+        }
 
         // Skills installed
         let manage_skill = ws_dir.join(".claude/skills/wsp-manage/SKILL.md");
@@ -638,6 +657,10 @@ mod tests {
     fn test_broken_symlink_recreated() {
         let tmp = tempfile::tempdir().unwrap();
         let ws_dir = tmp.path();
+
+        if !symlinks_available(ws_dir) {
+            return;
+        }
 
         // Create a broken symlink
         symlink_file("nonexistent-target", ws_dir.join("CLAUDE.md")).unwrap();

--- a/crates/wsp-core/src/agentmd.rs
+++ b/crates/wsp-core/src/agentmd.rs
@@ -250,23 +250,10 @@ fn ensure_symlink(ws_dir: &Path) -> Result<()> {
 }
 
 fn create_symlink_or_skip(original: &str, link: &Path) -> Result<()> {
-    match symlink_file(original, link) {
-        Ok(()) => Ok(()),
-        // ERROR_PRIVILEGE_NOT_HELD (1314): Developer Mode not enabled on Windows; skip.
-        #[cfg(windows)]
-        Err(e) if e.raw_os_error() == Some(1314) => Ok(()),
-        Err(e) => Err(e).context("creating CLAUDE.md symlink"),
-    }
-}
-
-#[cfg(unix)]
-fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> std::io::Result<()> {
-    std::os::unix::fs::symlink(original, link)
-}
-
-#[cfg(windows)]
-fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> std::io::Result<()> {
-    std::os::windows::fs::symlink_file(original, link)
+    // Skips silently on Windows without Developer Mode (os error 1314).
+    crate::symlink::symlink_file_or_skip(original, link)
+        .with_context(|| format!("creating symlink {}", link.display()))?;
+    Ok(())
 }
 
 fn install_skill(ws_dir: &Path) -> Result<()> {
@@ -289,12 +276,12 @@ fn install_skill(ws_dir: &Path) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::symlink_file;
     use super::*;
     use std::collections::BTreeMap;
 
     use chrono::Utc;
 
+    use crate::symlink::symlink_file;
     use crate::workspace::{Metadata, WorkspaceRepoRef};
 
     fn symlinks_available(dir: &Path) -> bool {

--- a/crates/wsp-core/src/filelock.rs
+++ b/crates/wsp-core/src/filelock.rs
@@ -201,7 +201,6 @@ mod tests {
         }
     }
 
-    #[cfg(unix)]
     #[test]
     fn acquire_writes_pid() {
         let tmp = tempfile::tempdir().unwrap();
@@ -210,10 +209,11 @@ mod tests {
 
         let lock = FileLock::acquire(&target, Duration::from_secs(1)).unwrap();
         let lock_path = FileLock::lock_path_for(&target);
+        // Drop before reading: Windows exclusive locks block reads from other handles.
+        drop(lock);
         let contents = fs::read_to_string(&lock_path).unwrap();
         let pid: u32 = contents.trim().parse().unwrap();
         assert_eq!(pid, std::process::id());
-        drop(lock);
     }
 
     #[test]

--- a/crates/wsp-core/src/gc.rs
+++ b/crates/wsp-core/src/gc.rs
@@ -85,18 +85,31 @@ fn copy_dir_recursive(src: &Path, dest: &Path) -> Result<()> {
         let dest_path = dest.join(item.file_name());
         if ft.is_symlink() {
             let target = fs::read_link(&src_path)?;
-            #[cfg(unix)]
-            std::os::unix::fs::symlink(&target, &dest_path)?;
-            #[cfg(windows)]
-            {
-                // Use metadata on src_path (follows the symlink at its actual
-                // location) rather than &target, which may be a relative path
-                // that resolves incorrectly against the process CWD.
-                let target_meta = std::fs::metadata(&src_path);
-                if target_meta.map(|m| m.is_dir()).unwrap_or(false) {
-                    std::os::windows::fs::symlink_dir(&target, &dest_path)?;
-                } else {
-                    std::os::windows::fs::symlink_file(&target, &dest_path)?;
+            let res: std::io::Result<()> = {
+                #[cfg(unix)]
+                {
+                    std::os::unix::fs::symlink(&target, &dest_path)
+                }
+                #[cfg(windows)]
+                {
+                    // Windows needs the file/dir variant chosen up front. Stat
+                    // src_path (follows the link at its actual location, not
+                    // &target which may resolve wrongly against the CWD).
+                    if std::fs::metadata(&src_path)
+                        .map(|m| m.is_dir())
+                        .unwrap_or(false)
+                    {
+                        std::os::windows::fs::symlink_dir(&target, &dest_path)
+                    } else {
+                        std::os::windows::fs::symlink_file(&target, &dest_path)
+                    }
+                }
+            };
+            if let Err(e) = res {
+                // Windows without Developer Mode can't create symlinks; skip this
+                // entry rather than aborting the whole GC copy.
+                if !crate::symlink::is_dev_mode_error(&e) {
+                    return Err(e.into());
                 }
             }
         } else if ft.is_dir() {

--- a/crates/wsp-core/src/giturl.rs
+++ b/crates/wsp-core/src/giturl.rs
@@ -340,8 +340,8 @@ mod tests {
             repo: "repo-a".into(),
         };
         assert_eq!(
-            p.mirror_path().to_str().unwrap().replace('\\', "/"),
-            "github.com/user/repo-a.git"
+            p.mirror_path(),
+            PathBuf::from("github.com").join("user").join("repo-a.git")
         );
     }
 

--- a/crates/wsp-core/src/lib.rs
+++ b/crates/wsp-core/src/lib.rs
@@ -74,6 +74,7 @@ pub mod mirror;
 pub mod output;
 pub mod setup_commands;
 pub mod setup_runner;
+pub mod symlink;
 pub mod template;
 pub(crate) mod util;
 pub mod workspace;

--- a/crates/wsp-core/src/setup_runner.rs
+++ b/crates/wsp-core/src/setup_runner.rs
@@ -1,6 +1,7 @@
 //! Interactive prompt and execution of per-repo setup commands.
 //!
-//! Each command is executed via `sh -c <cmd>` in the repo's clone directory.
+//! Each command is executed via `sh -c <cmd>` (Unix) or `cmd /c <cmd>` (Windows)
+//! in the repo's clone directory.
 //! **The approval flow is the security boundary**: users see the exact commands
 //! before anything runs. Approvals are stored by content hash so wsp only
 //! re-prompts when the commands change — the same model direnv uses.
@@ -141,12 +142,7 @@ fn read_line() -> Result<String> {
 /// Run each command in `clone_dir`. Non-zero exits are printed as warnings.
 pub(crate) fn run_commands(clone_dir: &Path, commands: &[String]) {
     for cmd in commands {
-        match std::process::Command::new("sh")
-            .arg("-c")
-            .arg(cmd)
-            .current_dir(clone_dir)
-            .status()
-        {
+        match shell_command(cmd).current_dir(clone_dir).status() {
             Ok(status) if status.success() => {}
             Ok(status) => {
                 eprintln!(
@@ -162,6 +158,20 @@ pub(crate) fn run_commands(clone_dir: &Path, commands: &[String]) {
             }
         }
     }
+}
+
+#[cfg(unix)]
+fn shell_command(cmd: &str) -> std::process::Command {
+    let mut c = std::process::Command::new("sh");
+    c.arg("-c").arg(cmd);
+    c
+}
+
+#[cfg(windows)]
+fn shell_command(cmd: &str) -> std::process::Command {
+    let mut c = std::process::Command::new("cmd");
+    c.arg("/c").arg(cmd);
+    c
 }
 
 // ---------------------------------------------------------------------------
@@ -239,30 +249,49 @@ mod tests {
         );
     }
 
+    // Platform-appropriate command to create an empty file at `name` (relative to cwd).
     #[cfg(unix)]
+    fn touch(name: &str) -> String {
+        format!("touch {name}")
+    }
+    #[cfg(windows)]
+    fn touch(name: &str) -> String {
+        format!("type nul > {name}")
+    }
+
+    // Platform-appropriate command that exits with a non-zero code.
+    #[cfg(unix)]
+    fn fail_cmd() -> &'static str {
+        "false"
+    }
+    #[cfg(windows)]
+    fn fail_cmd() -> &'static str {
+        "exit 1"
+    }
+
     #[test]
     fn run_commands_multiple_commands_all_run() {
         let tmp = make_temp_dir();
-        let sentinel = tmp.path().join("ran");
-        run_commands(
-            tmp.path(),
-            &[format!("touch {}", sentinel.display()), "true".to_string()],
+        // Use a bare filename — run_commands sets cwd to tmp, so no path separators
+        // appear in the shell command string.
+        run_commands(tmp.path(), &[touch("ran"), "echo ok".to_string()]);
+        assert!(
+            tmp.path().join("ran").exists(),
+            "sentinel file should have been created"
         );
-        assert!(sentinel.exists(), "sentinel file should have been created");
     }
 
     #[cfg(unix)]
     #[test]
     fn run_commands_continues_after_failure() {
         let tmp = make_temp_dir();
-        let sentinel = tmp.path().join("after_failure");
         // First command fails; second should still run.
         run_commands(
             tmp.path(),
-            &["false".to_string(), format!("touch {}", sentinel.display())],
+            &[fail_cmd().to_string(), touch("after_failure")],
         );
         assert!(
-            sentinel.exists(),
+            tmp.path().join("after_failure").exists(),
             "second command should run even after first fails"
         );
     }
@@ -271,12 +300,10 @@ mod tests {
     // Pre-approved path (store hit)
     // -----------------------------------------------------------------------
 
-    #[cfg(unix)]
     #[test]
     fn pre_approved_commands_run_without_prompt() {
         let tmp = make_temp_dir();
-        let sentinel = tmp.path().join("setup_ran");
-        let resolved = make_resolved(vec![&format!("touch {}", sentinel.display())]);
+        let resolved = make_resolved(vec![&touch("setup_ran")]);
 
         // Record approval so maybe_run_resolved skips the prompt.
         let hash = crate::approvals::commands_hash(&resolved.commands);
@@ -284,6 +311,9 @@ mod tests {
 
         let result = maybe_run_resolved(tmp.path(), tmp.path(), "test/repo", &resolved);
         assert_eq!(result.unwrap(), true);
-        assert!(sentinel.exists(), "pre-approved command should have run");
+        assert!(
+            tmp.path().join("setup_ran").exists(),
+            "pre-approved command should have run"
+        );
     }
 }

--- a/crates/wsp-core/src/setup_runner.rs
+++ b/crates/wsp-core/src/setup_runner.rs
@@ -298,7 +298,6 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[test]
     fn run_commands_continues_after_failure() {
         let tmp = make_temp_dir();

--- a/crates/wsp-core/src/setup_runner.rs
+++ b/crates/wsp-core/src/setup_runner.rs
@@ -1,7 +1,11 @@
 //! Interactive prompt and execution of per-repo setup commands.
 //!
 //! Each command is executed via `sh -c <cmd>` (Unix) or `cmd /c <cmd>` (Windows)
-//! in the repo's clone directory.
+//! in the repo's clone directory. `cmd` is the de-facto default for running a
+//! command string on Windows (matching npm's `script-shell` and Node's
+//! `%ComSpec%`); it forwards child exit codes reliably, unlike `powershell
+//! -Command`. (A configurable per-platform shell could be added later, à la
+//! npm's `script-shell`.)
 //! **The approval flow is the security boundary**: users see the exact commands
 //! before anything runs. Approvals are stored by content hash so wsp only
 //! re-prompts when the commands change — the same model direnv uses.
@@ -229,20 +233,21 @@ mod tests {
     fn run_commands_success_produces_no_warning() {
         let tmp = make_temp_dir();
         // Can't capture stderr without fork tricks; just assert it doesn't panic.
-        run_commands(tmp.path(), &["true".to_string()]);
+        run_commands(tmp.path(), &[ok_cmd().to_string()]);
     }
 
     #[test]
     fn run_commands_nonzero_exit_does_not_panic() {
         let tmp = make_temp_dir();
-        // "false" exits with code 1 — should print a warning but not panic.
-        run_commands(tmp.path(), &["false".to_string()]);
+        // A non-zero exit should print a warning but not panic.
+        run_commands(tmp.path(), &[fail_cmd().to_string()]);
     }
 
     #[test]
     fn run_commands_bad_command_does_not_panic() {
         let tmp = make_temp_dir();
-        // Nonexistent program inside sh -c results in exit 127 (shell not-found).
+        // A nonexistent program makes the shell exit non-zero (not-found);
+        // run_commands should warn, not panic.
         run_commands(
             tmp.path(),
             &["__wsp_nonexistent_cmd_for_testing__".to_string()],
@@ -267,6 +272,18 @@ mod tests {
     #[cfg(windows)]
     fn fail_cmd() -> &'static str {
         "exit 1"
+    }
+
+    // Platform-appropriate command that exits zero. `true` is a shell builtin on
+    // Unix but not a `cmd` builtin on Windows, where it would exit non-zero and
+    // silently turn the success test into a second failure test.
+    #[cfg(unix)]
+    fn ok_cmd() -> &'static str {
+        "true"
+    }
+    #[cfg(windows)]
+    fn ok_cmd() -> &'static str {
+        "exit 0"
     }
 
     #[test]

--- a/crates/wsp-core/src/symlink.rs
+++ b/crates/wsp-core/src/symlink.rs
@@ -1,0 +1,91 @@
+//! Cross-platform symlink helpers.
+//!
+//! Unless Developer Mode is enabled (or the process is elevated), Windows
+//! refuses to create a symlink with `ERROR_PRIVILEGE_NOT_HELD` (os error 1314).
+//! These helpers centralize the "degrade gracefully when symlinks are
+//! unavailable" policy so callers don't each re-implement it. `gc` handles its
+//! own file-vs-directory symlink replication inline (the only caller that needs
+//! it) and uses `is_dev_mode_error` to decide whether to skip.
+
+use std::io;
+use std::path::Path;
+
+/// Windows `ERROR_PRIVILEGE_NOT_HELD`: creating a symlink requires Developer
+/// Mode or an elevated process.
+const ERROR_PRIVILEGE_NOT_HELD: i32 = 1314;
+
+/// True if `err` is the Windows "symlinks need Developer Mode" error. Always
+/// false on Unix, where symlink creation needs no special privilege. The
+/// `cfg!(windows)` short-circuits so `raw_os_error()` is only meaningful on
+/// Windows.
+pub(crate) fn is_dev_mode_error(err: &io::Error) -> bool {
+    cfg!(windows) && err.raw_os_error() == Some(ERROR_PRIVILEGE_NOT_HELD)
+}
+
+/// Create a symlink at `link` pointing to `original`, where `original` is a file.
+pub(crate) fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(original, link)
+    }
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_file(original, link)
+    }
+}
+
+/// Create a file symlink, treating "Developer Mode not enabled" on Windows as a
+/// no-op success. Returns `true` if the link was created, `false` if it was
+/// skipped because the platform won't allow it.
+pub fn symlink_file_or_skip<P: AsRef<Path>, Q: AsRef<Path>>(
+    original: P,
+    link: Q,
+) -> io::Result<bool> {
+    match symlink_file(original, link) {
+        Ok(()) => Ok(true),
+        Err(e) if is_dev_mode_error(&e) => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn symlink_file_creates_link_where_supported() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("target.txt"), "hi").unwrap();
+        let link = tmp.path().join("link.txt");
+
+        match symlink_file_or_skip("target.txt", &link) {
+            Ok(true) => {
+                let meta = fs::symlink_metadata(&link).unwrap();
+                assert!(meta.file_type().is_symlink());
+            }
+            // Windows without Developer Mode: creation is skipped, link absent.
+            Ok(false) => assert!(!link.exists()),
+            Err(e) => panic!("unexpected symlink error: {e}"),
+        }
+    }
+
+    #[test]
+    fn is_dev_mode_error_false_for_other_errors() {
+        let err = io::Error::new(io::ErrorKind::NotFound, "nope");
+        assert!(!is_dev_mode_error(&err));
+    }
+
+    /// CI's Windows runners are elevated, so a real 1314 never occurs there and
+    /// the skip path is never exercised end-to-end. Synthesize the error to pin
+    /// both the constant and the platform gating.
+    #[test]
+    fn is_dev_mode_error_matches_1314_only_on_windows() {
+        let err = io::Error::from_raw_os_error(ERROR_PRIVILEGE_NOT_HELD);
+        assert_eq!(is_dev_mode_error(&err), cfg!(windows));
+
+        // A neighbouring os error must never be mistaken for it.
+        let other = io::Error::from_raw_os_error(ERROR_PRIVILEGE_NOT_HELD + 1);
+        assert!(!is_dev_mode_error(&other));
+    }
+}

--- a/crates/wsp-core/src/workspace.rs
+++ b/crates/wsp-core/src/workspace.rs
@@ -5859,7 +5859,8 @@ mod tests {
             want_contains: Vec<&'static str>,
         }
 
-        let cases: Vec<Case> = vec![
+        #[allow(unused_mut)]
+        let mut cases: Vec<Case> = vec![
             Case {
                 name: "clean workspace — only repo dirs + .wsp.yaml",
                 setup: Box::new(|ws| {
@@ -6057,6 +6058,23 @@ mod tests {
                 want_contains: vec!["?? notes.md", "?? .claude/settings.json"],
             },
         ];
+
+        #[cfg(unix)]
+        cases.push(Case {
+            name: "CLAUDE.md as symlink to AGENTS.md",
+            setup: Box::new(|ws| {
+                fs::write(ws.join(METADATA_FILE), "").unwrap();
+                fs::write(
+                    ws.join("AGENTS.md"),
+                    "# Workspace: test\n\n<!-- wsp:begin -->\n<!-- wsp:end -->\n",
+                )
+                .unwrap();
+                std::os::unix::fs::symlink("AGENTS.md", ws.join("CLAUDE.md")).unwrap();
+            }),
+            repos: vec![],
+            want_clean: true,
+            want_contains: vec![],
+        });
 
         for tc in &cases {
             let tmp = tempfile::tempdir().unwrap();

--- a/crates/wsp/src/cli/cfg.rs
+++ b/crates/wsp/src/cli/cfg.rs
@@ -1154,11 +1154,14 @@ mod tests {
             .save_to(&paths.config_path)
             .unwrap();
 
-        let ws_dir = std::env::temp_dir().join("wsp-test-ws");
-        let ws_dir_str = ws_dir.to_string_lossy().into_owned();
+        let ws_dir = tmp
+            .path()
+            .join("alt-workspaces")
+            .to_string_lossy()
+            .to_string();
         let cases = vec![
             ("branch-prefix", "jg"),
-            ("workspaces-dir", ws_dir_str.as_str()),
+            ("workspaces-dir", ws_dir.as_str()),
             ("sync-strategy", "merge"),
             ("agent-md", "true"),
             ("clone.protocol", "ssh"),

--- a/crates/wsp/src/cli/doctor.rs
+++ b/crates/wsp/src/cli/doctor.rs
@@ -12,6 +12,7 @@ use wsp_core::giturl;
 use wsp_core::lang;
 use wsp_core::mirror;
 use wsp_core::output::{CheckStatus, DoctorCheck, DoctorOutput, DoctorSummary, Output};
+use wsp_core::symlink;
 use wsp_core::template;
 use wsp_core::workspace;
 
@@ -1295,16 +1296,23 @@ fn check_agents_md_valid(
         if fix {
             match agentmd::update(ws_dir, meta) {
                 Ok(()) => {
-                    // Also ensure CLAUDE.md symlink
-                    let _ = fs::remove_file(&claude_path);
-                    #[cfg(unix)]
-                    let link_result: std::io::Result<()> =
-                        std::os::unix::fs::symlink("AGENTS.md", &claude_path);
-                    #[cfg(windows)]
-                    let link_result: std::io::Result<()> =
-                        std::os::windows::fs::symlink_file("AGENTS.md", &claude_path);
+                    // agentmd::update already ran ensure_symlink, which repairs a
+                    // missing or stale symlink but leaves a regular-file CLAUDE.md
+                    // alone — repairing that is doctor's job. Only rewrite when the
+                    // link isn't already correct, so we never destroy a valid
+                    // symlink (which on Windows without Developer Mode couldn't be
+                    // recreated). The shared helper skips gracefully on os 1314.
+                    let already_linked = fs::read_link(&claude_path)
+                        .map(|t| t == std::path::Path::new("AGENTS.md"))
+                        .unwrap_or(false);
+                    let link_result = if already_linked {
+                        Ok(true)
+                    } else {
+                        let _ = fs::remove_file(&claude_path);
+                        symlink::symlink_file_or_skip("AGENTS.md", &claude_path)
+                    };
                     match link_result {
-                        Ok(()) => {
+                        Ok(true) => {
                             checks.push(DoctorCheck {
                                 scope: ws_scope.into(),
                                 check: "agents-md-valid".into(),
@@ -1315,6 +1323,22 @@ fn check_agents_md_valid(
                             });
                             eprintln!("  ✓ regenerated AGENTS.md and CLAUDE.md");
                             *fixed += 1;
+                        }
+                        // Symlink unavailable (e.g. Windows without Developer Mode):
+                        // AGENTS.md was regenerated, but CLAUDE.md can't be linked.
+                        // Report a Warn (not a counted fix) so this stays consistent
+                        // with a plain re-run and tells the user how to resolve it.
+                        Ok(false) => {
+                            let msg = "regenerated AGENTS.md; CLAUDE.md symlink needs Developer Mode (Windows)";
+                            checks.push(DoctorCheck {
+                                scope: ws_scope.into(),
+                                check: "agents-md-valid".into(),
+                                status: CheckStatus::Warn,
+                                message: msg.into(),
+                                fixable,
+                                details: Some(serde_json::json!({ "problems": problems })),
+                            });
+                            eprintln!("  ⚠ {msg}");
                         }
                         Err(e) => {
                             checks.push(DoctorCheck {
@@ -3650,6 +3674,73 @@ mod tests {
         assert_eq!(
             fs::read_link(ws_dir.join("CLAUDE.md")).unwrap(),
             std::path::Path::new("AGENTS.md")
+        );
+    }
+
+    /// True if this platform/process can create symlinks. On Windows that needs
+    /// Developer Mode or elevation; probing at runtime lets the test below run on
+    /// Windows CI (elevated) instead of being compiled out like its `cfg(unix)`
+    /// siblings.
+    fn symlinks_supported(dir: &std::path::Path) -> bool {
+        let probe = dir.join(".symlink_probe");
+        let ok = wsp_core::symlink::symlink_file_or_skip("AGENTS.md", &probe).unwrap_or(false);
+        let _ = fs::remove_file(&probe);
+        ok
+    }
+
+    /// The fix path must not delete and recreate a CLAUDE.md symlink that is
+    /// already correct: on Windows without Developer Mode the delete would
+    /// succeed and the recreate would not, destroying a valid link to repair a
+    /// problem that lived in AGENTS.md.
+    #[test]
+    fn agents_md_fix_preserves_valid_claude_md_symlink() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ws_dir = tmp.path().join("ws");
+        let meta = test_metadata("test", "test/branch", std::collections::BTreeMap::new());
+        create_workspace_on_disk(&ws_dir, &meta);
+        if !symlinks_supported(&ws_dir) {
+            return;
+        }
+
+        // Valid CLAUDE.md symlink, but AGENTS.md has lost its wsp markers — so
+        // there is a real problem to fix that is not the symlink.
+        agentmd::update(&ws_dir, &meta).unwrap();
+        fs::write(ws_dir.join("AGENTS.md"), "no markers here").unwrap();
+        let claude_path = ws_dir.join("CLAUDE.md");
+        assert!(
+            fs::symlink_metadata(&claude_path)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+
+        let mut checks = Vec::new();
+        let mut fixed = 0;
+        check_agents_md_valid(
+            &ws_dir,
+            &meta,
+            "workspace/test",
+            true,
+            &mut checks,
+            &mut fixed,
+        );
+
+        assert_eq!(fixed, 1);
+        assert_eq!(checks[0].status, CheckStatus::Ok);
+        // Still a symlink pointing at AGENTS.md, and AGENTS.md was regenerated.
+        let claude_meta = fs::symlink_metadata(&claude_path).unwrap();
+        assert!(
+            claude_meta.file_type().is_symlink(),
+            "valid CLAUDE.md symlink must survive the fix"
+        );
+        assert_eq!(
+            fs::read_link(&claude_path).unwrap(),
+            std::path::Path::new("AGENTS.md")
+        );
+        assert!(
+            fs::read_to_string(ws_dir.join("AGENTS.md"))
+                .unwrap()
+                .contains(agentmd::MARKER_BEGIN)
         );
     }
 

--- a/crates/wsp/src/cli/doctor.rs
+++ b/crates/wsp/src/cli/doctor.rs
@@ -3512,6 +3512,12 @@ mod tests {
         // Create a valid AGENTS.md with markers
         agentmd::update(&ws_dir, &meta).unwrap();
 
+        // On Windows without Developer Mode, symlink creation is silently skipped
+        // (os error 1314). The doctor check requires the symlink, so skip if absent.
+        if !ws_dir.join("CLAUDE.md").exists() {
+            return;
+        }
+
         let mut checks = Vec::new();
         let mut fixed = 0;
         check_agents_md_valid(

--- a/crates/wsp/src/cli/setup.rs
+++ b/crates/wsp/src/cli/setup.rs
@@ -402,7 +402,7 @@ mod tests {
         for (shell, suffix) in cases {
             let rc = primary_rc_file(home, shell);
             assert!(
-                rc.to_string_lossy().ends_with(suffix),
+                rc.ends_with(suffix),
                 "primary_rc_file({}) = {}, expected to end with {}",
                 shell,
                 rc.display(),


### PR DESCRIPTION
## Summary

- Adapt shell invocation to use `cmd /c` on Windows instead of `sh -c`
- Handle `LockFileEx` blocking same-process reads on Windows in file locking
- Gracefully skip symlink creation when Developer Mode is not enabled (error 1314)
- Use `PathBuf` for path comparisons instead of strings to handle cross-platform separators
- Add Windows `install-hooks` recipe to Justfile
- Make test suite cross-platform: add `touch()`/`fail_cmd()` helpers, remove Unix-only `#[cfg(unix)]` guards from `run_commands_multiple_commands_all_run` and `pre_approved_commands_run_without_prompt`

## Test plan

- [ ] `cargo test` passes on Windows
- [ ] `cargo test` continues to pass on Linux/macOS
- [ ] `just install-hooks` works on Windows (PowerShell) and Unix

🤖 Generated with [Claude Code](https://claude.com/claude-code)