### PR TITLE
ci: lint test code and enforce it with --all-targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - run: cargo fmt --check
-      - run: cargo clippy -- -D warnings
+      # --all-targets so test code is linted too; mirrors `just check`.
+      - run: cargo clippy --workspace --all-targets -- -D warnings
 
   # Linux runs first. If logic is broken it shows up here cheaply before we
   # spin up macOS and Windows runners.

--- a/Justfile
+++ b/Justfile
@@ -10,10 +10,12 @@ fmt:
     cargo fmt --all
 
 # format check + clippy
+# --all-targets so tests and benches are linted too, not just the library and
+# binary: without it ~65 findings accumulated in test code, ungated.
 check:
     cargo fmt --all --check
-    cargo clippy --workspace -- -D warnings
-    cargo clippy --workspace --features wsp/codegen -- -D warnings
+    cargo clippy --workspace --all-targets -- -D warnings
+    cargo clippy --workspace --all-targets --features wsp/codegen -- -D warnings
 
 # generate SKILL.md from CLI introspection
 skill: (build-bin "codegen")
@@ -51,7 +53,7 @@ ci: check check-cross audit build test
 # auto-fix formatting and lint where possible
 fix:
     cargo fmt --all
-    cargo clippy --workspace --fix --allow-dirty -- -D warnings
+    cargo clippy --workspace --all-targets --fix --allow-dirty -- -D warnings
 
 # preview unreleased changelog
 changelog:

--- a/crates/wsp-core/src/config.rs
+++ b/crates/wsp-core/src/config.rs
@@ -505,8 +505,8 @@ mod tests {
         let cfg2 = Config::load_from(&cfg_path).unwrap();
 
         let li2 = cfg2.language_integrations.unwrap();
-        assert_eq!(li2["go"], true);
-        assert_eq!(li2["npm"], false);
+        assert!(li2["go"]);
+        assert!(!li2["npm"]);
     }
 
     #[test]
@@ -546,8 +546,10 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let cfg_path = tmp.path().join("config.yaml");
 
-        let mut cfg = Config::default();
-        cfg.workspaces_dir = Some("/home/user/projects".into());
+        let cfg = Config {
+            workspaces_dir: Some("/home/user/projects".into()),
+            ..Default::default()
+        };
         cfg.save_to(&cfg_path).unwrap();
 
         let cfg2 = Config::load_from(&cfg_path).unwrap();
