### PR TITLE
fix(workspace): handle non-main default branches and slash branch names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  ci:
+  check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -23,5 +23,22 @@ jobs:
 
       - run: cargo fmt --check
       - run: cargo clippy -- -D warnings
+
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: enable windows longpaths
+        if: runner.os == 'Windows'
+        run: git config --global core.longpaths true
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+
       - run: cargo build --release
       - run: cargo test -- --test-threads=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
 
 jobs:
+  # Fast platform-independent checks. Gating everything else on this avoids
+  # spinning up test runners when fmt/lint/audit would fail anyway.
   check:
     runs-on: ubuntu-latest
     steps:
@@ -24,21 +26,34 @@ jobs:
       - run: cargo fmt --check
       - run: cargo clippy -- -D warnings
 
-  test:
+  # Linux runs first. If logic is broken it shows up here cheaply before we
+  # spin up macOS and Windows runners.
+  test-linux:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+      - run: cargo build --release
+      - run: cargo test -- --test-threads=1
+
+  # Cross-platform jobs run in parallel only after Linux passes. fail-fast:false
+  # keeps both running so a single CI pass reveals all platform issues at once.
+  test-cross:
+    needs: test-linux
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [macos-latest, windows-latest]
     steps:
       - name: enable windows longpaths
         if: runner.os == 'Windows'
         run: git config --global core.longpaths true
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
       - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
-
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
-
       - run: cargo build --release
       - run: cargo test -- --test-threads=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Bug Fixes
+
+- *(workspace)* Handle non-main default branches in `wsp new` and `wsp repo add` — repos whose default branch is not `main` (e.g. `master`, `develop`, `release/2.x`) no longer fail with `fatal: 'origin/<branch>' is not a commit`
+- *(git)* Fix `split('/').last()` parser truncating slash-containing branch names (e.g. `release/2.x` → `2.x`) in `default_branch`, `default_branch_from_mirror`, and `default_branch_for_remote`
+
+### Refactor
+
+- *(git)* Extract `strip_ref_branch()` helper shared by all three default-branch parsing functions
+
 ## [0.18.0] - 2026-05-29
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-- *(workspace)* Handle non-main default branches in `wsp new` and `wsp repo add` — repos whose default branch is not `main` (e.g. `master`, `develop`, `release/2.x`) no longer fail with `fatal: 'origin/<branch>' is not a commit`
-- *(git)* Fix `split('/').last()` parser truncating slash-containing branch names (e.g. `release/2.x` → `2.x`) in `default_branch`, `default_branch_from_mirror`, and `default_branch_for_remote`
-
-### Refactor
-
-- *(git)* Extract `strip_ref_branch()` helper shared by all three default-branch parsing functions
+- *(workspace)* Fix `wsp new` and `wsp repo add` failing when a repo's default branch is not `main` (e.g. `master`, `develop`, `release/2.x`)
+- *(workspace)* Fix workspace creation silently using the wrong branch name for repos whose default branch contains a slash (e.g. `release/2.x`)
 
 ## [0.18.0] - 2026-05-29
 

--- a/crates/wsp-core/src/git.rs
+++ b/crates/wsp-core/src/git.rs
@@ -161,12 +161,7 @@ pub fn default_branch(dir: &Path) -> Result<String> {
         Err(_) => run(Some(dir), &["symbolic-ref", "HEAD"])
             .map_err(|e| anyhow::anyhow!("cannot detect default branch: {}", e))?,
     };
-
-    ref_str
-        .strip_prefix("refs/remotes/origin/")
-        .or_else(|| ref_str.strip_prefix("refs/heads/"))
-        .ok_or_else(|| anyhow::anyhow!("unexpected ref format: {}", ref_str))
-        .map(str::to_string)
+    strip_ref_branch(&ref_str, "origin")
 }
 
 /// Fetch from a local path with an explicit refspec, leaving no remote configured.
@@ -184,16 +179,28 @@ pub fn fetch_from_path(dir: &Path, source_path: &Path, refspec: &str, prune: boo
 }
 
 /// Read the default branch from a bare mirror's refs/remotes/origin/HEAD.
