### PR TITLE
ci: update pinned action SHAs in ci.yml and audit.yml

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -34,11 +34,11 @@ jobs:
       contents: read
       checks: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
 
-      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2
+      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -56,7 +56,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: compare pinned toolchain against latest stable
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,15 @@ jobs:
       contents: read
       checks: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
         with:
           components: clippy, rustfmt
 
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
-      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2
+      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -42,9 +42,9 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - run: cargo build --release
       - run: cargo test -- --test-threads=1
 
@@ -62,8 +62,8 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --global core.longpaths true
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - run: cargo build --release
       - run: cargo test -- --test-threads=1


### PR DESCRIPTION
## Summary

Replaces Dependabot's #75 with the two files that are actually ours to change.

#75 also rewrote `release.yml`, which cargo-dist owns and regenerates. Those hunks fail the `plan` freshness check — which is why #75 is `BLOCKED` — and are futile even if merged, since the next `dist generate` overwrites them. `release.yml` is updated separately in #77 by bumping cargo-dist, the supported path.

| Action | before | after |
|---|---|---|
| `actions/checkout` | v4 | **v7.0.1** |
| `Swatinem/rust-cache` | v2 | **v2.9.2** |
| `rustsec/audit-check` | v2.0.0 | unchanged (already latest) |

The checkout bump also clears the runner warning that v4's Node 20 runtime is deprecated — visible in recent `audit.yml` logs.

## Version comments are corrected, not copied

Dependabot left `# v4` beside a v7.0.1 SHA. For a SHA pin that trailing comment is the only human-readable version marker, so a wrong one is actively worse than none — it invites the assumption that the repo is still on v4. Annotations here reflect the actual pinned versions.

This also confirms Dependabot really did make the major bump; the stale comment made it look like it had stayed within v4.

## Why this exists rather than just merging #75

Dependabot cannot be scoped to a subset of workflow files, so every future actions PR will include `release.yml` and be blocked the same way. The durable practice — documented in `dependabot.yml` — is to take the hunks that are ours and leave that file to cargo-dist. #75 should be closed in favour of this.

## Test plan

- [x] Both workflows parse as valid YAML
- [x] `release.yml` untouched (`git diff --name-only` confirms only ci.yml and audit.yml)
- [x] Every pinned SHA resolved against the upstream tag list to confirm the annotation matches
- [ ] CI green — and it exercises the new checkout/rust-cache pins directly, since CI runs on these very workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)