### PR TITLE
build: pin rust-toolchain to 1.97.1, and fail when the pin goes stale

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -42,6 +42,49 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+  # Pinning rust-toolchain.toml to an exact version trades surprise breakage for
+  # silent staleness. Nothing bumps it — Dependabot has no rust-toolchain
+  # manager — so without this the pin rots quietly and new lints and fixes never
+  # arrive. Failing is the delivery mechanism, same as the dormancy job below.
+  #
+  # Rust releases roughly every six weeks, so this goes red at most that often
+  # and stays red until someone bumps the pin. That is the intended pressure:
+  # the bump lands in its own commit, where any new clippy lints are dealt with
+  # deliberately instead of surfacing inside an unrelated PR.
+  toolchain:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: compare pinned toolchain against latest stable
+        run: |
+          set -euo pipefail
+          manifest=$(curl -sSf https://static.rust-lang.org/dist/channel-rust-stable.toml)
+          # The manifest contains several `version` keys; only the one under
+          # [pkg.rust] is the Rust release itself. Taking the first match
+          # instead yields a sub-package version and a bogus comparison.
+          #
+          # `seen` rather than awk's `exit`: exiting early closes the pipe and
+          # SIGPIPEs the writer, which under pipefail fails the step even though
+          # the fetch and the parse both succeeded.
+          latest=$(printf '%s\n' "$manifest" \
+            | awk '/^\[pkg\.rust\]/{f=1} f && /^version/ && !seen {gsub(/[",]/,""); print $3; seen=1}')
+          pinned=$(sed -n 's/^channel[[:space:]]*=[[:space:]]*"\(.*\)".*/\1/p' rust-toolchain.toml)
+          echo "pinned=${pinned:-<none>} latest=${latest:-<none>}"
+          # Fail loudly rather than pass quietly if either lookup came back
+          # empty — a silent pass here would look identical to "up to date".
+          if [ -z "$latest" ] || [ -z "$pinned" ]; then
+            echo "::error::Could not determine pinned and/or latest Rust version; the freshness check did not actually run."
+            exit 1
+          fi
+          if [ "$pinned" != "$latest" ]; then
+            echo "::error::rust-toolchain.toml pins $pinned but stable is now $latest. Bump it in its own commit and resolve any new clippy lints there."
+            exit 1
+          fi
+          echo "Pin is current ($pinned)."
+
   # Warn before GitHub auto-disables the schedule above.
   #
   # A scheduled workflow cannot detect its own disabling — but it does not need

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -7,3 +7,10 @@
 # Bump this deliberately, as its own commit, so new lints arrive when someone is
 # looking at them rather than in the middle of an unrelated PR.
 channel = "1.97.1"
+# Declared explicitly rather than inherited from the rustup profile. When rustup
+# auto-installs this toolchain it uses whatever profile the machine is set to:
+# `default` locally (which happens to bundle clippy and rustfmt) but `minimal`
+# on CI runners, where `cargo fmt` then fails with "'cargo-fmt' is not installed
+# for the toolchain". Listing them here makes the requirement explicit and
+# profile-independent, for CI and contributors alike.
+components = ["clippy", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,9 @@
 [toolchain]
-channel = "stable"
+# Pinned to an exact version, not "stable". A floating channel means CI and a
+# developer machine can silently disagree: a stale local `stable` (1.96) against
+# a fresh runner's `stable` (1.97) red-lined PR #66 on a new clippy lint that had
+# nothing to do with its changes.
+#
+# Bump this deliberately, as its own commit, so new lints arrive when someone is
+# looking at them rather than in the middle of an unrelated PR.
+channel = "1.97.1"


### PR DESCRIPTION
## Summary

`rust-toolchain.toml` already existed (since `c81eb93`) but tracked the floating `stable` channel. That pins *which channel*, not *which version* — so CI and a developer machine can silently disagree.

Not hypothetical: it broke PR #66 mid-review. A stale local `stable` (1.96.0) against a fresh runner's `stable` (1.97.0) meant every local check passed while CI failed on `clippy::for_kv_map`, a lint new in 1.97 firing on pre-existing code the PR never touched. That branch was green in June and red in August without a line changing — Rust moved, not the repo.

**Pinning alone would just swap one silent failure for another**, so this PR also adds the check that makes the pin safe.

## 1. Pin to an exact version, with components

```toml
[toolchain]
channel = "1.97.1"
components = ["clippy", "rustfmt"]
```

The components line is not incidental. When rustup auto-installs a pinned toolchain it uses whatever profile the machine has: `default` on a typical dev machine (which bundles clippy and rustfmt) but `minimal` on CI runners (which bundles neither). Without it, `cargo fmt --check` fails with `'cargo-fmt' is not installed for the toolchain '1.97.1-x86_64-unknown-linux-gnu'`.

This was found the honest way — CI failed on the first push of this branch. An earlier local check had passed and looked like proof, but it only proved the behavior on a `default`-profile machine. Declaring the components makes the requirement explicit and profile-independent, for CI and contributors alike.

## 2. Fail when the pin falls behind stable

Nothing bumps `rust-toolchain.toml` — Dependabot has no rust-toolchain manager. Left alone, a pin rots quietly and you simply stop receiving new lints and fixes: the same silent-staleness shape the `dormancy` job already guards against, so the new `toolchain` job lives beside it in `audit.yml`.

It compares the pin against the `[pkg.rust]` version in the stable channel manifest and fails on divergence. Rust ships roughly every six weeks, so it goes red at most that often and stays red until bumped. That pressure is the point.

Two parsing hazards, both caught by *running* the script rather than reasoning about it:

- The manifest has several `version` keys; only the one under `[pkg.rust]` is the Rust release. A first-match grep returns a sub-package version (`0.98.0`) and compares garbage.
- `awk`'s `exit` closes the pipe and SIGPIPEs the writer; under `pipefail` that fails the step (exit 141) even though fetch and parse both succeeded. Uses a `seen` flag and consumes the whole stream instead.

An empty lookup on either side fails loudly, so a broken check can never be mistaken for an up-to-date pin.

## Why ci.yml is left alone

`ci.yml` still uses `dtolnay/rust-toolchain@<sha> # stable`, deliberately. rustup honors `rust-toolchain.toml` for any cargo invocation in the tree regardless of what the action set as default, so the file is the single source of truth and the action's install is redundant but harmless — it resolves to this same version today.

The alternative — `@master` with an explicit `toolchain:` input — was rejected as a second source of truth needing edits on every bump. The action's README documents neither reading the toolchain file nor what wins in a conflict, so this rests on rustup's semantics.

One cost: once stable moves past 1.97.1, CI downloads two toolchains per job until the pin is bumped. If that grates, drop the action and let rustup auto-install from the file.

## Trade-off, stated plainly

You must bump this file manually. The freshness check makes that impossible to forget, but it is still manual work roughly every six weeks. The choice is between occasional surprise breakage and occasional deliberate bumps; this takes the second.

## Test plan

- [x] `just check` passes (fmt + clippy, both feature configurations)
- [x] 653 tests pass, `cargo audit` clean
- [x] Freshness script executed locally in all three paths: match → exit 0, drift → exit 1, empty lookup → exit 1
- [x] `audit.yml` parses; jobs are `audit`, `toolchain`, `dormancy`
- [x] rustup resolves the pin and both components (`rustup show active-toolchain` reports the override)
- [ ] CI green — the authority here, having already caught the missing-components bug

Note the `toolchain` job itself does not run on this PR: `audit.yml` is schedule/`workflow_dispatch` only. After merge it can be exercised on demand via `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)