### PR TITLE
ci: add Dependabot for SHA-pinned workflow actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+
+# Workflow actions are pinned to full commit SHAs (see .github/workflows/*.yml)
+# so that a moved tag cannot swap in different code. Pinning alone is only half
+# the job: without something to advance the pins they silently rot, and upstream
+# security and bug fixes never arrive. AGENTS.md calls for Dependabot to be that
+# something.
+#
+# Reviewing these PRs is the point. Merging them unread re-creates floating tags
+# with extra steps — Dependabot moves a pin, it does not vet what changed.
+#
+# KNOWN INTERACTION WITH release.yml: Dependabot scans every workflow file and
+# cannot be scoped to a subset, so it will also propose bumps to release.yml —
+# which cargo-dist owns and regenerates (it currently uses floating tags such as
+# actions/checkout@v4, the SHA pins added in c81eb93 having been overwritten).
+# A Dependabot PR touching release.yml will fail the `dist plan` freshness check.
+# That failure is loud and self-explanatory: close the PR and bump cargo-dist
+# instead, rather than hand-editing release.yml.
+#
+# Cargo is deliberately absent. Dependency advisories are covered by
+# .github/workflows/audit.yml (nightly) and by CI's per-push audit, which also
+# catch informational advisories such as `unsound` that never become GHSA
+# vulnerabilities and so would not trigger a Dependabot security update.
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    # Actions release rarely, so the interval mostly sets detection latency;
+    # grouping is what keeps this to one PR and one CI run per week.
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Workflow actions are pinned to full commit SHAs (`.github/workflows/*.yml`) so a moved tag cannot swap in different code. Pinning alone is only half the job: nothing advances those pins, so they rot silently and upstream security and bug fixes never arrive.

AGENTS.md already calls for exactly this (line 106) — *"If you need SHA-pinned actions, use Dependabot (`dependabot.yml`, ecosystem `github-actions`)"*. The config was simply never added.

**Grouped**, so all action bumps land in one PR and one CI run per week. Worth being precise about why: the interval mostly sets detection latency, since actions release rarely and Dependabot only opens a PR when an upstream release exists. Grouping, not frequency, is what governs noise.

**Cargo is deliberately excluded.** Advisories are already covered by the nightly audit (#72) and CI's per-push audit — and those catch strictly more. RUSTSEC-2026-0190, the advisory that just broke `main`, was classified `unsound` rather than a vulnerability, so it never became a GHSA entry and a Dependabot security update would **not** have fired for it. Adding the cargo ecosystem would bring real PR traffic across 180 dependencies without covering that class.

## Known interaction with release.yml

Dependabot scans every workflow file and cannot be scoped to a subset, so it will also propose bumps to `release.yml` — which cargo-dist owns and regenerates. Note that file currently uses floating tags (`actions/checkout@v4`); the SHA pins added in `c81eb93` were overwritten by `dist generate`, exactly as AGENTS.md warns.

A Dependabot PR touching `release.yml` will therefore fail the `dist plan` freshness check. That failure is loud and self-explanatory rather than silent: close the PR and bump cargo-dist instead of hand-editing the file. This is documented in a comment in `dependabot.yml` so it does not surprise anyone later.

## Test plan

- [x] `dependabot.yml` parses as valid YAML; schema fields verified (`version: 2`, ecosystem, directory, schedule, groups)
- [x] Confirmed `release.yml` has zero SHA pins today, so the interaction above is real and worth documenting
- [ ] Dependabot validates the config on merge (visible under Insights → Dependency graph → Dependabot)

Note this config cannot be fully exercised until it is on the default branch — GitHub only reads `dependabot.yml` from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)