+///
+/// Bare mirrors cloned with `git clone --bare` write `refs/remotes/origin/HEAD`
+/// as a symref pointing to `refs/heads/<branch>` (not `refs/remotes/origin/<branch>`).
+/// The `refs/heads/` fallback arm handles this case — it is load-bearing and must
+/// not be removed as "dead code".
 pub fn default_branch_from_mirror(mirror_dir: &Path) -> Result<String> {
     let ref_str = run(
         Some(mirror_dir),
         &["symbolic-ref", "refs/remotes/origin/HEAD"],
     )?;
+    strip_ref_branch(&ref_str, "origin")
+}
+
+/// Strip the remote-tracking or heads prefix from a symbolic-ref output, returning
+/// just the branch name (which may itself contain slashes, e.g. `release/2.x`).
+fn strip_ref_branch(ref_str: &str, remote: &str) -> Result<String> {
+    let remote_prefix = format!("refs/remotes/{}/", remote);
     ref_str
-        .strip_prefix("refs/remotes/origin/")
+        .strip_prefix(remote_prefix.as_str())
         .or_else(|| ref_str.strip_prefix("refs/heads/"))
-        .ok_or_else(|| anyhow::anyhow!("unexpected ref format: {}", ref_str))
         .map(str::to_string)
+        .ok_or_else(|| anyhow::anyhow!("unexpected ref format: {}", ref_str))
 }
 
 /// Check whether a named remote exists in a repo.
@@ -295,12 +302,7 @@ pub fn default_branch_for_remote(dir: &Path, remote: &str) -> Result<String> {
             .map_err(|e| anyhow::anyhow!("cannot detect default branch for {}: {}", remote, e))?,
     };
 
-    let remote_prefix = format!("refs/remotes/{}/", remote);
-    ref_str
-        .strip_prefix(remote_prefix.as_str())
-        .or_else(|| ref_str.strip_prefix("refs/heads/"))
-        .ok_or_else(|| anyhow::anyhow!("unexpected ref format: {}", ref_str))
-        .map(str::to_string)
+    strip_ref_branch(&ref_str, remote)
 }
 
 pub fn remote_set_head(dir: &Path, remote: &str, branch: &str) -> Result<()> {

--- a/crates/wsp-core/src/git.rs
+++ b/crates/wsp-core/src/git.rs
@@ -194,13 +194,24 @@ pub fn default_branch_from_mirror(mirror_dir: &Path) -> Result<String> {
 
 /// Strip the remote-tracking or heads prefix from a symbolic-ref output, returning
 /// just the branch name (which may itself contain slashes, e.g. `release/2.x`).
+///
+/// The `refs/heads/` fallback arm is load-bearing for all callers: bare mirror clones
+/// write `refs/remotes/origin/HEAD` pointing to `refs/heads/<branch>`, and the HEAD
+/// fallback in `default_branch` / `default_branch_for_remote` also returns a
+/// `refs/heads/` ref. Do not remove it as "dead code".
 fn strip_ref_branch(ref_str: &str, remote: &str) -> Result<String> {
+    anyhow::ensure!(!remote.is_empty(), "remote name must not be empty");
     let remote_prefix = format!("refs/remotes/{}/", remote);
-    ref_str
-        .strip_prefix(remote_prefix.as_str())
+    let branch = ref_str
+        .strip_prefix(&remote_prefix)
         .or_else(|| ref_str.strip_prefix("refs/heads/"))
-        .map(str::to_string)
-        .ok_or_else(|| anyhow::anyhow!("unexpected ref format: {}", ref_str))
+        .ok_or_else(|| anyhow::anyhow!("unexpected ref format: {}", ref_str))?;
+    anyhow::ensure!(
+        !branch.is_empty(),
+        "ref {} has an empty branch name",
+        ref_str
+    );
+    Ok(branch.to_string())
 }
 
 /// Check whether a named remote exists in a repo.
@@ -1505,5 +1516,70 @@ mod tests {
             "nonexistent ref must be Err, not Ok(None): {:?}",
             result
         );
+    }
+
+    // --- strip_ref_branch unit tests ---
+
+    #[test]
+    fn strip_ref_branch_simple_branch() {
+        assert_eq!(
+            strip_ref_branch("refs/remotes/origin/main", "origin").unwrap(),
+            "main"
+        );
+    }
+
+    #[test]
+    fn strip_ref_branch_slash_branch() {
+        // Branch names with slashes must not be truncated at the first slash.
+        assert_eq!(
+            strip_ref_branch("refs/remotes/origin/release/2.x", "origin").unwrap(),
+            "release/2.x"
+        );
+    }
+
+    #[test]
+    fn strip_ref_branch_heads_fallback() {
+        // Bare mirror clones write refs/heads/<branch> rather than refs/remotes/origin/<branch>.
+        assert_eq!(
+            strip_ref_branch("refs/heads/main", "origin").unwrap(),
+            "main"
+        );
+        assert_eq!(
+            strip_ref_branch("refs/heads/release/2.x", "origin").unwrap(),
+            "release/2.x"
+        );
+    }
+
+    #[test]
+    fn strip_ref_branch_wrong_remote_prefix_is_err() {
+        // A refs/remotes/upstream/… ref must not match when remote="origin".
+        let result = strip_ref_branch("refs/remotes/upstream/main", "origin");
+        assert!(
+            result.is_err(),
+            "wrong remote prefix should be Err: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn strip_ref_branch_unrecognized_prefix_is_err() {
+        let result = strip_ref_branch("refs/tags/v1.0", "origin");
+        assert!(
+            result.is_err(),
+            "unrecognized prefix should be Err: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn strip_ref_branch_empty_ref_is_err() {
+        let result = strip_ref_branch("", "origin");
+        assert!(result.is_err(), "empty ref should be Err: {:?}", result);
+    }
+
+    #[test]
+    fn strip_ref_branch_empty_remote_is_err() {
+        let result = strip_ref_branch("refs/remotes/origin/main", "");
+        assert!(result.is_err(), "empty remote should be Err: {:?}", result);
     }
 }

--- a/crates/wsp-core/src/git.rs
+++ b/crates/wsp-core/src/git.rs
@@ -162,11 +162,11 @@ pub fn default_branch(dir: &Path) -> Result<String> {
             .map_err(|e| anyhow::anyhow!("cannot detect default branch: {}", e))?,
     };
 
-    let parts: Vec<&str> = ref_str.split('/').collect();
-    if parts.len() < 3 {
-        bail!("unexpected ref format: {}", ref_str);
-    }
-    Ok(parts[parts.len() - 1].to_string())
+    ref_str
+        .strip_prefix("refs/remotes/origin/")
+        .or_else(|| ref_str.strip_prefix("refs/heads/"))
+        .ok_or_else(|| anyhow::anyhow!("unexpected ref format: {}", ref_str))
+        .map(str::to_string)
 }
 
 /// Fetch from a local path with an explicit refspec, leaving no remote configured.
@@ -189,11 +189,11 @@ pub fn default_branch_from_mirror(mirror_dir: &Path) -> Result<String> {
         Some(mirror_dir),
         &["symbolic-ref", "refs/remotes/origin/HEAD"],
     )?;
-    let parts: Vec<&str> = ref_str.split('/').collect();
-    if parts.len() < 3 {
-        bail!("unexpected ref format: {}", ref_str);
-    }
-    Ok(parts[parts.len() - 1].to_string())
+    ref_str
+        .strip_prefix("refs/remotes/origin/")
+        .or_else(|| ref_str.strip_prefix("refs/heads/"))
+        .ok_or_else(|| anyhow::anyhow!("unexpected ref format: {}", ref_str))
+        .map(str::to_string)
 }
 
 /// Check whether a named remote exists in a repo.
