### PR TITLE
fix(doctor): refresh the registry snapshot after registering a repo

### DIFF
--- a/crates/wsp/src/cli/doctor.rs
+++ b/crates/wsp/src/cli/doctor.rs
@@ -200,6 +200,15 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
             &mut fixed,
         );
 
+        // `cfg` was loaded before any fix ran, and registering a repo above
+        // writes the new entry straight to the config file. The
+        // origin-url-match check below compares each clone against
+        // `cfg.upstream_url()`, so on a stale snapshot it warns about the entry
+        // this run just created — and declines to fix it, because the stale
+        // registered URL is empty. That is why the warning used to survive the
+        // run that resolved it and clear only on a second `wsp doctor --fix`.
+        let cfg = config::Config::load_from(&paths.config_path).unwrap_or(cfg);
+
         // W9. AGENTS.md / CLAUDE.md validity
         check_agents_md_valid(&ws_dir, &meta, &ws_scope, fix, &mut checks, &mut fixed);
 
@@ -2909,9 +2918,11 @@ mod tests {
         git::run(Some(&clone_dir), &["remote", "add", "origin", origin_url]).unwrap();
 
         let paths = test_paths(tmp);
-        if let Ok(parsed) = giturl::parse(origin_url) {
-            fs::create_dir_all(mirror::dir(&paths.mirrors_dir, &parsed)).unwrap();
-        }
+        // Not `if let Ok(..)`: silently skipping this on a parse failure would
+        // turn the test from "mirror already exists" into "attempt a real clone
+        // over the network" — slow or flaky rather than a clear failure.
+        let parsed = giturl::parse(origin_url).expect("test origin URL must parse");
+        fs::create_dir_all(mirror::dir(&paths.mirrors_dir, &parsed)).unwrap();
 
         // Registry is empty, so the repo is unregistered.
         (ws_dir, meta, config::Config::default(), paths)
@@ -2992,11 +3003,14 @@ mod tests {
         assert_eq!(fixed, 0, "nothing was registered, so nothing was fixed");
         assert_eq!(checks.len(), 1);
         assert_eq!(checks[0].status, CheckStatus::Warn);
+        // Not `.unwrap_or(true)`: a failed load would then satisfy the
+        // assertion, so a broken registry would read as an empty one.
+        let saved = config::Config::load_from(&paths.config_path)
+            .expect("config must remain loadable after a no-op fix");
         assert!(
-            config::Config::load_from(&paths.config_path)
-                .map(|c| c.repos.is_empty())
-                .unwrap_or(true),
-            "registry must stay empty when there is no origin to read"
+            saved.repos.is_empty(),
+            "registry must stay empty when there is no origin to read, got: {:?}",
+            saved.repos.keys().collect::<Vec<_>>()
         );
     }
 


### PR DESCRIPTION
Closes #65.

## The bug

`run()` loads the config once, up front (`doctor.rs:76`). `check_unregistered_repos --fix` writes new entries straight to the config file but leaves that snapshot stale. The later origin-url-match check then compares each clone against `cfg.upstream_url()`:

- `urls_equivalent(clone_url, "")` → false, so it wants to warn
- `fix && !registered_url.is_empty()` → false, so it won't fix

So a single `wsp doctor --fix` registered the repo **and still warned** `origin URL differs from registered URL` — about the entry it had just created — clearing only on a second run.

That is the second symptom in #65, and the reason #80 stopped short of closing it. With registration already covered by #80, this completes the issue.

## The fix

One line: reload after registration.

```rust
let cfg = config::Config::load_from(&paths.config_path).unwrap_or(cfg);
```

Unconditional rather than gated on `fix` — with nothing written it is one cheap read of a small file, and a diagnostic command can afford that more easily than readers can afford another branch. `cfg` is not used after this block, so it moves rather than clones.

I audited the other two config writers in `run()` for the same shape. `check_deprecated_config_keys` touches key names, not `repos`. `check_template_repos_registered` writes earlier, but `check_unregistered_repos` re-checks `contains_key` *inside* the config lock, so no duplicate entry is possible — at most the `registered N repo(s)` count could over-report in the narrow case where a workspace repo is also a template repo registered earlier in the same run. Left alone; fixing a cosmetic count is not worth the branch.

## Also: two assertions from #80 that passed on failure

- the no-op test ended `.unwrap_or(true)`, so a config that **failed to load** satisfied "the registry is empty". Now it expects a successful load and prints the offending keys.
- the fixture used `if let Ok(parsed)`, silently skipping mirror creation on a parse failure — turning the test from "mirror already exists" into a real network clone. Now it expects the URL to parse.

## Coverage

The reload itself is not unit-testable: reaching origin-url-match means driving `run()`, which needs the process CWD moved and pulls in every global check. Notes for building that harness are on #69.

## Test plan

- [x] `just check` passes
- [x] 655 tests pass
- [x] Verified clean when merged together with #81 (clippy `--all-targets` both feature configs, fmt, full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)