### PR TITLE
fix: actionable warning when a workspace repo has no mirror

### DIFF
--- a/crates/wsp-core/src/workspace.rs
+++ b/crates/wsp-core/src/workspace.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result, bail};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::config::Paths;
+use crate::config::{Config, Paths};
 use crate::filelock;
 use crate::git;
 use crate::giturl;
@@ -1137,47 +1137,125 @@ impl Metadata {
 
 const MIRROR_PROPAGATE_REFSPEC: &str = "+refs/remotes/origin/*:refs/remotes/origin/*";
 
+/// A workspace repo queued for mirror ref propagation.
+struct PropagationTarget {
+    identity: String,
+    dir_name: String,
+    clone_dir: PathBuf,
+    mirror_dir: PathBuf,
+    /// Whether the identity is present in the global registry.
+    registered: bool,
+}
+
+/// Warning for a workspace repo whose clone directory is gone.
+///
+/// Without this the fetch below fails with a bare `No such file or directory`
+/// from the process spawn, which says nothing about the workspace.
+fn missing_clone_warning(identity: &str, dir_name: &str) -> String {
+    format!(
+        "  warning: {}: clone directory '{}' is missing, skipping mirror ref propagation\n  \
+         hint: run `wsp doctor` to inspect, or `wsp repo rm {}` to remove it from this workspace",
+        identity, dir_name, dir_name
+    )
+}
+
+/// Warning for a workspace repo that has no mirror to propagate from.
+///
+/// A missing mirror almost always means the identity was never registered (so
+/// no mirror was ever cloned); the mirror being deleted out from under a
+/// registered repo is the rarer case. Both surface as the same opaque
+/// `does not appear to be a git repository` fatal from `git fetch`, so name the
+/// cause and the fix instead of letting git's error through.
+///
+/// The mirror path is deliberately not shown — mirrors are invisible
+/// infrastructure, and `wsp doctor --fix` is the remedy either way.
+fn missing_mirror_warning(identity: &str, dir_name: &str, registered: bool) -> String {
+    if registered {
+        format!(
+            "  warning: {}: mirror is missing, skipping mirror ref propagation\n  \
+             hint: run `wsp doctor --fix` to re-clone the mirror",
+            identity
+        )
+    } else {
+        format!(
+            "  warning: {} is referenced by this workspace but is not registered, \
+             skipping mirror ref propagation\n  \
+             hint: run `wsp doctor --fix` to register it from the clone's origin URL, \
+             or `wsp repo rm {}` to remove it from this workspace",
+            identity, dir_name
+        )
+    }
+}
+
 /// Propagate mirror refs into workspace clones (parallel, best-effort).
 /// Fetches `refs/remotes/origin/*` from the mirror into each clone's `origin/*`.
 /// Also removes the legacy `wsp-mirror` remote if present.
 /// Callers wanting deleted-branch cleanup should pass `prune: true`.
-pub fn propagate_mirror_to_clones(mirrors_dir: &Path, ws_dir: &Path, meta: &Metadata, prune: bool) {
-    let clones: Vec<(String, PathBuf, PathBuf)> = meta
+///
+/// Repos without a usable clone or mirror are skipped with an actionable
+/// warning on stderr; `cfg` is only consulted to tell an unregistered repo apart
+/// from a registered one whose mirror went missing.
+pub fn propagate_mirror_to_clones(
+    mirrors_dir: &Path,
+    ws_dir: &Path,
+    meta: &Metadata,
+    cfg: &Config,
+    prune: bool,
+) {
+    let targets: Vec<PropagationTarget> = meta
         .repos
         .keys()
         .filter_map(|id| {
             let dn = meta.dir_name(id).ok()?;
             let parsed = parse_identity(id).ok()?;
-            let mirror_path = mirror::dir(mirrors_dir, &parsed);
-            Some((id.clone(), ws_dir.join(dn), mirror_path))
+            Some(PropagationTarget {
+                identity: id.clone(),
+                clone_dir: ws_dir.join(&dn),
+                dir_name: dn,
+                mirror_dir: mirror::dir(mirrors_dir, &parsed),
+                registered: cfg.repos.contains_key(id),
+            })
         })
         .collect();
 
-    if clones.is_empty() {
+    if targets.is_empty() {
         return;
     }
 
     std::thread::scope(|s| {
-        let handles: Vec<_> = clones
+        let handles: Vec<_> = targets
             .iter()
-            .map(|(id, clone_dir, mirror_path)| {
+            .map(|t| {
                 s.spawn(move || {
-                    remove_legacy_wsp_mirror(clone_dir);
-                    if let Err(e) = git::fetch_from_path(
-                        clone_dir,
-                        mirror_path,
+                    if !t.clone_dir.exists() {
+                        return Some(missing_clone_warning(&t.identity, &t.dir_name));
+                    }
+                    remove_legacy_wsp_mirror(&t.clone_dir);
+                    if !t.mirror_dir.exists() {
+                        return Some(missing_mirror_warning(
+                            &t.identity,
+                            &t.dir_name,
+                            t.registered,
+                        ));
+                    }
+                    git::fetch_from_path(
+                        &t.clone_dir,
+                        &t.mirror_dir,
                         MIRROR_PROPAGATE_REFSPEC,
                         prune,
-                    ) {
-                        eprintln!("  warning: propagate mirror for {}: {}", id, e);
-                    }
+                    )
+                    .err()
+                    .map(|e| format!("  warning: propagate mirror for {}: {}", t.identity, e))
                 })
             })
             .collect();
+        // Print after joining so warnings from parallel fetches don't interleave.
         for h in handles {
-            h.join().unwrap_or_else(|_| {
-                eprintln!("warning: propagate thread panicked");
-            });
+            match h.join() {
+                Ok(Some(warning)) => eprintln!("{}", warning),
+                Ok(None) => {}
+                Err(_) => eprintln!("warning: propagate thread panicked"),
+            }
         }
     });
 }
@@ -5421,11 +5499,56 @@ mod tests {
 
         // Propagate
         let meta = load_metadata(&ws_dir).unwrap();
-        propagate_mirror_to_clones(&paths.mirrors_dir, &ws_dir, &meta, false);
+        propagate_mirror_to_clones(
+            &paths.mirrors_dir,
+            &ws_dir,
+            &meta,
+            &Config::default(),
+            false,
+        );
 
         // After propagation, clone should have the new commit at origin/main
         let clone_sha_after = git::run(Some(&clone_dir), &["rev-parse", "origin/main"]).unwrap();
         assert_eq!(clone_sha_after, mirror_sha);
+    }
+
+    /// A missing mirror is skipped with a warning (see the `wsp cd` integration
+    /// tests for the message itself) and must leave the clone untouched.
+    #[test]
+    fn test_propagate_skips_missing_mirror() {
+        let (paths, _d, _r, identity, upstream_urls) = setup_test_env();
+
+        let refs = BTreeMap::from([(identity.clone(), String::new())]);
+        create(
+            &paths,
+            "prop-no-mirror",
+            &refs,
+            None,
+            None,
+            &upstream_urls,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let ws_dir = dir(&paths.workspaces_dir, "prop-no-mirror");
+        let clone_dir = ws_dir.join("test-repo");
+        let sha_before = git::run(Some(&clone_dir), &["rev-parse", "origin/main"]).unwrap();
+
+        let parsed = parse_identity(&identity).unwrap();
+        fs::remove_dir_all(mirror::dir(&paths.mirrors_dir, &parsed)).unwrap();
+
+        let meta = load_metadata(&ws_dir).unwrap();
+        propagate_mirror_to_clones(
+            &paths.mirrors_dir,
+            &ws_dir,
+            &meta,
+            &Config::default(),
+            false,
+        );
+
+        let sha_after = git::run(Some(&clone_dir), &["rev-parse", "origin/main"]).unwrap();
+        assert_eq!(sha_before, sha_after, "clone refs should be untouched");
     }
 
     #[test]
@@ -5463,7 +5586,13 @@ mod tests {
 
         // Propagate
         let meta = load_metadata(&ws_dir).unwrap();
-        propagate_mirror_to_clones(&paths.mirrors_dir, &ws_dir, &meta, false);
+        propagate_mirror_to_clones(
+            &paths.mirrors_dir,
+            &ws_dir,
+            &meta,
+            &Config::default(),
+            false,
+        );
 
         // wsp-mirror should have been removed
         assert!(
@@ -5510,7 +5639,13 @@ mod tests {
 
         git::fetch(&mirror_dir, true).unwrap();
         let meta = load_metadata(&ws_dir).unwrap();
-        propagate_mirror_to_clones(&paths.mirrors_dir, &ws_dir, &meta, false);
+        propagate_mirror_to_clones(
+            &paths.mirrors_dir,
+            &ws_dir,
+            &meta,
+            &Config::default(),
+            false,
+        );
 
         // Clone should now see origin/feature-x
         assert!(
@@ -5535,7 +5670,7 @@ mod tests {
         git::fetch(&mirror_dir, true).unwrap();
 
         // Propagate with prune=true — should remove stale origin/feature-x
-        propagate_mirror_to_clones(&paths.mirrors_dir, &ws_dir, &meta, true);
+        propagate_mirror_to_clones(&paths.mirrors_dir, &ws_dir, &meta, &Config::default(), true);
 
         assert!(
             !git::ref_exists(&clone_dir, "refs/remotes/origin/feature-x"),

--- a/crates/wsp/src/cli/cd.rs
+++ b/crates/wsp/src/cli/cd.rs
@@ -2,7 +2,7 @@ use anyhow::{Result, bail};
 use clap::{Arg, ArgMatches, Command};
 use clap_complete::engine::ArgValueCandidates;
 
-use wsp_core::config::Paths;
+use wsp_core::config::{Config, Paths};
 use wsp_core::output::{Output, PathOutput};
 use wsp_core::workspace;
 
@@ -31,9 +31,11 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
         bail!("workspace '{}' not found", name);
     }
 
-    // Propagate mirror refs to clones
+    // Propagate mirror refs to clones. Best-effort: a broken config only costs
+    // the registered/unregistered distinction in the skip warnings.
     if let Ok(meta) = workspace::load_metadata(&ws_dir) {
-        workspace::propagate_mirror_to_clones(&paths.mirrors_dir, &ws_dir, &meta, false);
+        let cfg = Config::load_from(&paths.config_path).unwrap_or_default();
+        workspace::propagate_mirror_to_clones(&paths.mirrors_dir, &ws_dir, &meta, &cfg, false);
     }
 
     if std::env::var("WSP_SHELL").is_err() {

--- a/crates/wsp/src/cli/doctor.rs
+++ b/crates/wsp/src/cli/doctor.rs
@@ -953,10 +953,8 @@ fn check_legacy_ref_field(
     let fixable = true;
     if fix {
         match wsp_core::filelock::with_metadata(ws_dir, |m| {
-            for (_, ref_opt) in m.repos.iter_mut() {
-                if let Some(repo_ref) = ref_opt {
-                    repo_ref.r#ref = String::new();
-                }
+            for repo_ref in m.repos.values_mut().flatten() {
+                repo_ref.r#ref = String::new();
             }
             Ok(())
         }) {

--- a/crates/wsp/src/cli/fetch.rs
+++ b/crates/wsp/src/cli/fetch.rs
@@ -53,9 +53,17 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
         None
     };
 
+    // Loaded once: --all reads the repo list from it, and ref propagation uses
+    // it to tell an unregistered repo from a registered one whose mirror is
+    // gone. A workspace-scoped fetch still works without a readable config —
+    // only the precision of that warning suffers.
+    let cfg = match config::Config::load_from(&paths.config_path) {
+        Ok(cfg) => cfg,
+        Err(e) if all => bail!("loading config: {}", e),
+        Err(_) => config::Config::default(),
+    };
+
     let identities: Vec<String> = if all {
-        let cfg = config::Config::load_from(&paths.config_path)
-            .map_err(|e| anyhow::anyhow!("loading config: {}", e))?;
         cfg.repos.keys().cloned().collect()
     } else {
         match &current_ws {
@@ -149,13 +157,14 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
                         &paths.mirrors_dir,
                         &ws_dir,
                         &meta,
+                        &cfg,
                         prune,
                     );
                 }
             }
         }
     } else if let Some((ws_dir, meta)) = &current_ws {
-        workspace::propagate_mirror_to_clones(&paths.mirrors_dir, ws_dir, meta, prune);
+        workspace::propagate_mirror_to_clones(&paths.mirrors_dir, ws_dir, meta, &cfg, prune);
     }
 
     let output = FetchOutput {

--- a/crates/wsp/src/cli/sync.rs
+++ b/crates/wsp/src/cli/sync.rs
@@ -140,7 +140,7 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
         // Phase 1b: Propagate mirror refs to clones (runs for all repos, including
         // those whose mirror fetch failed — stale mirror data is still useful and
         // propagation is a local no-op when nothing changed).
-        workspace::propagate_mirror_to_clones(&paths.mirrors_dir, &ws_dir, &meta, true);
+        workspace::propagate_mirror_to_clones(&paths.mirrors_dir, &ws_dir, &meta, &cfg, true);
 
         results
             .into_iter()

--- a/crates/wsp/tests/mirror_propagation_warning.rs
+++ b/crates/wsp/tests/mirror_propagation_warning.rs
@@ -1,0 +1,164 @@
+/// Integration tests for the mirror-propagation skip warnings.
+///
+/// When a workspace repo has no mirror — usually because its slug was never
+/// added to the global registry — `wsp cd` used to dump a raw `git fetch` fatal
+/// ("does not appear to be a git repository") that said nothing about the
+/// missing registry entry. These tests run the actual binary and assert the
+/// warning names the cause and the fix instead.
+use assert_cmd::Command;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use wsp_core::config::{Config, RepoEntry};
+use wsp_core::workspace;
+
+const IDENTITY: &str = "github.com/acme/widgets";
+const WS_NAME: &str = "my-feature";
+const RAW_GIT_FATAL: &str = "does not appear to be a git repository";
+
+struct Env {
+    _tmp: tempfile::TempDir,
+    xdg_data_home: PathBuf,
+    ws_dir: PathBuf,
+    clone_dir: PathBuf,
+}
+
+fn git(dir: &Path, args: &[&str]) {
+    let out = std::process::Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Build a workspace holding one repo clone whose mirror does not exist.
+/// `registered` controls whether the repo identity is in the global registry.
+fn setup(registered: bool) -> Env {
+    let tmp = tempfile::tempdir().unwrap();
+    let xdg_data_home = tmp.path().join("data");
+    let data_dir = xdg_data_home.join("wsp");
+    let workspaces_dir = tmp.path().join("workspaces");
+    fs::create_dir_all(&data_dir).unwrap();
+    fs::create_dir_all(&workspaces_dir).unwrap();
+
+    let mut cfg = Config {
+        workspaces_dir: Some(workspaces_dir.display().to_string()),
+        ..Default::default()
+    };
+    if registered {
+        cfg.repos.insert(
+            IDENTITY.to_string(),
+            RepoEntry {
+                url: "git@test.local:acme/widgets.git".to_string(),
+                added: chrono::Utc::now(),
+                setup_commands: None,
+            },
+        );
+    }
+    cfg.save_to(&data_dir.join("config.yaml")).unwrap();
+
+    let ws_dir = workspaces_dir.join(WS_NAME);
+    let clone_dir = ws_dir.join("widgets");
+    fs::create_dir_all(&clone_dir).unwrap();
+    git(&clone_dir, &["init", "--initial-branch=main"]);
+
+    let meta = workspace::Metadata {
+        version: 0,
+        name: WS_NAME.to_string(),
+        branch: format!("test/{WS_NAME}"),
+        repos: BTreeMap::from([(IDENTITY.to_string(), None)]),
+        created: chrono::Utc::now(),
+        description: None,
+        last_used: None,
+        created_from: None,
+        dirs: BTreeMap::new(),
+        config: None,
+        setup_commands: BTreeMap::new(),
+    };
+    workspace::save_metadata(&ws_dir, &meta).unwrap();
+
+    Env {
+        _tmp: tmp,
+        xdg_data_home,
+        ws_dir,
+        clone_dir,
+    }
+}
+
+/// Run `wsp cd <workspace>` and return stderr.
+fn run_cd(env: &Env) -> String {
+    let assert = Command::cargo_bin("wsp")
+        .unwrap()
+        .env("XDG_DATA_HOME", &env.xdg_data_home)
+        .env("NO_COLOR", "1")
+        .current_dir(&env.ws_dir)
+        .args(["cd", WS_NAME])
+        .assert()
+        .success();
+    String::from_utf8(assert.get_output().stderr.clone()).unwrap()
+}
+
+#[test]
+fn unregistered_repo_warning_names_registry_and_fix() {
+    let env = setup(/* registered */ false);
+    let stderr = run_cd(&env);
+
+    assert!(
+        stderr.contains(IDENTITY) && stderr.contains("not registered"),
+        "stderr should name the unregistered repo, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("wsp doctor --fix") && stderr.contains("wsp repo rm widgets"),
+        "stderr should offer both remedies, got:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains(RAW_GIT_FATAL),
+        "raw git fatal should not leak, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn registered_repo_with_missing_mirror_warns_about_the_mirror() {
+    let env = setup(/* registered */ true);
+    let stderr = run_cd(&env);
+
+    assert!(
+        stderr.contains(IDENTITY) && stderr.contains("mirror"),
+        "stderr should name the missing mirror, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("wsp doctor --fix"),
+        "stderr should offer a fix, got:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("not registered"),
+        "a registered repo should not be reported as unregistered, got:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains(RAW_GIT_FATAL),
+        "raw git fatal should not leak, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn missing_clone_directory_warns_instead_of_failing_the_spawn() {
+    let env = setup(/* registered */ true);
+    fs::remove_dir_all(&env.clone_dir).unwrap();
+    let stderr = run_cd(&env);
+
+    assert!(
+        stderr.contains("clone directory 'widgets' is missing"),
+        "stderr should name the missing clone dir, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("wsp doctor"),
+        "stderr should offer a fix, got:\n{stderr}"
+    );
+}


### PR DESCRIPTION
Fixes #63.

## Problem

`cd`-ing into a workspace whose `.wsp.yaml` references a repo that isn't in the global registry dumped a raw git fatal from the mirror-propagation hook:

```
warning: propagate mirror for github.com/<owner>/<repo>: git fetch -- ~/.local/share/wsp/mirrors/... (in ~/dev/workspaces/<ws>/<repo>): exit status: 128
fatal: '~/.local/share/wsp/mirrors/github.com/<owner>/<repo>.git' does not appear to be a git repository
fatal: Could not read from remote repository.
```

`wsp doctor` already diagnoses this cleanly; the cd hook did not.

## Change

`workspace::propagate_mirror_to_clones` now pre-flights each repo instead of letting `git fetch` fail:

| Situation | New output |
|---|---|
| Repo not in registry | `warning: <identity> is referenced by this workspace but is not registered, skipping mirror ref propagation` + hint: `wsp doctor --fix` to register from the clone's origin URL, or `wsp repo rm <repo>` |
| Registered, mirror gone | `warning: <identity>: mirror is missing, skipping mirror ref propagation` + hint: `wsp doctor --fix` to re-clone |
| Clone directory gone | `warning: <identity>: clone directory '<dir>' is missing…` — previously a bare `No such file or directory` from the process spawn |

Both remedies are ones `wsp doctor --fix` already implements (register from clone origin; re-clone a missing mirror), so the hint is actionable as written.

Notes:

- Telling the unregistered case apart from a missing mirror needs the registry, so the function takes a `&Config`. `sync` already had one loaded; `fetch` now loads it once but still tolerates an unreadable config for workspace-scoped fetches (only `--all` bails, as before); `cd` loads it best-effort.
- Warnings print after the propagation threads join, so parallel fetches can't interleave output.
- The mirror path is deliberately not shown — "mirrors are invisible infrastructure," and `wsp doctor --fix` is the remedy either way.

This covers `wsp fetch` and `wsp sync` too, since they share the same function; the issue only reported `cd`.

## Tests

- `crates/wsp/tests/mirror_propagation_warning.rs` (new): three binary-level tests that run `wsp cd` against a workspace with no mirror and assert both the actionable text and the absence of the raw git fatal. Same style as `gc_warning.rs`.
- `test_propagate_skips_missing_mirror`: a missing mirror leaves the clone's refs untouched.

`just check`, `just check-cross`, `just build`, `just test` (649 tests) pass; SKILL.md is fresh. `cargo audit` was not run locally (cargo-audit not installed).

The first commit is an unrelated one-line clippy fix in `doctor.rs` — current stable clippy flags pre-existing `for_kv_map`/`manual_flatten` there, which breaks `just check` (and the pre-commit hook) on a clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)