@@ -295,11 +295,12 @@ pub fn default_branch_for_remote(dir: &Path, remote: &str) -> Result<String> {
             .map_err(|e| anyhow::anyhow!("cannot detect default branch for {}: {}", remote, e))?,
     };
 
-    let parts: Vec<&str> = ref_str.split('/').collect();
-    if parts.len() < 3 {
-        bail!("unexpected ref format: {}", ref_str);
-    }
-    Ok(parts[parts.len() - 1].to_string())
+    let remote_prefix = format!("refs/remotes/{}/", remote);
+    ref_str
+        .strip_prefix(remote_prefix.as_str())
+        .or_else(|| ref_str.strip_prefix("refs/heads/"))
+        .ok_or_else(|| anyhow::anyhow!("unexpected ref format: {}", ref_str))
+        .map(str::to_string)
 }
 
 pub fn remote_set_head(dir: &Path, remote: &str, branch: &str) -> Result<()> {

--- a/crates/wsp-core/src/git.rs
+++ b/crates/wsp-core/src/git.rs
@@ -184,11 +184,26 @@ pub fn fetch_from_path(dir: &Path, source_path: &Path, refspec: &str, prune: boo
 /// as a symref pointing to `refs/heads/<branch>` (not `refs/remotes/origin/<branch>`).
 /// The `refs/heads/` fallback arm handles this case — it is load-bearing and must
 /// not be removed as "dead code".
+///
+/// When the symref target contains characters that git considers invalid (e.g. `*`),
+/// `git symbolic-ref` itself returns an error. In that case we read the loose-file
+/// symref directly so callers can inspect the raw value and reject it with a clear
+/// error message (the REFSPEC_UNSAFE guard in `clone_from_mirror` handles this).
 pub fn default_branch_from_mirror(mirror_dir: &Path) -> Result<String> {
     let ref_str = run(
         Some(mirror_dir),
         &["symbolic-ref", "refs/remotes/origin/HEAD"],
-    )?;
+    )
+    .or_else(|_| {
+        let path = mirror_dir.join("refs/remotes/origin/HEAD");
+        let content = std::fs::read_to_string(&path)
+            .with_context(|| format!("reading symref {}", path.display()))?;
+        content
+            .trim()
+            .strip_prefix("ref: ")
+            .map(str::to_string)
+            .ok_or_else(|| anyhow::anyhow!("not a symref: {}", path.display()))
+    })?;
     strip_ref_branch(&ref_str, "origin")
 }
 

--- a/crates/wsp-core/src/workspace.rs
+++ b/crates/wsp-core/src/workspace.rs
@@ -2152,11 +2152,24 @@ fn clone_from_mirror(
             // inconsistent with refs/heads/* (e.g. after an upstream default branch rename
             // with --prune). Attempt a targeted local re-fetch from the mirror before failing.
             if !git::ref_exists(&dest, &origin_ref) {
+                // Validate before inserting into a refspec — a branch name of `*` would
+                // fetch all refs, which is much wider than intended.
+                git::validate_branch_name(&default_br).with_context(|| {
+                    format!(
+                        "mirror default branch {:?} is not a valid branch name",
+                        default_br
+                    )
+                })?;
                 let refspec = format!(
                     "+refs/heads/{}:refs/remotes/origin/{}",
                     default_br, default_br
                 );
-                let _ = git::fetch_from_path(&dest, &mirror_dir, &refspec, false);
+                eprintln!(
+                    "  note: {} absent from dest clone, re-fetching from mirror",
+                    origin_ref
+                );
+                git::fetch_from_path(&dest, &mirror_dir, &refspec, false)
+                    .with_context(|| format!("re-fetch of {} from mirror failed", origin_ref))?;
             }
 
             if git::ref_exists(&dest, &origin_ref) {

--- a/crates/wsp-core/src/workspace.rs
+++ b/crates/wsp-core/src/workspace.rs
@@ -2145,44 +2145,46 @@ fn clone_from_mirror(
     // branch. Devs set tracking explicitly via `git push -u` after first push.
     match mirror_default_br {
         Some(default_br) => {
-            let origin_ref = format!("refs/remotes/origin/{}", default_br);
+            // Validate unconditionally — a branch name of `*` would produce a refspec
+            // that fetches all refs, which is much wider than intended.
+            git::validate_branch_name(&default_br).with_context(|| {
+                format!(
+                    "mirror default branch {:?} is not a valid branch name",
+                    default_br
+                )
+            })?;
+            // tracking_ref is the full canonical path used with ref_exists; start_point
+            // is the short form passed to `git checkout -b`. Step 6 above uses a
+            // different local named `origin_ref` holding the short form — keep them
+            // distinct to avoid confusion.
+            let tracking_ref = format!("refs/remotes/origin/{}", default_br);
             let start_point = format!("origin/{}", default_br);
 
-            // origin/<default> may be absent when the mirror's refs/remotes/origin/* are
+            // tracking_ref may be absent when the mirror's refs/remotes/origin/* are
             // inconsistent with refs/heads/* (e.g. after an upstream default branch rename
             // with --prune). Attempt a targeted local re-fetch from the mirror before failing.
-            if !git::ref_exists(&dest, &origin_ref) {
-                // Validate before inserting into a refspec — a branch name of `*` would
-                // fetch all refs, which is much wider than intended.
-                git::validate_branch_name(&default_br).with_context(|| {
-                    format!(
-                        "mirror default branch {:?} is not a valid branch name",
-                        default_br
-                    )
-                })?;
+            if !git::ref_exists(&dest, &tracking_ref) {
                 let refspec = format!(
                     "+refs/heads/{}:refs/remotes/origin/{}",
                     default_br, default_br
                 );
                 eprintln!(
                     "  note: {} absent from dest clone, re-fetching from mirror",
-                    origin_ref
+                    tracking_ref
                 );
                 git::fetch_from_path(&dest, &mirror_dir, &refspec, false)
-                    .with_context(|| format!("re-fetch of {} from mirror failed", origin_ref))?;
+                    .with_context(|| format!("re-fetch of {} from mirror failed", tracking_ref))?;
+                if !git::ref_exists(&dest, &tracking_ref) {
+                    bail!(
+                        "cannot create workspace branch from '{}': {} is still missing after \
+                         re-fetch — the mirror may be inconsistent; try `wsp doctor --fix`",
+                        default_br,
+                        tracking_ref
+                    );
+                }
             }
 
-            if git::ref_exists(&dest, &origin_ref) {
-                git::checkout_new_branch(&dest, branch, &start_point)?;
-            } else {
-                bail!(
-                    "cannot create workspace branch from '{}': {} is missing from the \
-                     dest clone and could not be fetched from the mirror — \
-                     the mirror may be inconsistent; try `wsp doctor --fix`",
-                    default_br,
-                    origin_ref
-                );
-            }
+            git::checkout_new_branch(&dest, branch, &start_point)?;
         }
         None => {
             // Empty repo — no branches exist yet. Create an orphan branch.

--- a/crates/wsp-core/src/workspace.rs
+++ b/crates/wsp-core/src/workspace.rs
@@ -2145,14 +2145,20 @@ fn clone_from_mirror(
     // branch. Devs set tracking explicitly via `git push -u` after first push.
     match mirror_default_br {
         Some(default_br) => {
-            // Validate unconditionally — a branch name of `*` would produce a refspec
-            // that fetches all refs, which is much wider than intended.
-            git::validate_branch_name(&default_br).with_context(|| {
-                format!(
-                    "mirror default branch {:?} is not a valid branch name",
+            // Guard against refspec metacharacters before building the targeted refspec
+            // below. The branch name originates from `git symbolic-ref` on a
+            // locally-owned mirror (already validated by git), so this is defence-in-depth
+            // rather than a trust boundary. A subprocess fork per clone would be wasteful;
+            // an inline check for the characters that git treats as refspec wildcards is
+            // sufficient and free.
+            const REFSPEC_UNSAFE: &[char] = &['*', ':', '?', '[', '\\'];
+            if default_br.chars().any(|c| REFSPEC_UNSAFE.contains(&c)) {
+                bail!(
+                    "mirror default branch {:?} contains characters that are unsafe in a git \
+                     refspec; the mirror may be corrupted",
                     default_br
-                )
-            })?;
+                );
+            }
             // tracking_ref is the full canonical path used with ref_exists; start_point
             // is the short form passed to `git checkout -b`. Step 6 above uses a
             // different local named `origin_ref` holding the short form — keep them
@@ -2876,6 +2882,196 @@ mod tests {
             &["merge-base", "--is-ancestor", "origin/release/2.x", "HEAD"],
         )
         .expect("workspace branch should be descended from origin/release/2.x");
+    }
+
+    #[test]
+    fn test_add_repos_with_non_main_default_branch() {
+        // add_repos calls clone_from_mirror through the same path as create_inner.
+        // Verify that adding a repo with a non-main default branch works correctly.
+        let (paths, _d, _r, main_identity, main_upstream_urls) = setup_test_env();
+
+        let main_refs = BTreeMap::from([(main_identity.clone(), String::new())]);
+        create(
+            &paths,
+            "add-non-main-ws",
+            &main_refs,
+            Some("jganoff"),
+            None,
+            &main_upstream_urls,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let ws_dir = dir(&paths.workspaces_dir, "add-non-main-ws");
+
+        let (_repo_dir, identity, refs, upstream_urls) =
+            setup_non_main_mirror(&paths, "master", "master-add-repo");
+
+        add_repos(&paths.mirrors_dir, &ws_dir, &refs, &upstream_urls, false).unwrap();
+
+        let meta = load_metadata(&ws_dir).unwrap();
+        let clone_dir = ws_dir.join(meta.dir_name(&identity).unwrap());
+        let head = git::run(Some(&clone_dir), &["symbolic-ref", "--short", "HEAD"]).unwrap();
+        assert_eq!(head, "jganoff/add-non-main-ws");
+
+        git::run(
+            Some(&clone_dir),
+            &["merge-base", "--is-ancestor", "origin/master", "HEAD"],
+        )
+        .expect("added repo branch should be descended from origin/master");
+    }
+
+    #[test]
+    fn test_add_repos_with_slash_default_branch() {
+        // add_repos must not truncate slash-containing branch names (e.g. release/2.x).
+        let (paths, _d, _r, main_identity, main_upstream_urls) = setup_test_env();
+
+        let main_refs = BTreeMap::from([(main_identity.clone(), String::new())]);
+        create(
+            &paths,
+            "add-slash-ws",
+            &main_refs,
+            Some("jganoff"),
+            None,
+            &main_upstream_urls,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let ws_dir = dir(&paths.workspaces_dir, "add-slash-ws");
+
+        let (_repo_dir, identity, refs, upstream_urls) =
+            setup_non_main_mirror(&paths, "release/2.x", "slash-add-repo");
+
+        add_repos(&paths.mirrors_dir, &ws_dir, &refs, &upstream_urls, false).unwrap();
+
+        let meta = load_metadata(&ws_dir).unwrap();
+        let clone_dir = ws_dir.join(meta.dir_name(&identity).unwrap());
+        let head = git::run(Some(&clone_dir), &["symbolic-ref", "--short", "HEAD"]).unwrap();
+        assert_eq!(head, "jganoff/add-slash-ws");
+
+        git::run(
+            Some(&clone_dir),
+            &["merge-base", "--is-ancestor", "origin/release/2.x", "HEAD"],
+        )
+        .expect("added repo branch should be descended from origin/release/2.x");
+    }
+
+    #[test]
+    fn test_create_fails_when_mirror_default_branch_is_missing() {
+        // Simulates a mirror where refs/remotes/origin/HEAD was updated (e.g. after
+        // an upstream rename + prune) to point to a branch that no longer exists
+        // in refs/heads/. create() must return Err rather than silently succeeding
+        // or panicking.
+        let tmp_data = tempfile::tempdir().unwrap();
+        let tmp_home = tempfile::tempdir().unwrap();
+        let data_dir = tmp_data.path().join("wsp");
+        let workspaces_dir = tmp_home.path().join("dev").join("workspaces");
+        fs::create_dir_all(&workspaces_dir).unwrap();
+        let paths = Paths::from_dirs(&data_dir, &workspaces_dir);
+
+        let (_repo_dir, _identity, refs, upstream_urls) =
+            setup_non_main_mirror(&paths, "master", "inconsistent-repo");
+
+        // Point the mirror's HEAD to a branch that was never fetched into refs/heads/.
+        let parsed = giturl::Parsed {
+            host: "test.local".into(),
+            owner: "user".into(),
+            repo: "inconsistent-repo".into(),
+        };
+        let mirror_dir = mirror::dir(&paths.mirrors_dir, &parsed);
+        let out = Command::new("git")
+            .args([
+                "symbolic-ref",
+                "refs/remotes/origin/HEAD",
+                "refs/heads/nonexistent-branch",
+            ])
+            .current_dir(&mirror_dir)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "corrupting HEAD symref: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        let result = create(
+            &paths,
+            "bad-ws",
+            &refs,
+            None,
+            None,
+            &upstream_urls,
+            None,
+            None,
+        );
+        assert!(
+            result.is_err(),
+            "create should fail when mirror HEAD points to a nonexistent branch"
+        );
+        let msg = format!("{:#}", result.unwrap_err());
+        assert!(
+            msg.contains("re-fetch") || msg.contains("nonexistent"),
+            "error should mention the failed re-fetch: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_create_fails_when_mirror_default_branch_has_refspec_metacharacter() {
+        // Simulates a corrupted mirror whose HEAD resolves to a branch name containing
+        // '*', which would turn the targeted refspec into a glob fetching all refs.
+        let tmp_data = tempfile::tempdir().unwrap();
+        let tmp_home = tempfile::tempdir().unwrap();
+        let data_dir = tmp_data.path().join("wsp");
+        let workspaces_dir = tmp_home.path().join("dev").join("workspaces");
+        fs::create_dir_all(&workspaces_dir).unwrap();
+        let paths = Paths::from_dirs(&data_dir, &workspaces_dir);
+
+        let (_repo_dir, _identity, refs, upstream_urls) =
+            setup_non_main_mirror(&paths, "master", "wildcard-repo");
+
+        let parsed = giturl::Parsed {
+            host: "test.local".into(),
+            owner: "user".into(),
+            repo: "wildcard-repo".into(),
+        };
+        let mirror_dir = mirror::dir(&paths.mirrors_dir, &parsed);
+        // Write a HEAD that resolves to `*` — strip_ref_branch strips the prefix,
+        // leaving a branch name of `*` which the inline metacharacter guard must reject.
+        let out = Command::new("git")
+            .args(["symbolic-ref", "refs/remotes/origin/HEAD", "refs/heads/*"])
+            .current_dir(&mirror_dir)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "corrupting HEAD symref: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        let result = create(
+            &paths,
+            "wildcard-ws",
+            &refs,
+            None,
+            None,
+            &upstream_urls,
+            None,
+            None,
+        );
+        assert!(
+            result.is_err(),
+            "create should fail when mirror HEAD contains a refspec metacharacter"
+        );
+        let msg = format!("{:#}", result.unwrap_err());
+        assert!(
+            msg.contains("unsafe") || msg.contains("metacharacter") || msg.contains("corrupted"),
+            "error should mention the unsafe branch name: {}",
+            msg
+        );
     }
 
     #[test]

--- a/crates/wsp-core/src/workspace.rs
+++ b/crates/wsp-core/src/workspace.rs
@@ -2145,8 +2145,31 @@ fn clone_from_mirror(
     // branch. Devs set tracking explicitly via `git push -u` after first push.
     match mirror_default_br {
         Some(default_br) => {
+            let origin_ref = format!("refs/remotes/origin/{}", default_br);
             let start_point = format!("origin/{}", default_br);
-            git::checkout_new_branch(&dest, branch, &start_point)?;
+
+            // origin/<default> may be absent when the mirror's refs/remotes/origin/* are
+            // inconsistent with refs/heads/* (e.g. after an upstream default branch rename
+            // with --prune). Attempt a targeted local re-fetch from the mirror before failing.
+            if !git::ref_exists(&dest, &origin_ref) {
+                let refspec = format!(
+                    "+refs/heads/{}:refs/remotes/origin/{}",
+                    default_br, default_br
+                );
+                let _ = git::fetch_from_path(&dest, &mirror_dir, &refspec, false);
+            }
+
+            if git::ref_exists(&dest, &origin_ref) {
+                git::checkout_new_branch(&dest, branch, &start_point)?;
+            } else {
+                bail!(
+                    "cannot create workspace branch from '{}': {} is missing from the \
+                     dest clone and could not be fetched from the mirror — \
+                     the mirror may be inconsistent; try `wsp doctor --fix`",
+                    default_br,
+                    origin_ref
+                );
+            }
         }
         None => {
             // Empty repo — no branches exist yet. Create an orphan branch.
@@ -2690,6 +2713,149 @@ mod tests {
         let clone_dir = ws_dir.join(meta.dir_name(&identity).unwrap());
         let head = git::run(Some(&clone_dir), &["symbolic-ref", "--short", "HEAD"]).unwrap();
         assert_eq!(head, "jganoff/empty-ws");
+    }
+
+    fn setup_non_main_mirror(
+        paths: &Paths,
+        branch: &str,
+        repo_name: &str,
+    ) -> (tempfile::TempDir, String, BTreeMap<String, String>, BTreeMap<String, String>) {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init_branch = format!("--initial-branch={}", branch);
+        let cmds: Vec<Vec<&str>> = vec![
+            vec!["git", "init", &init_branch],
+            vec!["git", "config", "user.email", "test@test.com"],
+            vec!["git", "config", "user.name", "Test"],
+            vec!["git", "config", "commit.gpgsign", "false"],
+            vec!["git", "commit", "--allow-empty", "-m", "initial"],
+        ];
+        for args in &cmds {
+            let output = Command::new(args[0])
+                .args(&args[1..])
+                .current_dir(repo_dir.path())
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "command {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        let parsed = giturl::Parsed {
+            host: "test.local".into(),
+            owner: "user".into(),
+            repo: repo_name.into(),
+        };
+        mirror::clone(
+            &paths.mirrors_dir,
+            &parsed,
+            repo_dir.path().to_str().unwrap(),
+        )
+        .unwrap();
+
+        let mirror_dir = mirror::dir(&paths.mirrors_dir, &parsed);
+        let head_target = format!("refs/heads/{}", branch);
+        let output = Command::new("git")
+            .args(["symbolic-ref", "refs/remotes/origin/HEAD", &head_target])
+            .current_dir(&mirror_dir)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "setting HEAD ref: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let identity = parsed.identity();
+        let refs = BTreeMap::from([(identity.clone(), String::new())]);
+        let upstream_urls = BTreeMap::from([(
+            identity.clone(),
+            repo_dir.path().to_str().unwrap().to_string(),
+        )]);
+        (repo_dir, identity, refs, upstream_urls)
+    }
+
+    #[test]
+    fn test_create_with_non_main_default_branch() {
+        let tmp_data = tempfile::tempdir().unwrap();
+        let tmp_home = tempfile::tempdir().unwrap();
+        let data_dir = tmp_data.path().join("wsp");
+        let workspaces_dir = tmp_home.path().join("dev").join("workspaces");
+        fs::create_dir_all(&workspaces_dir).unwrap();
+        let paths = Paths::from_dirs(&data_dir, &workspaces_dir);
+
+        let (_repo_dir, identity, refs, upstream_urls) =
+            setup_non_main_mirror(&paths, "master", "master-repo");
+
+        create(
+            &paths,
+            "master-ws",
+            &refs,
+            Some("jganoff"),
+            None,
+            &upstream_urls,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let ws_dir = dir(&paths.workspaces_dir, "master-ws");
+        let meta = load_metadata(&ws_dir).unwrap();
+        assert_eq!(meta.branch, "jganoff/master-ws");
+
+        let clone_dir = ws_dir.join(meta.dir_name(&identity).unwrap());
+        let head = git::run(Some(&clone_dir), &["symbolic-ref", "--short", "HEAD"]).unwrap();
+        assert_eq!(head, "jganoff/master-ws");
+
+        // Workspace branch must be descended from master, not an orphan.
+        git::run(
+            Some(&clone_dir),
+            &["merge-base", "--is-ancestor", "origin/master", "HEAD"],
+        )
+        .expect("workspace branch should be descended from origin/master");
+    }
+
+    #[test]
+    fn test_create_with_slash_default_branch() {
+        // Branch names containing slashes (e.g. release/2.x) must parse correctly;
+        // the old split('/').last() parser truncated them to just '2.x'.
+        let tmp_data = tempfile::tempdir().unwrap();
+        let tmp_home = tempfile::tempdir().unwrap();
+        let data_dir = tmp_data.path().join("wsp");
+        let workspaces_dir = tmp_home.path().join("dev").join("workspaces");
+        fs::create_dir_all(&workspaces_dir).unwrap();
+        let paths = Paths::from_dirs(&data_dir, &workspaces_dir);
+
+        let (_repo_dir, identity, refs, upstream_urls) =
+            setup_non_main_mirror(&paths, "release/2.x", "slash-branch-repo");
+
+        create(
+            &paths,
+            "slash-ws",
+            &refs,
+            Some("jganoff"),
+            None,
+            &upstream_urls,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let ws_dir = dir(&paths.workspaces_dir, "slash-ws");
+        let meta = load_metadata(&ws_dir).unwrap();
+        assert_eq!(meta.branch, "jganoff/slash-ws");
+
+        let clone_dir = ws_dir.join(meta.dir_name(&identity).unwrap());
+        let head = git::run(Some(&clone_dir), &["symbolic-ref", "--short", "HEAD"]).unwrap();
+        assert_eq!(head, "jganoff/slash-ws");
+
+        git::run(
+            Some(&clone_dir),
+            &["merge-base", "--is-ancestor", "origin/release/2.x", "HEAD"],
+        )
+        .expect("workspace branch should be descended from origin/release/2.x");
     }
 
     #[test]

--- a/crates/wsp-core/src/workspace.rs
+++ b/crates/wsp-core/src/workspace.rs
@@ -3039,18 +3039,16 @@ mod tests {
             repo: "wildcard-repo".into(),
         };
         let mirror_dir = mirror::dir(&paths.mirrors_dir, &parsed);
-        // Write a HEAD that resolves to `*` — strip_ref_branch strips the prefix,
-        // leaving a branch name of `*` which the inline metacharacter guard must reject.
-        let out = Command::new("git")
-            .args(["symbolic-ref", "refs/remotes/origin/HEAD", "refs/heads/*"])
-            .current_dir(&mirror_dir)
-            .output()
-            .unwrap();
-        assert!(
-            out.status.success(),
-            "corrupting HEAD symref: {}",
-            String::from_utf8_lossy(&out.stderr)
-        );
+        // Write the symref file directly: `*` is not a valid git ref name so
+        // `git symbolic-ref` would reject it, but git reads the file as-is.
+        // strip_ref_branch will strip `refs/heads/` leaving `*`, which the
+        // inline metacharacter guard in clone_from_mirror must reject.
+        let head_path = mirror_dir
+            .join("refs")
+            .join("remotes")
+            .join("origin")
+            .join("HEAD");
+        fs::write(&head_path, "ref: refs/heads/*\n").unwrap();
 
         let result = create(
             &paths,

--- a/crates/wsp-core/src/workspace.rs
+++ b/crates/wsp-core/src/workspace.rs
@@ -2719,7 +2719,12 @@ mod tests {
         paths: &Paths,
         branch: &str,
         repo_name: &str,
-    ) -> (tempfile::TempDir, String, BTreeMap<String, String>, BTreeMap<String, String>) {
+    ) -> (
+        tempfile::TempDir,
+        String,
+        BTreeMap<String, String>,
+        BTreeMap<String, String>,
+    ) {
         let repo_dir = tempfile::tempdir().unwrap();
         let init_branch = format!("--initial-branch={}", branch);
         let cmds: Vec<Vec<&str>> = vec![


### PR DESCRIPTION
## Summary

- Fixes `wsp new` and `wsp repo add` failing with `fatal: 'origin/<branch>' is not a commit` when a repo's default branch is not `main`
- Fixes a parsing bug in `default_branch_from_mirror`, `default_branch`, and `default_branch_for_remote` where `split('/').last()` truncated slash-containing branch names (e.g. `release/2.x` → `2.x`)

**Root cause:** `clone_from_mirror` step 7 used `origin/<default>` as a start point without verifying the ref was actually populated in the dest clone. When a mirror's `refs/remotes/origin/*` were inconsistent with `refs/heads/*` (e.g. after an upstream default branch rename with `--prune`), the ref was missing and git died with a fatal error.

**Fix:**
- Guard `origin/<default>` with `ref_exists` before use
- If absent, attempt a targeted local re-fetch from the mirror (`+refs/heads/<default>:refs/remotes/origin/<default>`)
- Bail with a clear, actionable error if still missing after re-fetch
- Replace `split('/').last()` with `strip_prefix` on the known ref namespace in all three parsing functions

## Test plan

- [ ] `test_create_with_non_main_default_branch` — creates workspace from repo with `master` default branch
- [x] `test_create_with_slash_default_branch` — creates workspace from repo with `release/2.x` default branch (validates parser fix)
- [x] `test_create_with_empty_repo` — existing orphan-branch test still passes
- [x] Full CI test suite

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)