@@ -561,8 +563,10 @@ mod tests {
         std::fs::create_dir_all(&data_dir).unwrap();
         let cfg_path = data_dir.join("config.yaml");
 
-        let mut cfg = Config::default();
-        cfg.workspaces_dir = Some("/custom/workspaces".into());
+        let cfg = Config {
+            workspaces_dir: Some("/custom/workspaces".into()),
+            ..Default::default()
+        };
         cfg.save_to(&cfg_path).unwrap();
 
         // Simulate what Paths::resolve does: load config, use override
@@ -723,8 +727,10 @@ mod tests {
 
     #[test]
     fn test_experimental_string_value() {
-        let mut exp = ExperimentalConfig::default();
-        exp.enabled = true;
+        let mut exp = ExperimentalConfig {
+            enabled: true,
+            ..Default::default()
+        };
         exp.features.insert(
             "shell-tmux".into(),
             ExperimentalValue::String("window-title".into()),
@@ -735,8 +741,10 @@ mod tests {
 
     #[test]
     fn test_shell_tmux_mode_new_key() {
-        let mut exp = ExperimentalConfig::default();
-        exp.enabled = true;
+        let mut exp = ExperimentalConfig {
+            enabled: true,
+            ..Default::default()
+        };
         exp.features.insert(
             "shell-tmux".into(),
             ExperimentalValue::String("window-title".into()),
@@ -746,8 +754,10 @@ mod tests {
 
     #[test]
     fn test_shell_tmux_mode_deprecated_key() {
-        let mut exp = ExperimentalConfig::default();
-        exp.enabled = true;
+        let mut exp = ExperimentalConfig {
+            enabled: true,
+            ..Default::default()
+        };
         exp.features
             .insert("shell-tmux-title".into(), ExperimentalValue::Bool(true));
         assert_eq!(exp.shell_tmux_mode(), Some("window-title"));
@@ -755,8 +765,10 @@ mod tests {
 
     #[test]
     fn test_shell_tmux_mode_new_key_overrides_deprecated() {
-        let mut exp = ExperimentalConfig::default();
-        exp.enabled = true;
+        let mut exp = ExperimentalConfig {
+            enabled: true,
+            ..Default::default()
+        };
         exp.features.insert(
             "shell-tmux".into(),
             ExperimentalValue::String("false".into()),
@@ -793,9 +805,11 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let cfg_path = tmp.path().join("config.yaml");
 
-        let mut cfg = Config::default();
-        cfg.shell_tmux = Some("window-title".into());
-        cfg.shell_prompt = Some(true);
+        let cfg = Config {
+            shell_tmux: Some("window-title".into()),
+            shell_prompt: Some(true),
+            ..Default::default()
+        };
         cfg.save_to(&cfg_path).unwrap();
 
         let yaml = fs::read_to_string(&cfg_path).unwrap();
@@ -924,8 +938,10 @@ mod tests {
     fn test_experimental_shell_tmux_mode_false_case_insensitive() {
         // ExperimentalConfig::shell_tmux_mode should treat "FALSE" as disabled
         for variant in &["FALSE", "False"] {
-            let mut exp = ExperimentalConfig::default();
-            exp.enabled = true;
+            let mut exp = ExperimentalConfig {
+                enabled: true,
+                ..Default::default()
+            };
             exp.features.insert(
                 "shell-tmux".into(),
                 ExperimentalValue::String((*variant).to_string()),

--- a/crates/wsp-core/src/setup_commands.rs
+++ b/crates/wsp-core/src/setup_commands.rs
@@ -327,7 +327,7 @@ mod tests {
             RepoEntry {
                 url: format!(
                     "git@test.local:user/{}.git",
-                    identity.split('/').last().unwrap()
+                    identity.split('/').next_back().unwrap()
                 ),
                 added: chrono::Utc::now(),
                 setup_commands: cmds,

--- a/crates/wsp-core/src/setup_runner.rs
+++ b/crates/wsp-core/src/setup_runner.rs
@@ -208,7 +208,7 @@ mod tests {
         let tmp = make_temp_dir();
         let resolved = make_resolved(vec![]);
         let result = maybe_run_resolved(tmp.path(), tmp.path(), "test/repo", &resolved);
-        assert_eq!(result.unwrap(), false);
+        assert!(!result.unwrap());
     }
 
     #[test]
@@ -222,7 +222,7 @@ mod tests {
         let tmp = make_temp_dir();
         let resolved = make_resolved(vec!["echo hello"]);
         let result = maybe_run_resolved(tmp.path(), tmp.path(), "test/repo", &resolved);
-        assert_eq!(result.unwrap(), false);
+        assert!(!result.unwrap());
     }
 
     // -----------------------------------------------------------------------
@@ -326,7 +326,7 @@ mod tests {
         crate::approvals::record_always(tmp.path(), "test/repo", &hash).unwrap();
 
         let result = maybe_run_resolved(tmp.path(), tmp.path(), "test/repo", &resolved);
-        assert_eq!(result.unwrap(), true);
+        assert!(result.unwrap());
         assert!(
             tmp.path().join("setup_ran").exists(),
             "pre-approved command should have run"

--- a/crates/wsp-core/src/template.rs
+++ b/crates/wsp-core/src/template.rs
@@ -1223,8 +1223,10 @@ created: 2026-03-07T10:00:00Z
     fn apply_config_overrides_config() {
         use std::collections::BTreeMap;
 
-        let mut cfg = config::Config::default();
-        cfg.sync_strategy = Some("rebase".into());
+        let mut cfg = config::Config {
+            sync_strategy: Some("rebase".into()),
+            ..Default::default()
+        };
         let mut li = BTreeMap::new();
         li.insert("go".into(), false);
         cfg.language_integrations = Some(li);
@@ -1245,18 +1247,17 @@ created: 2026-03-07T10:00:00Z
 
         let effective = tmpl.apply_config(&cfg);
         assert_eq!(effective.sync_strategy.as_deref(), Some("merge"));
-        assert_eq!(
-            effective.language_integrations.as_ref().unwrap()["go"],
-            true
-        );
+        assert!(effective.language_integrations.as_ref().unwrap()["go"]);
     }
 
     #[test]
     fn apply_config_preserves_config_when_absent() {
         use std::collections::BTreeMap;
 
-        let mut cfg = config::Config::default();
-        cfg.sync_strategy = Some("rebase".into());
+        let mut cfg = config::Config {
+            sync_strategy: Some("rebase".into()),
+            ..Default::default()
+        };
         let mut li = BTreeMap::new();
         li.insert("go".into(), true);
         cfg.language_integrations = Some(li);
@@ -1273,10 +1274,7 @@ created: 2026-03-07T10:00:00Z
 
         let effective = tmpl.apply_config(&cfg);
         assert_eq!(effective.sync_strategy.as_deref(), Some("rebase"));
-        assert_eq!(
-            effective.language_integrations.as_ref().unwrap()["go"],
-            true
-        );
+        assert!(effective.language_integrations.as_ref().unwrap()["go"]);
     }
 
     #[test]
@@ -1305,7 +1303,7 @@ created: 2026-03-07T10:00:00Z
 
         let s = parsed.config.unwrap();
         assert_eq!(s.sync_strategy.as_deref(), Some("merge"));
-        assert_eq!(s.language_integrations.as_ref().unwrap()["go"], true);
+        assert!(s.language_integrations.as_ref().unwrap()["go"]);
     }
 
     #[test]
@@ -1726,14 +1724,13 @@ created: 2026-03-07T10:00:00Z
     fn set_config_language_integration() {
         let mut tmpl = sample_template();
         set_config(&mut tmpl, "lang.go", "true").unwrap();
-        assert_eq!(
+        assert!(
             tmpl.config
                 .as_ref()
                 .unwrap()
                 .language_integrations
                 .as_ref()
-                .unwrap()["go"],
-            true
+                .unwrap()["go"]
         );
     }
 

--- a/crates/wsp-core/src/util.rs
+++ b/crates/wsp-core/src/util.rs
@@ -27,6 +27,15 @@ pub(crate) fn read_yaml_file(path: &Path) -> Result<String> {
     Ok(buf)
 }
 
+pub(crate) fn read_stdin_line() -> String {
+    let stdin = std::io::stdin();
+    let mut line = String::new();
+    if let Err(e) = stdin.lock().read_line(&mut line) {
+        eprintln!("warning: failed to read stdin: {}", e);
+    }
+    line
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -62,13 +71,4 @@ mod tests {
         let result = read_yaml_file(Path::new("/nonexistent/file.yaml"));
         assert!(result.is_err());
     }
-}
-
-pub(crate) fn read_stdin_line() -> String {
-    let stdin = std::io::stdin();
-    let mut line = String::new();
-    if let Err(e) = stdin.lock().read_line(&mut line) {
-        eprintln!("warning: failed to read stdin: {}", e);
-    }
-    line
 }

--- a/crates/wsp-core/src/workspace.rs
+++ b/crates/wsp-core/src/workspace.rs
@@ -4500,7 +4500,13 @@ mod tests {
         assert!(ws_dir.join("test-repo").exists());
         assert!(ws_dir.join("other-repo").exists());
 
-        remove_repos(&paths.mirrors_dir, &ws_dir, &[identity2.clone()], false).unwrap();
+        remove_repos(
+            &paths.mirrors_dir,
+            &ws_dir,
+            std::slice::from_ref(&identity2),
+            false,
+        )
+        .unwrap();
 
         let meta = load_metadata(&ws_dir).unwrap();
         assert_eq!(meta.repos.len(), 1);
@@ -4564,7 +4570,12 @@ mod tests {
         let repo_dir = ws_dir.join("test-repo");
         fs::write(repo_dir.join("dirty.txt"), "x").unwrap();
 
-        let result = remove_repos(&paths.mirrors_dir, &ws_dir, &[identity.clone()], false);
+        let result = remove_repos(
+            &paths.mirrors_dir,
+            &ws_dir,
+            std::slice::from_ref(&identity),
+            false,
+        );
         assert!(result.is_err());
         assert!(
             result
@@ -4595,7 +4606,13 @@ mod tests {
         let repo_dir = ws_dir.join("test-repo");
         fs::write(repo_dir.join("dirty.txt"), "x").unwrap();
 
-        remove_repos(&paths.mirrors_dir, &ws_dir, &[identity.clone()], true).unwrap();
+        remove_repos(
+            &paths.mirrors_dir,
+            &ws_dir,
+            std::slice::from_ref(&identity),
+            true,
+        )
+        .unwrap();
 
         let meta = load_metadata(&ws_dir).unwrap();
         assert!(meta.repos.is_empty());
@@ -4635,7 +4652,13 @@ mod tests {
         assert!(ws_dir.join("user-test-repo").exists());
         assert!(ws_dir.join("other-test-repo").exists());
 
-        remove_repos(&paths.mirrors_dir, &ws_dir, &[identity2.clone()], false).unwrap();
+        remove_repos(
+            &paths.mirrors_dir,
+            &ws_dir,
+            std::slice::from_ref(&identity2),
+            false,
+        )
+        .unwrap();
 
         let meta = load_metadata(&ws_dir).unwrap();
         assert_eq!(meta.repos.len(), 1);
@@ -4937,7 +4960,13 @@ mod tests {
         commit_push_and_track(&repo_dir, "rmr-squash", "feat.txt", "feature");
         squash_merge_branch(source_repo.path(), "rmr-squash", "main");
 
-        remove_repos(&paths.mirrors_dir, &ws_dir, &[identity.clone()], false).unwrap();
+        remove_repos(
+            &paths.mirrors_dir,
+            &ws_dir,
+            std::slice::from_ref(&identity),
+            false,
+        )
+        .unwrap();
         let meta = load_metadata(&ws_dir).unwrap();
         assert!(meta.repos.is_empty());
     }
@@ -4989,7 +5018,13 @@ mod tests {
             String::from_utf8_lossy(&out.stderr)
         );
 
-        remove_repos(&paths.mirrors_dir, &ws_dir, &[identity.clone()], false).unwrap();
+        remove_repos(
+            &paths.mirrors_dir,
+            &ws_dir,
+            std::slice::from_ref(&identity),
+            false,
+        )
+        .unwrap();
         let meta = load_metadata(&ws_dir).unwrap();
         assert!(meta.repos.is_empty());
     }
@@ -5068,7 +5103,12 @@ mod tests {
 
         commit_push_and_track(&repo_dir, "rmr-pushed", "wip.txt", "wip");
 
-        let result = remove_repos(&paths.mirrors_dir, &ws_dir, &[identity.clone()], false);
+        let result = remove_repos(
+            &paths.mirrors_dir,
+            &ws_dir,
+            std::slice::from_ref(&identity),
+            false,
+        );
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -5186,7 +5226,12 @@ mod tests {
         let repo_dir = ws_dir.join("test-repo");
         commit_on_new_branch(&repo_dir, "hotfix/urgent", "fix.txt", "urgent fix");
 
-        let result = remove_repos(&paths.mirrors_dir, &ws_dir, &[identity.clone()], false);
+        let result = remove_repos(
+            &paths.mirrors_dir,
+            &ws_dir,
+            std::slice::from_ref(&identity),
+            false,
+        );
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -5280,7 +5325,12 @@ mod tests {
             String::from_utf8_lossy(&out.stderr)
         );
 
-        let result = remove_repos(&paths.mirrors_dir, &ws_dir, &[identity.clone()], false);
+        let result = remove_repos(
+            &paths.mirrors_dir,
+            &ws_dir,
+            std::slice::from_ref(&identity),
+            false,
+        );
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -5331,7 +5381,12 @@ mod tests {
             .unwrap();
         assert!(out.status.success());
 
-        let result = remove_repos(&paths.mirrors_dir, &ws_dir, &[identity.clone()], false);
+        let result = remove_repos(
+            &paths.mirrors_dir,
+            &ws_dir,
+            std::slice::from_ref(&identity),
+            false,
+        );
         assert!(
             result.is_err(),
             "remove_repos must block on pushed-but-unmerged current branch"
@@ -6430,7 +6485,7 @@ mod tests {
 
         let meta = make_simple_metadata(&[]);
         let problems = check_root_content(ws_dir, &meta).unwrap();
-        let ignore = load_wspignore(&data_dir, ws_dir);
+        let ignore = load_wspignore(data_dir, ws_dir);
         let filtered = filter_ignored(&problems, &ignore);
 
         // .claude/settings.json should be filtered out, notes.md should remain

--- a/crates/wsp/src/cli/cfg.rs
+++ b/crates/wsp/src/cli/cfg.rs
@@ -1277,8 +1277,10 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let paths = test_paths(tmp.path());
         // Simulate a config written by an older version of wsp
-        let mut cfg = config::Config::default();
-        cfg.pr_source = Some("gh".into());
+        let cfg = config::Config {
+            pr_source: Some("gh".into()),
+            ..Default::default()
+        };
         cfg.save_to(&paths.config_path).unwrap();
 
         let cmd = get_cmd();
@@ -1448,8 +1450,10 @@ mod tests {
     fn workspace_get_falls_back_to_global() {
         let tmp = tempfile::tempdir().unwrap();
         let paths = test_paths(tmp.path());
-        let mut cfg = config::Config::default();
-        cfg.sync_strategy = Some("merge".into());
+        let cfg = config::Config {
+            sync_strategy: Some("merge".into()),
+            ..Default::default()
+        };
         cfg.save_to(&paths.config_path).unwrap();
         let ws_dir = setup_workspace(tmp.path());
 
@@ -1498,8 +1502,10 @@ mod tests {
     fn workspace_unset_falls_back_to_global() {
         let tmp = tempfile::tempdir().unwrap();
         let paths = test_paths(tmp.path());
-        let mut cfg = config::Config::default();
-        cfg.sync_strategy = Some("merge".into());
+        let cfg = config::Config {
+            sync_strategy: Some("merge".into()),
+            ..Default::default()
+        };
         cfg.save_to(&paths.config_path).unwrap();
         let ws_dir = setup_workspace(tmp.path());
 
@@ -1586,8 +1592,10 @@ mod tests {
 
     #[test]
     fn apply_workspace_config_hierarchy() {
-        let mut global = config::Config::default();
-        global.sync_strategy = Some("rebase".into());
+        let mut global = config::Config {
+            sync_strategy: Some("rebase".into()),
+            ..Default::default()
+        };
         global.git_config = Some({
             let mut m = BTreeMap::new();
             m.insert("push.default".into(), "current".into());

--- a/crates/wsp/src/cli/completers.rs
+++ b/crates/wsp/src/cli/completers.rs
@@ -564,8 +564,10 @@ mod tests {
         std::fs::create_dir_all(&data_dir).unwrap();
         // Point workspaces_dir at a path that does not exist.
         let ws_dir = tmp.path().join("no-such-workspaces");
-        let mut cfg = wsp_core::config::Config::default();
-        cfg.workspaces_dir = Some(ws_dir.to_string_lossy().into_owned());
+        let cfg = wsp_core::config::Config {
+            workspaces_dir: Some(ws_dir.to_string_lossy().into_owned()),
+            ..Default::default()
+        };
         cfg.save_to(&data_dir.join("config.yaml")).unwrap();
 
         unsafe { std::env::set_var("XDG_DATA_HOME", tmp.path()) };
@@ -612,8 +614,10 @@ mod tests {
         }
 
         // Write config pointing to our temp workspaces directory.
-        let mut cfg = wsp_core::config::Config::default();
-        cfg.workspaces_dir = Some(ws_root.to_string_lossy().into_owned());
+        let cfg = wsp_core::config::Config {
+            workspaces_dir: Some(ws_root.to_string_lossy().into_owned()),
+            ..Default::default()
+        };
         cfg.save_to(&data_dir.join("config.yaml")).unwrap();
 
         unsafe { std::env::set_var("XDG_DATA_HOME", tmp.path()) };

--- a/crates/wsp/src/cli/doctor.rs
+++ b/crates/wsp/src/cli/doctor.rs
@@ -3467,10 +3467,8 @@ mod tests {
 
         // Verify the fix persisted to disk
         let reloaded = workspace::load_metadata(&ws_dir).unwrap();
-        for (_, ref_opt) in &reloaded.repos {
-            if let Some(repo_ref) = ref_opt {
-                assert!(repo_ref.r#ref.is_empty(), "ref should be cleared");
-            }
+        for repo_ref in reloaded.repos.values().flatten() {
+            assert!(repo_ref.r#ref.is_empty(), "ref should be cleared");
         }
     }
 

--- a/crates/wsp/src/cli/list.rs
+++ b/crates/wsp/src/cli/list.rs
@@ -130,7 +130,7 @@ mod tests {
 
     #[test]
     fn test_sort_by_created() {
-        let mut entries = vec![
+        let mut entries = [
             WorkspaceListEntry {
                 name: "old".into(),
                 branch: "old".into(),
@@ -176,7 +176,7 @@ mod tests {
 
     #[test]
     fn test_sort_empty_created_sorts_last() {
-        let mut entries = vec![
+        let mut entries = [
             WorkspaceListEntry {
                 name: "error-ws".into(),
                 branch: "ERROR".into(),

--- a/crates/wsp/src/cli/status.rs
+++ b/crates/wsp/src/cli/status.rs
@@ -13,6 +13,171 @@ use wsp_core::workspace;
 
 use super::completers;
 
+pub fn cmd() -> Command {
+    Command::new("st")
+        .visible_alias("status")
+        .about("Git status across workspace repos [read-only]")
+        .long_about(
+            "Git status across workspace repos [read-only].\n\n\
+             Shows each repo's branch, commits ahead/behind upstream, and number of \
+             changed files. Detects wrong-branch checkouts and warns when HEAD differs \
+             from the workspace branch. Also reports unexpected files in the workspace root.\n\n\
+             Paths listed in `.wspignore` (at workspace root) or the global \
+             `~/.local/share/wsp/wspignore` are suppressed from root checks.",
+        )
+        .arg(Arg::new("workspace").add(ArgValueCandidates::new(completers::complete_workspaces)))
+        .arg(
+            Arg::new("verbose")
+                .short('v')
+                .long("verbose")
+                .help("Show per-repo file lists")
+                .action(clap::ArgAction::SetTrue),
+        )
+}
+
+pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
+    let ws_dir: PathBuf =
+        if let Some(name) = matches.try_get_one::<String>("workspace").ok().flatten() {
+            workspace::dir(&paths.workspaces_dir, name)
+        } else {
+            let cwd = std::env::current_dir()?;
+            workspace::detect(&cwd)?
+        };
+
+    if let Some(warning) = gc::check_workspace(&ws_dir, /* read_only */ true)? {
+        print_gc_warning(&warning);
+    }
+
+    let verbose = matches
+        .try_get_one::<bool>("verbose")
+        .ok()
+        .flatten()
+        .copied()
+        .unwrap_or(false);
+
+    let meta = workspace::load_metadata(&ws_dir)
+        .map_err(|e| anyhow::anyhow!("reading workspace: {}", e))?;
+
+    // Collect repo identities in BTreeMap order so results are deterministic.
+    let repo_identities: Vec<String> = meta.repos.keys().cloned().collect();
+
+    // Run per-repo git queries in parallel. Each repo spawns several subprocesses
+    // (branch, upstream, ahead/behind, changed files); parallelism cuts wall time
+    // proportionally to repo count.
+    let mut repos: Vec<RepoStatusEntry> = std::thread::scope(|s| {
+        let handles: Vec<_> = repo_identities
+            .iter()
+            .map(|identity| {
+                let ws_dir = &ws_dir;
+                let meta = &meta;
+                s.spawn(move || {
+                    let dir_name = match meta.dir_name(identity) {
+                        Ok(d) => d,
+                        Err(e) => {
+                            return RepoStatusEntry {
+                                identity: identity.clone(),
+                                shortname: identity
+                                    .rsplit('/')
+                                    .next()
+                                    .unwrap_or(identity)
+                                    .to_string(),
+                                path: String::new(),
+                                branch: String::new(),
+                                ahead: 0,
+                                behind: 0,
+                                changed: 0,
+                                has_upstream: false,
+                                role: "active".into(),
+                                files: vec![],
+                                error: Some(e.to_string()),
+                                expected_branch: None,
+                                pr: None,
+                            };
+                        }
+                    };
+
+                    let repo_dir = ws_dir.join(&dir_name);
+                    let branch = git::branch_current(&repo_dir).unwrap_or_else(|_| "?".to_string());
+
+                    // Detect wrong-branch: HEAD differs from workspace branch
+                    let expected_branch = if branch != meta.branch && branch != "?" {
+                        Some(meta.branch.clone())
+                    } else {
+                        None
+                    };
+
+                    let upstream = git::resolve_upstream_ref(&repo_dir);
+                    let has_upstream = matches!(upstream, git::UpstreamRef::Tracking);
+                    let ahead = git::ahead_count_from(&repo_dir, &upstream).unwrap_or(0);
+                    let behind = git::behind_count_from(&repo_dir, &upstream).unwrap_or(0);
+                    let files = git::changed_files(&repo_dir).unwrap_or_default();
+                    let changed = files.len() as u32;
+                    RepoStatusEntry {
+                        identity: identity.clone(),
+                        shortname: dir_name.clone(),
+                        path: repo_dir.to_string_lossy().to_string(),
+                        branch,
+                        ahead,
+                        behind,
+                        changed,
+                        has_upstream,
+                        role: "active".into(),
+                        files,
+                        error: None,
+                        expected_branch,
+                        pr: None, // filled in below when pr.source is set
+                    }
+                })
+            })
+            .collect();
+
+        handles
+            .into_iter()
+            .map(|h| h.join().expect("status thread panicked"))
+            .collect()
+    });
+
+    // Fetch PR data in parallel when `pr.source = github` is set in config.
+    let cfg = config::Config::load_from(&paths.config_path).unwrap_or_default();
+    let pr_enabled = cfg.pr_source.as_deref().is_some_and(|s| s != "false");
+    if pr_enabled {
+        let inputs: Vec<(String, String)> = repos
+            .iter()
+            .map(|r| (r.identity.clone(), meta.branch.clone()))
+            .collect();
+        let pr_results = crate::pr::fetch_parallel(&inputs);
+        for ((identity, _branch), pr) in pr_results {
+            if let Some(repo) = repos.iter_mut().find(|r| r.identity == identity) {
+                repo.pr = pr;
+            }
+        }
+    }
+
+    let ignore = workspace::load_wspignore(paths.data_dir(), &ws_dir);
+    let root = match workspace::check_root_content(&ws_dir, &meta) {
+        Ok(items) => {
+            let filtered = workspace::filter_ignored(&items, &ignore);
+            filtered.iter().map(|p| p.to_string()).collect()
+        }
+        Err(e) => {
+            eprintln!("  warning: root content check failed: {}", e);
+            vec![]
+        }
+    };
+
+    Ok(Output::Status(StatusOutput {
+        workspace: meta.name,
+        branch: meta.branch,
+        workspace_dir: ws_dir,
+        description: meta.description,
+        created: meta.created,
+        repos,
+        root,
+        verbose,
+        pr_enabled,
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -255,169 +420,4 @@ mod tests {
             _ => panic!("expected Status output"),
         }
     }
-}
-
-pub fn cmd() -> Command {
-    Command::new("st")
-        .visible_alias("status")
-        .about("Git status across workspace repos [read-only]")
-        .long_about(
-            "Git status across workspace repos [read-only].\n\n\
-             Shows each repo's branch, commits ahead/behind upstream, and number of \
-             changed files. Detects wrong-branch checkouts and warns when HEAD differs \
-             from the workspace branch. Also reports unexpected files in the workspace root.\n\n\
-             Paths listed in `.wspignore` (at workspace root) or the global \
-             `~/.local/share/wsp/wspignore` are suppressed from root checks.",
-        )
-        .arg(Arg::new("workspace").add(ArgValueCandidates::new(completers::complete_workspaces)))
-        .arg(
-            Arg::new("verbose")
-                .short('v')
-                .long("verbose")
-                .help("Show per-repo file lists")
-                .action(clap::ArgAction::SetTrue),
-        )
-}
-
-pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
-    let ws_dir: PathBuf =
-        if let Some(name) = matches.try_get_one::<String>("workspace").ok().flatten() {
-            workspace::dir(&paths.workspaces_dir, name)
-        } else {
-            let cwd = std::env::current_dir()?;
-            workspace::detect(&cwd)?
-        };
-
-    if let Some(warning) = gc::check_workspace(&ws_dir, /* read_only */ true)? {
-        print_gc_warning(&warning);
-    }
-
-    let verbose = matches
-        .try_get_one::<bool>("verbose")
-        .ok()
-        .flatten()
-        .copied()
-        .unwrap_or(false);
-
-    let meta = workspace::load_metadata(&ws_dir)
-        .map_err(|e| anyhow::anyhow!("reading workspace: {}", e))?;
-
-    // Collect repo identities in BTreeMap order so results are deterministic.
-    let repo_identities: Vec<String> = meta.repos.keys().cloned().collect();
-
-    // Run per-repo git queries in parallel. Each repo spawns several subprocesses
-    // (branch, upstream, ahead/behind, changed files); parallelism cuts wall time
-    // proportionally to repo count.
-    let mut repos: Vec<RepoStatusEntry> = std::thread::scope(|s| {
-        let handles: Vec<_> = repo_identities
-            .iter()
-            .map(|identity| {
-                let ws_dir = &ws_dir;
-                let meta = &meta;
-                s.spawn(move || {
-                    let dir_name = match meta.dir_name(identity) {
-                        Ok(d) => d,
-                        Err(e) => {
-                            return RepoStatusEntry {
-                                identity: identity.clone(),
-                                shortname: identity
-                                    .rsplit('/')
-                                    .next()
-                                    .unwrap_or(identity)
-                                    .to_string(),
-                                path: String::new(),
-                                branch: String::new(),
-                                ahead: 0,
-                                behind: 0,
-                                changed: 0,
-                                has_upstream: false,
-                                role: "active".into(),
-                                files: vec![],
-                                error: Some(e.to_string()),
-                                expected_branch: None,
-                                pr: None,
-                            };
-                        }
-                    };
-
-                    let repo_dir = ws_dir.join(&dir_name);
-                    let branch = git::branch_current(&repo_dir).unwrap_or_else(|_| "?".to_string());
-
-                    // Detect wrong-branch: HEAD differs from workspace branch
-                    let expected_branch = if branch != meta.branch && branch != "?" {
-                        Some(meta.branch.clone())
-                    } else {
-                        None
-                    };
-
-                    let upstream = git::resolve_upstream_ref(&repo_dir);
-                    let has_upstream = matches!(upstream, git::UpstreamRef::Tracking);
-                    let ahead = git::ahead_count_from(&repo_dir, &upstream).unwrap_or(0);
-                    let behind = git::behind_count_from(&repo_dir, &upstream).unwrap_or(0);
-                    let files = git::changed_files(&repo_dir).unwrap_or_default();
-                    let changed = files.len() as u32;
-                    RepoStatusEntry {
-                        identity: identity.clone(),
-                        shortname: dir_name.clone(),
-                        path: repo_dir.to_string_lossy().to_string(),
-                        branch,
-                        ahead,
-                        behind,
-                        changed,
-                        has_upstream,
-                        role: "active".into(),
-                        files,
-                        error: None,
-                        expected_branch,
-                        pr: None, // filled in below when pr.source is set
-                    }
-                })
-            })
-            .collect();
-
-        handles
-            .into_iter()
-            .map(|h| h.join().expect("status thread panicked"))
-            .collect()
-    });
-
-    // Fetch PR data in parallel when `pr.source = github` is set in config.
-    let cfg = config::Config::load_from(&paths.config_path).unwrap_or_default();
-    let pr_enabled = cfg.pr_source.as_deref().is_some_and(|s| s != "false");
-    if pr_enabled {
-        let inputs: Vec<(String, String)> = repos
-            .iter()
-            .map(|r| (r.identity.clone(), meta.branch.clone()))
-            .collect();
-        let pr_results = crate::pr::fetch_parallel(&inputs);
-        for ((identity, _branch), pr) in pr_results {
-            if let Some(repo) = repos.iter_mut().find(|r| r.identity == identity) {
-                repo.pr = pr;
-            }
-        }
-    }
-
-    let ignore = workspace::load_wspignore(paths.data_dir(), &ws_dir);
-    let root = match workspace::check_root_content(&ws_dir, &meta) {
-        Ok(items) => {
-            let filtered = workspace::filter_ignored(&items, &ignore);
-            filtered.iter().map(|p| p.to_string()).collect()
-        }
-        Err(e) => {
-            eprintln!("  warning: root content check failed: {}", e);
-            vec![]
-        }
-    };
-
-    Ok(Output::Status(StatusOutput {
-        workspace: meta.name,
-        branch: meta.branch,
-        workspace_dir: ws_dir,
-        description: meta.description,
-        created: meta.created,
-        repos,
-        root,
-        verbose,
-        pr_enabled,
-    }))
 }

--- a/crates/wsp/src/hints.rs
+++ b/crates/wsp/src/hints.rs
@@ -180,9 +180,11 @@ mod tests {
     fn no_hints_when_disabled_globally() {
         let tp = make_paths();
         let paths = &tp.paths;
-        let mut cfg = Config::default();
-        cfg.hints = Some(false);
-        assert!(evaluate("new", &cfg, &paths).is_empty());
+        let cfg = Config {
+            hints: Some(false),
+            ..Default::default()
+        };
+        assert!(evaluate("new", &cfg, paths).is_empty());
     }
 
     #[test]
@@ -191,7 +193,7 @@ mod tests {
         let paths = &tp.paths;
         let mut cfg = cfg_with_cooldown(0); // no cooldown so it always fires
         cfg.branch_prefix = None;
-        let hints = evaluate("new", &cfg, &paths);
+        let hints = evaluate("new", &cfg, paths);
         assert!(
             hints.iter().any(|h| h.contains("branchPrefix")),
             "expected branchPrefix hint, got: {:?}",
@@ -204,7 +206,7 @@ mod tests {
         let tp = make_paths();
         let paths = &tp.paths;
         let cfg = cfg_with_prefix();
-        let hints = evaluate("new", &cfg, &paths);
+        let hints = evaluate("new", &cfg, paths);
         assert!(
             !hints.iter().any(|h| h.contains("branchPrefix")),
             "branchPrefix hint should not fire when prefix is set"
@@ -215,13 +217,15 @@ mod tests {
     fn branch_prefix_hint_suppressed_via_advice() {
         let tp = make_paths();
         let paths = &tp.paths;
-        let mut cfg = Config::default();
-        cfg.advice = Some({
-            let mut m = BTreeMap::new();
-            m.insert("branchPrefix".into(), false);
-            m
-        });
-        let hints = evaluate("new", &cfg, &paths);
+        let cfg = Config {
+            advice: Some({
+                let mut m = BTreeMap::new();
+                m.insert("branchPrefix".into(), false);
+                m
+            }),
+            ..Default::default()
+        };
+        let hints = evaluate("new", &cfg, paths);
         assert!(
             !hints.iter().any(|h| h.contains("branchPrefix")),
             "branchPrefix hint should be suppressed by advice key"
@@ -234,7 +238,7 @@ mod tests {
         let paths = &tp.paths;
         let cfg = cfg_with_cooldown(0);
         for cmd in &["new", "repo/add"] {
-            let hints = evaluate(cmd, &cfg, &paths);
+            let hints = evaluate(cmd, &cfg, paths);
             assert!(
                 hints.iter().any(|h| h.contains("setupCommands")),
                 "expected setupCommands hint for command {:?}, got: {:?}",
@@ -263,7 +267,7 @@ mod tests {
             ..Default::default()
         };
         for cmd in &["new", "repo/add"] {
-            let hints = evaluate(cmd, &cfg, &paths);
+            let hints = evaluate(cmd, &cfg, paths);
             assert!(
                 !hints.iter().any(|h| h.contains("setupCommands")),
                 "setupCommands hint should not fire when registry already has setup commands ({cmd})"
@@ -281,7 +285,7 @@ mod tests {
             m.insert("setupCommands".into(), false);
             m
         });
-        let hints = evaluate("new", &cfg, &paths);
+        let hints = evaluate("new", &cfg, paths);
         assert!(
             !hints.iter().any(|h| h.contains("setupCommands")),
             "setupCommands hint should be suppressed by advice key"
@@ -296,14 +300,14 @@ mod tests {
         let cfg = Config::default();
 
         // First call: hint fires and records the marker
-        let hints1 = evaluate("new", &cfg, &paths);
+        let hints1 = evaluate("new", &cfg, paths);
         assert!(
             hints1.iter().any(|h| h.contains("branchPrefix")),
             "hint should fire on first call"
         );
 
         // Second call (immediate): cooldown suppresses it
-        let hints2 = evaluate("new", &cfg, &paths);
+        let hints2 = evaluate("new", &cfg, paths);
         assert!(
             !hints2.iter().any(|h| h.contains("branchPrefix")),
             "hint should be suppressed within cooldown window"
@@ -317,8 +321,8 @@ mod tests {
         let cfg = cfg_with_cooldown(0);
 
         // Fire twice in a row; both times it should appear
-        let h1 = evaluate("new", &cfg, &paths);
-        let h2 = evaluate("new", &cfg, &paths);
+        let h1 = evaluate("new", &cfg, paths);
+        let h2 = evaluate("new", &cfg, paths);
         assert!(
             h1.iter().any(|h| h.contains("branchPrefix")),
             "first call should show hint"
@@ -353,7 +357,7 @@ mod tests {
         let tp = make_paths();
         let paths = &tp.paths;
         let cfg = Config::default();
-        let hints = evaluate("ls", &cfg, &paths);
+        let hints = evaluate("ls", &cfg, paths);
         assert!(hints.is_empty(), "ls should produce no hints");
     }
 
@@ -383,7 +387,7 @@ mod tests {
         let tp = make_paths();
         let paths = &tp.paths;
         let cfg = cfg_with_registry_setup("myrepo");
-        let hints = evaluate("repo/setup-commands/add", &cfg, &paths);
+        let hints = evaluate("repo/setup-commands/add", &cfg, paths);
         assert!(
             hints.iter().any(|h| h.contains("registrySetupCommands")),
             "expected registrySetupCommands hint for inferred add, got: {hints:?}"
@@ -395,7 +399,7 @@ mod tests {
         let tp = make_paths();
         let paths = &tp.paths;
         let cfg = cfg_with_registry_setup("myrepo");
-        let hints = evaluate("repo/setup-commands/add/registry", &cfg, &paths);
+        let hints = evaluate("repo/setup-commands/add/registry", &cfg, paths);
         assert!(
             hints.iter().any(|h| h.contains("registrySetupCommands")),
             "expected registrySetupCommands hint for explicit --registry add, got: {hints:?}"
@@ -411,7 +415,7 @@ mod tests {
             "repo/setup-commands/add/workspace",
             "repo/setup-commands/add/repo",
         ] {
-            let hints = evaluate(cmd, &cfg, &paths);
+            let hints = evaluate(cmd, &cfg, paths);
             assert!(
                 !hints.iter().any(|h| h.contains("registrySetupCommands")),
                 "registrySetupCommands hint should not fire for {cmd:?}, got: {hints:?}"
@@ -425,7 +429,7 @@ mod tests {
         let paths = &tp.paths;
         let cfg = cfg_with_registry_setup("myrepo");
         for cmd in &["repo/setup-commands/rm", "repo/setup-commands/ls", "new"] {
-            let hints = evaluate(cmd, &cfg, &paths);
+            let hints = evaluate(cmd, &cfg, paths);
             assert!(
                 !hints.iter().any(|h| h.contains("registrySetupCommands")),
                 "registrySetupCommands hint should not fire for {cmd:?}, got: {hints:?}"
@@ -452,7 +456,7 @@ mod tests {
             repos,
             ..Default::default()
         };
-        let hints = evaluate("repo/setup-commands/add", &cfg, &paths);
+        let hints = evaluate("repo/setup-commands/add", &cfg, paths);
         assert!(
             !hints.iter().any(|h| h.contains("registrySetupCommands")),
             "hint should not fire when registry has no setup commands"
@@ -469,7 +473,7 @@ mod tests {
             m.insert("registrySetupCommands".into(), false);
             m
         });
-        let hints = evaluate("repo/setup-commands/add", &cfg, &paths);
+        let hints = evaluate("repo/setup-commands/add", &cfg, paths);
         assert!(
             !hints.iter().any(|h| h.contains("registrySetupCommands")),
             "registrySetupCommands hint should be suppressed by advice key"

--- a/crates/wsp/src/output.rs
+++ b/crates/wsp/src/output.rs
@@ -846,9 +846,15 @@ mod tests {
         String::from_utf8(buf).unwrap()
     }
 
+    /// (name, headers, rows, expected)
+    type TableCase<'a> = (&'a str, Vec<&'a str>, Vec<Vec<&'a str>>, &'a str);
+
+    /// (name, ahead, behind, modified, has_upstream, expected_branch, want)
+    type RepoStatusCase<'a> = (&'a str, u32, u32, u32, bool, &'a Option<String>, &'a str);
+
     #[test]
     fn test_table() {
-        let cases: Vec<(&str, Vec<&str>, Vec<Vec<&str>>, &str)> = vec![
+        let cases: Vec<TableCase<'_>> = vec![
             (
                 "single column",
                 vec!["Name"],
@@ -921,8 +927,7 @@ mod tests {
     #[test]
     fn test_format_repo_status() {
         let none: Option<String> = None;
-        //                  (name, ahead, behind, modified, has_upstream, expected_branch, want)
-        let cases: Vec<(&str, u32, u32, u32, bool, &Option<String>, &str)> = vec![
+        let cases: Vec<RepoStatusCase<'_>> = vec![
             ("clean", 0, 0, 0, true, &none, "clean"),
             ("clean no upstream", 0, 0, 0, false, &none, "clean"),
             ("modified only", 0, 0, 5, true, &none, "5 modified"),

--- a/crates/wsp/tests/shell_completion.rs
+++ b/crates/wsp/tests/shell_completion.rs
@@ -1,13 +1,13 @@
-/// Integration tests that spawn real shells to verify tab-completion works
-/// end-to-end.
-///
-/// These tests catch runtime behavior that string-pattern unit tests cannot —
-/// e.g. PowerShell 5.1 silently dropping empty string arguments when calling
-/// native executables with `&`, which breaks `wsp <TAB>` (empty wordToComplete).
-///
-/// Each test simulates what the Register-ArgumentCompleter / complete scriptblock
-/// does when the user presses TAB with an empty prefix, directly exercising the
-/// clap_complete invocation path.
+//! Integration tests that spawn real shells to verify tab-completion works
+//! end-to-end.
+//!
+//! These tests catch runtime behavior that string-pattern unit tests cannot —
+//! e.g. PowerShell 5.1 silently dropping empty string arguments when calling
+//! native executables with `&`, which breaks `wsp <TAB>` (empty wordToComplete).
+//!
+//! Each test simulates what the Register-ArgumentCompleter / complete scriptblock
+//! does when the user presses TAB with an empty prefix, directly exercising the
+//! clap_complete invocation path.
 
 const WSP: &str = env!("CARGO_BIN_EXE_wsp");
 


### PR DESCRIPTION
## Summary

Neither `just check` nor `ci.yml` passed `--all-targets`, so clippy only ever saw the library and binary targets. **Test code was completely ungated**, and 65 findings had accumulated across 10 files — `hints.rs` (22), `config.rs` (18), `workspace.rs` (11), `cfg.rs` (8), `template.rs` (8), and others.

This fixes all 65 and turns the gate on in both places so they cannot silently come back.

Found while working on #74, where an `--all-targets` run surfaced them; I skipped them then as out of scope for a toolchain PR.

## What changed

Most were mechanical, applied by `clippy --fix`: needless borrows, `clone` where `slice::from_ref` works, `assert_eq!` against literal bools.

Done by hand:

- **18 sites** of `let mut x = T::default(); x.field = ...` rewritten as struct literals with `..Default::default()` — already the documented convention in AGENTS.md for `Template` test literals.
- **Two very-complex tuple types** in `output.rs` given named aliases (`TableCase`, `RepoStatusCase`). The alias now carries the field-order comment that previously floated above the `vec!`.
- **`shell_completion.rs`** used `///` for file-level docs with nothing to attach to → `//!`.
- **`doctor.rs`** iterated `values()` then matched `Some` → `values().flatten()`.

## Two code relocations — verified as pure moves

`clippy::items_after_test_module` fires where an item is declared *after* `mod tests`, and its autofix relocates the item above the test module. That happened in **two** files:

| File | Item moved | Diff |
|---|---|---|
| `crates/wsp/src/cli/status.rs` | `pub fn cmd()` | 165 added / 165 removed |
| `crates/wsp-core/src/util.rs` | `read_stdin_line()` | 9 added / 9 removed |

Both verified mechanically rather than by eye:
- added and removed line counts match exactly
- every changed line appears an **even** number of times across the diff, i.e. nothing was altered in transit
- each symbol is still defined exactly once

These are the only two hunks outside a `#[cfg(test)]` module. Every other change in this PR is inside test code — checked by comparing each hunk's line number against the file's `#[cfg(test)]` position.

## Enforcement

```diff
-    cargo clippy --workspace -- -D warnings
+    cargo clippy --workspace --all-targets -- -D warnings
```

in `just check` (both feature configurations), `just fix`, and `ci.yml`. The CI line also gains `--workspace`, which it was missing.

## Test plan

- [x] `cargo clippy --workspace --all-targets` clean — 0 findings, default and `wsp/codegen`
- [x] `just check` passes with the new flags
- [x] 653 tests pass
- [x] `SKILL.md` fresh
- [x] `cargo check --workspace --all-targets --target x86_64-pc-windows-msvc` clean
- [x] Both relocations verified as pure moves; no other change touches production code

The payoff is future PRs: from here, lint drift in test code fails CI instead of accumulating unseen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)