### PR TITLE
feat(completion): add PowerShell shell integration

### DIFF
--- a/crates/wsp/src/cli/completion.rs
+++ b/crates/wsp/src/cli/completion.rs
@@ -41,12 +41,16 @@ pub fn cmd() -> Command {
         .long_about(
             "Output shell integration (completions + wrapper function) [read-only].\n\n\
              Prints a shell script that provides tab completion and the `wsp cd` wrapper \
-             function. Add `eval \"$(wsp completion zsh)\"` to your shell rc file.",
+             function.\n\n\
+             zsh:        eval \"$(wsp completion zsh)\"\n\
+             bash:       eval \"$(wsp completion bash)\"\n\
+             fish:       wsp completion fish | source\n\
+             powershell: Invoke-Expression (wsp completion powershell | Out-String)",
         )
         .arg(
             Arg::new("shell")
                 .required(true)
-                .value_parser(["zsh", "bash", "fish"]),
+                .value_parser(["zsh", "bash", "fish", "powershell"]),
         )
 }
 
@@ -86,7 +90,14 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
             generate_fish(&mut std::io::stdout(), paths, hooks)?;
             Ok(Output::None)
         }
-        _ => bail!("unsupported shell: {} (supported: zsh, bash, fish)", shell),
+        "powershell" => {
+            generate_powershell(&mut std::io::stdout(), paths, hooks)?;
+            Ok(Output::None)
+        }
+        _ => bail!(
+            "unsupported shell: {} (supported: zsh, bash, fish, powershell)",
+            shell
+        ),
     }
 }
 
