### PR TITLE
build: bump pinned toolchain to 1.98.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -6,7 +6,7 @@
 #
 # Bump this deliberately, as its own commit, so new lints arrive when someone is
 # looking at them rather than in the middle of an unrelated PR.
-channel = "1.97.1"
+channel = "1.98.0"
 # Declared explicitly rather than inherited from the rustup profile. When rustup
 # auto-installs this toolchain it uses whatever profile the machine is set to:
 # `default` locally (which happens to bundle clippy and rustfmt) but `minimal`


### PR DESCRIPTION
## Summary

The nightly toolchain check caught the drift on its second scheduled run:

```
pinned=1.97.1 latest=1.98.0
::error::rust-toolchain.toml pins 1.97.1 but stable is now 1.98.0.
          Bump it in its own commit and resolve any new clippy lints there.
```

Rust 1.98.0 landed 2026-08-18. This is the mechanism added in #74 working as designed — without it the drift would have stayed invisible until it surfaced as an unexplained failure in whatever unrelated PR ran next, which is exactly what 1.97 did to #66.

**No new clippy lints this time**, so the version bump is the entire change. That will not always be true; the 1.96 → 1.97 bump brought `clippy::for_kv_map`, which is why the process routes these through their own commit.

## Verification on 1.98.0

- [x] `just check` — fmt + clippy, both feature configurations
- [x] 653 tests pass
- [x] `cargo audit` clean
- [x] `cargo check --workspace --all-targets --target x86_64-pc-windows-msvc`
- [x] `SKILL.md` fresh
- [x] rustup auto-installed the pin with `components = ["clippy", "rustfmt"]` intact

Once merged, the nightly `toolchain` job returns to green; it has been failing each morning since 1.98.0 shipped.

## Ordering note

Landing this first is deliberate. Repo-wide clippy changes affect every open PR, so fixing them once on `main` lets the others rebase onto a clean baseline instead of each carrying unrelated lint churn. #75 follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)