@@ -109,6 +120,12 @@ fn posix_escape(s: &str) -> String {
 /// Fish supports `\'` inside single-quoted strings.
 fn fish_escape(s: &str) -> String {
     s.replace('\'', "\\'")
+}
+
+/// Escape a string for embedding inside PowerShell single quotes.
+/// Single quotes are escaped by doubling them: `'` → `''`
+fn ps_escape(s: &str) -> String {
+    s.replace('\'', "''")
 }
 
 // ---------- zsh / bash (POSIX-like) ----------
@@ -263,7 +280,7 @@ fn build_posix_cd_out(cmd_name: &str) -> String {
          \x20     done\n\
          \x20     if [[ -n \"$_wsp_name\" ]]; then\n\
          \x20       local wsp_dir=\"$wsp_root/$_wsp_name\"\n\
-         \x20       if [[ \"$PWD\" = \"$wsp_dir\"* ]]; then\n\
+         \x20       if [[ \"$PWD\" = \"$wsp_dir\" || \"$PWD\" = \"$wsp_dir\"/* ]]; then\n\
          \x20         cd \"$wsp_root\" || cd \"$HOME\"\n\
          \x20       fi\n\
          \x20     fi\n\
@@ -415,7 +432,7 @@ function wsp\n\
             end\n\
             if test -n \"$_wsp_name\"\n\
                 set -l wsp_dir \"$wsp_root/$_wsp_name\"\n\
-                if string match -q \"$wsp_dir*\" $PWD\n\
+                if string match -q -- \"$wsp_dir\" $PWD; or string match -q -- \"$wsp_dir/*\" $PWD\n\
                     cd \"$wsp_root\"; or cd $HOME\n\
                 end\n\
             end\n\
@@ -521,6 +538,161 @@ fn write_fish_hooks(w: &mut dyn Write, root_esc: &str, hooks: ShellHookOpts) -> 
     writeln!(w)?;
     writeln!(w, "# Trigger on initial load")?;
     writeln!(w, "_wsp_hook")?;
+
+    Ok(())
+}
+
+// ---------- powershell ----------
+
+fn generate_powershell(w: &mut dyn Write, paths: &Paths, _hooks: ShellHookOpts) -> Result<()> {
+    let bin_str = bin_path()?;
+    let wsp_root = paths.workspaces_dir.display().to_string();
+    write_powershell(w, &bin_str, &wsp_root)
+}
+
+fn write_powershell(w: &mut dyn Write, bin_str: &str, wsp_root: &str) -> Result<()> {
+    let bin_esc = ps_escape(bin_str);
+    let root_esc = ps_escape(wsp_root);
+
+    writeln!(w, "function wsp {{")?;
+    writeln!(w, "    $wspBin = '{bin_esc}'")?;
+    writeln!(w, "    $wspRoot = '{root_esc}'")?;
+    writeln!(w)?;
+    writeln!(w, "    switch ($args[0]) {{")?;
+    writeln!(w, "        'new' {{")?;
+    writeln!(
+        w,
+        "            $restArgs = @($args | Select-Object -Skip 1)"
+    )?;
+    writeln!(w, "            & $wspBin new @restArgs")?;
+    writeln!(
+        w,
+        "            if ($LASTEXITCODE -eq 0 -and $restArgs.Count -gt 0) {{"
+    )?;
+    writeln!(
+        w,
+        "                Set-Location (Join-Path $wspRoot $restArgs[0])"
+    )?;
+    writeln!(w, "            }}")?;
+    writeln!(w, "        }}")?;
+    writeln!(w, "        'cd' {{")?;
+    writeln!(
+        w,
+        "            $restArgs = @($args | Select-Object -Skip 1)"
+    )?;
+    writeln!(w, "            $env:WSP_SHELL = '1'")?;
+    writeln!(w, "            $dir = & $wspBin cd @restArgs")?;
+    writeln!(
+        w,
+        "            Remove-Item Env:\\WSP_SHELL -ErrorAction SilentlyContinue"
+    )?;
+    writeln!(w, "            if ($LASTEXITCODE -eq 0 -and $dir) {{")?;
+    writeln!(w, "                Set-Location $dir")?;
+    writeln!(w, "            }}")?;
+    writeln!(w, "        }}")?;
+    writeln!(w, "        {{ $_ -in 'rm', 'remove' }} {{")?;
+    writeln!(
+        w,
+        "            $restArgs = @($args | Select-Object -Skip 1)"
+    )?;
+    writeln!(w, "            $wspName = $null")?;
+    writeln!(w, "            foreach ($a in $restArgs) {{")?;
+    writeln!(
+        w,
+        "                if (-not $a.StartsWith('-')) {{ $wspName = $a; break }}"
+    )?;
+    writeln!(w, "            }}")?;
+    writeln!(w, "            if ($wspName) {{")?;
+    writeln!(w, "                $wspDir = Join-Path $wspRoot $wspName")?;
+    writeln!(
+        w,
+        "                if ($PWD.Path -eq $wspDir -or $PWD.Path -like \"$wspDir\\*\") {{"
+    )?;
+    writeln!(w, "                    Set-Location $wspRoot")?;
+    writeln!(w, "                }}")?;
+    writeln!(w, "            }}")?;
+    writeln!(w, "            & $wspBin rm @restArgs")?;
+    writeln!(
+        w,
+        "            if (-not (Test-Path -LiteralPath $PWD.Path -PathType Container)) {{"
+    )?;
+    writeln!(w, "                Set-Location $wspRoot")?;
+    writeln!(w, "            }}")?;
+    writeln!(w, "        }}")?;
+    writeln!(w, "        'recover' {{")?;
+    writeln!(
+        w,
+        "            $restArgs = @($args | Select-Object -Skip 1)"
+    )?;
+    writeln!(w, "            & $wspBin recover @restArgs")?;
+    writeln!(
+        w,
+        "            if ($LASTEXITCODE -eq 0 -and $restArgs.Count -gt 0) {{"
+    )?;
+    writeln!(w, "                $wspName = $restArgs[0]")?;
+    writeln!(
+        w,
+        "                if ($wspName -and $wspName -notin 'ls', 'list', 'show' -and -not $wspName.StartsWith('-')) {{"
+    )?;
+    writeln!(
+        w,
+        "                    Set-Location (Join-Path $wspRoot $wspName)"
+    )?;
+    writeln!(w, "                }}")?;
+    writeln!(w, "            }}")?;
+    writeln!(w, "        }}")?;
+    writeln!(w, "        default {{")?;
+    writeln!(w, "            & $wspBin @args")?;
+    writeln!(w, "        }}")?;
+    writeln!(w, "    }}")?;
+    writeln!(w, "}}")?;
+    writeln!(w)?;
+    // Register-ArgumentCompleter without -Native fires for functions, not just
+    // external executables. -Native would be ignored because `wsp` is a function.
+    writeln!(
+        w,
+        "Register-ArgumentCompleter -CommandName wsp -ScriptBlock {{"
+    )?;
+    writeln!(
+        w,
+        "    param($wordToComplete, $commandAst, $cursorPosition)"
+    )?;
+    writeln!(w, "    $prev = $env:COMPLETE")?;
+    writeln!(w, "    $env:COMPLETE = 'powershell'")?;
+    writeln!(w, "    $argStr = $commandAst.Extent.Text")?;
+    writeln!(
+        w,
+        "    $argStr = $argStr.Substring(0, [math]::Min($cursorPosition, $argStr.Length))"
+    )?;
+    writeln!(w, "    if ($wordToComplete -eq '') {{")?;
+    // PS 5.1 silently drops empty-string args to native exes when using &.
+    // --% (stop-parsing) passes the trailing `""` as a raw command-line token;
+    // CommandLineToArgvW then gives clap_complete the empty argv slot it needs.
+    writeln!(w, "        $results = Invoke-Expression @\"")?;
+    writeln!(w, "& '{bin_esc}' --% -- $argStr `\"`\"")?;
+    writeln!(w, "\"@")?;
+    writeln!(w, "    }} else {{")?;
+    writeln!(w, "        $results = Invoke-Expression @\"")?;
+    writeln!(w, "& '{bin_esc}' -- $argStr")?;
+    writeln!(w, "\"@")?;
+    writeln!(w, "    }}")?;
+    writeln!(
+        w,
+        "    if ($null -eq $prev) {{ Remove-Item Env:\\COMPLETE }} else {{ $env:COMPLETE = $prev }}"
+    )?;
+    writeln!(w, "    $results | ForEach-Object {{")?;
+    writeln!(w, "        $split = $_ -split \"`t\"")?;
+    writeln!(w, "        $cmd = $split[0]")?;
+    writeln!(
+        w,
+        "        $help = if ($split.Length -ge 2) {{ $split[1] }} else {{ $split[0] }}"
+    )?;
+    writeln!(
+        w,
+        "        [System.Management.Automation.CompletionResult]::new($cmd, $cmd, 'ParameterValue', $help)"
+    )?;
+    writeln!(w, "    }}")?;
+    writeln!(w, "}}")?;
 
     Ok(())
 }
@@ -1037,6 +1209,176 @@ mod tests {
         assert!(
             out.contains(r"local wsp_root='/home/o'\''brien/dev'"),
             "hook wsp_root must escape single quotes: {}",
+            out
+        );
+    }
+
+    // Regression: rm cd-out check must require a path separator after the workspace
+    // name, otherwise `wsp rm foo` incorrectly cds you out when you're in `foobar`.
+    #[test]
+    fn test_posix_rm_does_not_false_positive_on_prefix_match() {
+        for shell in &["zsh", "bash"] {
+            let out = output(|w| {
+                write_posix(
+                    w,
+                    "/usr/bin/wsp",
+                    "/home/user/dev",
+                    shell,
+                    ShellHookOpts::default(),
+                )
+            });
+            assert!(
+                out.contains(r#"= "$wsp_dir" || "$PWD" = "$wsp_dir"/*"#),
+                "{shell}: rm check must require separator, not bare prefix glob"
+            );
+        }
+    }
+
+    #[test]
+    fn test_fish_rm_does_not_false_positive_on_prefix_match() {
+        let out = output(|w| {
+            write_fish(
+                w,
+                "/usr/bin/wsp",
+                "/home/user/dev",
+                ShellHookOpts::default(),
+            )
+        });
+        assert!(
+            out.contains(
+                r#"string match -q -- "$wsp_dir" $PWD; or string match -q -- "$wsp_dir/*" $PWD"#
+            ),
+            "fish: rm check must require separator, not bare prefix glob"
+        );
+    }
+
+    // --- PowerShell tests ---
+
+    #[test]
+    fn test_ps_quotes_bin_path_and_wsp_root() {
+        let out = output(|w| write_powershell(w, r"C:\path\to\wsp.exe", r"C:\Users\user\dev"));
+        assert!(
+            out.contains(r"$wspBin = 'C:\path\to\wsp.exe'"),
+            "wsp_bin should be single-quoted"
+        );
+        assert!(
+            out.contains(r"$wspRoot = 'C:\Users\user\dev'"),
+            "wsp_root should be single-quoted"
+        );
+    }
+
+    #[test]
+    fn test_ps_contains_all_cases() {
+        let out = output(|w| write_powershell(w, r"C:\wsp.exe", r"C:\dev"));
+        assert!(out.contains("'new'"), "missing new case");
+        assert!(out.contains("'cd'"), "missing cd case");
+        assert!(out.contains("'rm', 'remove'"), "missing rm/remove case");
+        assert!(out.contains("'recover'"), "missing recover case");
+        assert!(out.contains("default"), "missing default case");
+    }
+
+    #[test]
+    fn test_ps_complete_registration() {
+        let out = output(|w| write_powershell(w, r"C:\wsp.exe", r"C:\dev"));
+        // Must use non-Native so the completer fires for the wsp function, not
+        // just for external executables.
+        assert!(
+            out.contains("Register-ArgumentCompleter -CommandName wsp -ScriptBlock"),
+            "must register non-native completer for the wsp function"
+        );
+        assert!(
+            !out.contains("Register-ArgumentCompleter -Native"),
+            "-Native would only fire for external executables, not the wsp function"
+        );
+        assert!(
+            out.contains("$env:COMPLETE = 'powershell'"),
+            "scriptblock must set COMPLETE env var"
+        );
+        assert!(
+            out.contains(r"& 'C:\wsp.exe' -- $argStr"),
+            "non-empty word branch must call binary normally"
+        );
+        assert!(
+            out.contains(r"& 'C:\wsp.exe' --% -- $argStr"),
+            "empty word branch must use --% to pass empty string (PS 5.1 drops bare '' args)"
+        );
+        assert!(
+            !out.contains("$argStr += \" ''\""),
+            "should not use += '' workaround (PS 5.1 silently drops empty args to native exes)"
+        );
+        assert!(
+            out.contains("CompletionResult"),
+            "scriptblock must return CompletionResult objects"
+        );
+    }
+
+    #[test]
+    fn test_ps_recover_cds_into_workspace() {
+        let out = output(|w| write_powershell(w, r"C:\wsp.exe", r"C:\dev"));
+        assert!(out.contains("'recover'"), "recover case must be present");
+        assert!(
+            out.contains("Set-Location (Join-Path $wspRoot $wspName)"),
+            "recover must cd into restored workspace"
+        );
+        assert!(
+            out.contains("ls") && out.contains("list") && out.contains("show"),
+            "recover must skip cd for ls/list/show subcommands"
+        );
+        assert!(
+            out.contains("$wspName.StartsWith('-')"),
+            "recover must skip cd for flag arguments"
+        );
+    }
+
+    #[test]
+    fn test_ps_rm_cds_out_of_workspace() {
+        let out = output(|w| write_powershell(w, r"C:\wsp.exe", r"C:\dev"));
+        assert!(
+            out.contains("'rm', 'remove'"),
+            "rm/remove case must be present"
+        );
+        // Must cd out before deleting if currently inside the workspace
+        assert!(
+            out.contains("$wspDir = Join-Path $wspRoot $wspName"),
+            "rm must compute workspace dir"
+        );
+        assert!(
+            out.contains("$PWD.Path -eq $wspDir -or $PWD.Path -like \"$wspDir\\*\""),
+            "rm must check if cwd is exactly or inside workspace (with separator)"
+        );
+        // Must always call `rm`, even when user typed `remove`
+        assert!(
+            out.contains("& $wspBin rm @restArgs"),
+            "remove must normalize to rm"
+        );
+        // Must cd away if the directory disappeared (e.g. rm -f with no prompt)
+        assert!(
+            out.contains("Test-Path -LiteralPath $PWD.Path -PathType Container"),
+            "rm must cd away if cwd no longer exists"
+        );
+    }
+
+    #[test]
+    fn test_ps_bin_with_single_quote() {
+        let out = output(|w| write_powershell(w, r"C:\it's\wsp.exe", r"C:\dev"));
+        assert!(
+            out.contains(r"$wspBin = 'C:\it''s\wsp.exe'"),
+            "wsp_bin single quote must be doubled: {}",
+            out
+        );
+        assert!(
+            out.contains(r"& 'C:\it''s\wsp.exe' -- $argStr"),
+            "completion scriptblock single quote must be doubled: {}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_ps_root_with_single_quote() {
+        let out = output(|w| write_powershell(w, r"C:\wsp.exe", r"C:\o'brien\dev"));
+        assert!(
+            out.contains(r"$wspRoot = 'C:\o''brien\dev'"),
+            "wsp_root single quote must be doubled: {}",
             out
         );
     }

--- a/crates/wsp/src/cli/completion.rs
+++ b/crates/wsp/src/cli/completion.rs
@@ -53,7 +53,7 @@ pub fn cmd() -> Command {
              powershell: Add-Content -Path $PROFILE -Value \
              \"`nInvoke-Expression (wsp completion powershell | Out-String)\"\n\n\
              PowerShell: if $PROFILE does not exist yet, run first:\n\
-               New-Item -ItemType File -Force $PROFILE",
+             \x20\x20New-Item -ItemType File -Force $PROFILE",
         )
         .arg(
             Arg::new("shell")
@@ -553,6 +553,7 @@ fn write_fish_hooks(w: &mut dyn Write, root_esc: &str, hooks: ShellHookOpts) -> 
 // ---------- powershell ----------
 
 fn generate_powershell(w: &mut dyn Write, paths: &Paths, _hooks: ShellHookOpts) -> Result<()> {
+    // TODO: shell hooks (tmux window title, prompt) not yet implemented for PowerShell
     let bin_str = bin_path()?;
     let wsp_root = paths.workspaces_dir.display().to_string();
     write_powershell(w, &bin_str, &wsp_root)
@@ -577,10 +578,19 @@ fn write_powershell(w: &mut dyn Write, bin_str: &str, wsp_root: &str) -> Result<
         w,
         "            if ($LASTEXITCODE -eq 0 -and $restArgs.Count -gt 0) {{"
     )?;
+    writeln!(w, "                $wspName = $null")?;
+    writeln!(w, "                foreach ($a in $restArgs) {{")?;
     writeln!(
         w,
-        "                Set-Location (Join-Path $wspRoot $restArgs[0])"
+        "                    if (-not $a.StartsWith('-')) {{ $wspName = $a; break }}"
     )?;
+    writeln!(w, "                }}")?;
+    writeln!(w, "                if ($wspName) {{")?;
+    writeln!(
+        w,
+        "                    Set-Location (Join-Path $wspRoot $wspName)"
+    )?;
+    writeln!(w, "                }}")?;
     writeln!(w, "            }}")?;
     writeln!(w, "        }}")?;
     writeln!(w, "        'cd' {{")?;
@@ -637,11 +647,14 @@ fn write_powershell(w: &mut dyn Write, bin_str: &str, wsp_root: &str) -> Result<
         w,
         "            if ($LASTEXITCODE -eq 0 -and $restArgs.Count -gt 0) {{"
     )?;
-    writeln!(w, "                $wspName = $restArgs[0]")?;
+    writeln!(w, "                $wspName = $null")?;
+    writeln!(w, "                foreach ($a in $restArgs) {{")?;
     writeln!(
         w,
-        "                if ($wspName -and $wspName -notin 'ls', 'list', 'show' -and -not $wspName.StartsWith('-')) {{"
+        "                    if (-not $a.StartsWith('-') -and $a -notin 'ls', 'list', 'show') {{ $wspName = $a; break }}"
     )?;
+    writeln!(w, "                }}")?;
+    writeln!(w, "                if ($wspName) {{")?;
     writeln!(
         w,
         "                    Set-Location (Join-Path $wspRoot $wspName)"
@@ -667,22 +680,27 @@ fn write_powershell(w: &mut dyn Write, bin_str: &str, wsp_root: &str) -> Result<
     )?;
     writeln!(w, "    $prev = $env:COMPLETE")?;
     writeln!(w, "    $env:COMPLETE = 'powershell'")?;
-    writeln!(w, "    $argStr = $commandAst.Extent.Text")?;
-    writeln!(
-        w,
-        "    $argStr = $argStr.Substring(0, [math]::Min($cursorPosition, $argStr.Length))"
-    )?;
     writeln!(w, "    if ($wordToComplete -eq '') {{")?;
     // PS 5.1 silently drops empty-string args to native exes when using &.
     // --% (stop-parsing) passes the trailing `""` as a raw command-line token;
     // CommandLineToArgvW then gives clap_complete the empty argv slot it needs.
+    // $argStr is expanded in the here-string before Invoke-Expression sees --%.
+    writeln!(w, "        $argStr = $commandAst.Extent.Text")?;
+    writeln!(
+        w,
+        "        $argStr = $argStr.Substring(0, [math]::Min($cursorPosition, $argStr.Length))"
+    )?;
     writeln!(w, "        $results = Invoke-Expression @\"")?;
     writeln!(w, "& '{bin_esc}' --% -- $argStr `\"`\"")?;
     writeln!(w, "\"@")?;
     writeln!(w, "    }} else {{")?;
-    writeln!(w, "        $results = Invoke-Expression @\"")?;
-    writeln!(w, "& '{bin_esc}' -- $argStr")?;
-    writeln!(w, "\"@")?;
+    // Use CommandElements directly to avoid re-evaluating user-typed text
+    // through Invoke-Expression (prevents injection via $() in argument values).
+    writeln!(
+        w,
+        "        $tokens = @($commandAst.CommandElements | ForEach-Object {{ $_.Extent.Text }})"
+    )?;
+    writeln!(w, "        $results = & '{bin_esc}' -- @tokens")?;
     writeln!(w, "    }}")?;
     writeln!(
         w,
@@ -1286,6 +1304,21 @@ mod tests {
     }
 
     #[test]
+    fn test_ps_new_skips_flag_args_when_cding() {
+        let out = output(|w| write_powershell(w, r"C:\wsp.exe", r"C:\dev"));
+        // Must iterate restArgs to find the workspace name, not blindly use restArgs[0],
+        // so that `wsp new --template foo my-workspace` cds into my-workspace not --template.
+        assert!(
+            !out.contains("Set-Location (Join-Path $wspRoot $restArgs[0])"),
+            "new must not use restArgs[0] directly as workspace name"
+        );
+        assert!(
+            out.contains("$a.StartsWith('-')"),
+            "new must skip flag arguments when looking for workspace name"
+        );
+    }
+
+    #[test]
     fn test_ps_complete_registration() {
         let out = output(|w| write_powershell(w, r"C:\wsp.exe", r"C:\dev"));
         // Must use non-Native so the completer fires for the wsp function, not
@@ -1303,8 +1336,8 @@ mod tests {
             "scriptblock must set COMPLETE env var"
         );
         assert!(
-            out.contains(r"& 'C:\wsp.exe' -- $argStr"),
-            "non-empty word branch must call binary normally"
+            out.contains(r"& 'C:\wsp.exe' -- @tokens"),
+            "non-empty word branch must use CommandElements tokens (avoids Invoke-Expression injection)"
         );
         assert!(
             out.contains(r"& 'C:\wsp.exe' --% -- $argStr"),
@@ -1333,8 +1366,12 @@ mod tests {
             "recover must skip cd for ls/list/show subcommands"
         );
         assert!(
-            out.contains("$wspName.StartsWith('-')"),
+            out.contains("$a.StartsWith('-')"),
             "recover must skip cd for flag arguments"
+        );
+        assert!(
+            !out.contains("$wspName = $restArgs[0]"),
+            "recover must not use restArgs[0] directly (flags before workspace name would be used as workspace name)"
         );
     }
 
@@ -1375,7 +1412,7 @@ mod tests {
             out
         );
         assert!(
-            out.contains(r"& 'C:\it''s\wsp.exe' -- $argStr"),
+            out.contains(r"& 'C:\it''s\wsp.exe' -- @tokens"),
             "completion scriptblock single quote must be doubled: {}",
             out
         );

--- a/crates/wsp/src/cli/completion.rs
+++ b/crates/wsp/src/cli/completion.rs
@@ -45,7 +45,15 @@ pub fn cmd() -> Command {
              zsh:        eval \"$(wsp completion zsh)\"\n\
              bash:       eval \"$(wsp completion bash)\"\n\
              fish:       wsp completion fish | source\n\
-             powershell: Invoke-Expression (wsp completion powershell | Out-String)",
+             powershell: Invoke-Expression (wsp completion powershell | Out-String)\n\n\
+             To load automatically in every new shell, add the appropriate line above to \
+             your shell's startup file:\n\n\
+             zsh/bash:   echo 'eval \"$(wsp completion <shell>)\"' >> ~/.zshrc  (or ~/.bashrc)\n\
+             fish:       echo 'wsp completion fish | source' >> ~/.config/fish/config.fish\n\
+             powershell: Add-Content -Path $PROFILE -Value \
+             \"`nInvoke-Expression (wsp completion powershell | Out-String)\"\n\n\
+             PowerShell: if $PROFILE does not exist yet, run first:\n\
+               New-Item -ItemType File -Force $PROFILE",
         )
         .arg(
             Arg::new("shell")

--- a/crates/wsp/tests/shell_completion.rs
+++ b/crates/wsp/tests/shell_completion.rs
@@ -1,0 +1,146 @@
+/// Integration tests that spawn real shells to verify tab-completion works
+/// end-to-end.
+///
+/// These tests catch runtime behavior that string-pattern unit tests cannot —
+/// e.g. PowerShell 5.1 silently dropping empty string arguments when calling
+/// native executables with `&`, which breaks `wsp <TAB>` (empty wordToComplete).
+///
+/// Each test simulates what the Register-ArgumentCompleter / complete scriptblock
+/// does when the user presses TAB with an empty prefix, directly exercising the
+/// clap_complete invocation path.
+
+const WSP: &str = env!("CARGO_BIN_EXE_wsp");
+
+// ---------------------------------------------------------------------------
+// Windows — PowerShell
+// ---------------------------------------------------------------------------
+
+/// Empty-word completion (wsp <TAB>): the empty case exercises the --% fix.
+///
+/// PowerShell 5.1 silently drops `''` when passed to a native exe via `&`.
+/// The generated scriptblock uses `--% ` (stop-parsing) so the trailing `""`
+/// survives as a raw command-line token that CommandLineToArgvW parses as an
+/// empty string. This test verifies that mechanism works end-to-end.
+#[test]
+#[cfg(windows)]
+fn powershell_empty_word_completion_returns_subcommands() {
+    let wsp_ps = WSP.replace('\'', "''"); // escape ' for PS single-quoted string
+    // --% passes everything after it verbatim to CreateProcess. "" in the raw
+    // Windows command line is how an empty argument is represented;
+    // CommandLineToArgvW parses it as an empty string.
+    // (The generated scriptblock uses Invoke-Expression @"..."@ which expands
+    // `"`" → "" before --% sees it — same net effect via a different route.)
+    let script = format!("$env:COMPLETE = 'powershell'; & '{wsp_ps}' --% -- wsp \"\"");
+
+    let out = std::process::Command::new("powershell.exe")
+        .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+        .output()
+        .expect("powershell.exe not found — should always be present on Windows");
+
+    assert!(
+        out.status.success(),
+        "completion exited non-zero\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.is_empty(),
+        "expected completions but got empty output\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        stdout.contains("new"),
+        "expected 'new' subcommand in completions\ngot:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("list"),
+        "expected 'list' subcommand in completions\ngot:\n{stdout}"
+    );
+}
+
+/// Non-empty prefix completion (wsp n<TAB>): the else branch, guards against
+/// regressions in the normal completion path.
+#[test]
+#[cfg(windows)]
+fn powershell_prefix_completion_returns_matching() {
+    let wsp_ps = WSP.replace('\'', "''");
+    let script = format!("$env:COMPLETE = 'powershell'; & '{wsp_ps}' -- wsp n");
+
+    let out = std::process::Command::new("powershell.exe")
+        .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+        .output()
+        .expect("powershell.exe not found");
+
+    assert!(out.status.success(), "completion exited non-zero");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("new"),
+        "expected 'new' for prefix 'n'\ngot:\n{stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Unix — bash
+// ---------------------------------------------------------------------------
+
+/// Empty-word completion under bash.
+///
+/// bash passes empty strings to child processes correctly (no PS 5.1 bug).
+/// bash's write_complete uses _CLAP_COMPLETE_INDEX from the environment rather
+/// than args.len()-1, so we set it to 1 and pass an explicit empty token.
+/// This guards against regressions in the completion engine itself.
+#[test]
+#[cfg(unix)]
+fn bash_empty_word_completion_returns_subcommands() {
+    let wsp_esc = WSP.replace('\'', "'\\''"); // POSIX single-quote escape
+    let script =
+        format!("_CLAP_COMPLETE_INDEX=1 _CLAP_IFS=$'\\n' COMPLETE=bash '{wsp_esc}' -- wsp ''");
+
+    let out = std::process::Command::new("bash")
+        .args(["-c", &script])
+        .output()
+        .expect("bash not found — should always be present on Unix");
+
+    assert!(
+        out.status.success(),
+        "completion exited non-zero\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.is_empty(),
+        "expected completions but got empty output\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        stdout.contains("new"),
+        "expected 'new' subcommand in completions\ngot:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("list"),
+        "expected 'list' subcommand in completions\ngot:\n{stdout}"
+    );
+}
+
+/// Non-empty prefix completion under bash: guards the normal path.
+#[test]
+#[cfg(unix)]
+fn bash_prefix_completion_returns_matching() {
+    let wsp_esc = WSP.replace('\'', "'\\''");
+    let script =
+        format!("_CLAP_COMPLETE_INDEX=1 _CLAP_IFS=$'\\n' COMPLETE=bash '{wsp_esc}' -- wsp n");
+
+    let out = std::process::Command::new("bash")
+        .args(["-c", &script])
+        .output()
+        .expect("bash not found");
+
+    assert!(out.status.success(), "completion exited non-zero");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("new"),
+        "expected 'new' for prefix 'n'\ngot:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `wsp completion powershell` output: a `wsp` function wrapper and a `Register-ArgumentCompleter` scriptblock
- Use non-native registration so the completer fires for the function, not just the external executable
- Handle PowerShell 5.1's empty-arg-drop bug via the `--% ` stop-parsing token
- Add shell-spawning integration tests for both Windows (`powershell.exe`) and Unix (bash)
- Add persistent setup instructions to `wsp completion --help`

## Setup

Add to your PowerShell profile (`$PROFILE`):

```powershell
Invoke-Expression (wsp completion powershell | Out-String)
```

## Test plan

- [ ] `wsp completion powershell` outputs a valid script
- [ ] Sourcing the script in PowerShell enables tab completion for `wsp` subcommands and workspace names
- [ ] `wsp <TAB>` works (empty-word completion via `--% ` fix)
- [ ] Integration tests pass on Windows and Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)