### PR TITLE
fix(repo add): refresh mirrors before cloning into a workspace

### DIFF
--- a/crates/wsp/src/cli/add.rs
+++ b/crates/wsp/src/cli/add.rs
@@ -48,6 +48,12 @@ pub fn cmd() -> Command {
                 .action(clap::ArgAction::SetTrue)
                 .help("Skip template discovery in added repos"),
         )
+        .arg(
+            Arg::new("no-fetch")
+                .long("no-fetch")
+                .action(clap::ArgAction::SetTrue)
+                .help("Skip fetching mirrors before cloning"),
+        )
 }
 
 pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
@@ -183,13 +189,28 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
     let ws_meta = workspace::load_metadata(&ws_dir)?;
     let ws_branch = ws_meta.branch.clone();
     let remote_ref = format!("refs/remotes/origin/{}", ws_branch);
+
+    let mirrors: Vec<(String, std::path::PathBuf)> = repo_refs
+        .keys()
+        .filter_map(|id| {
+            giturl::Parsed::from_identity(id)
+                .ok()
+                .map(|p| (id.clone(), mirror::dir(&paths.mirrors_dir, &p)))
+        })
+        .collect();
+
+    // Refresh before reading the mirrors, not just before cloning: the
+    // tracking decision below asks whether the workspace branch exists
+    // remotely, and on a stale mirror a recently pushed branch looks missing —
+    // silently starting a fresh branch from origin/default instead of tracking.
+    if !matches.get_flag("no-fetch") {
+        super::fetch::prefetch_mirrors(&mirrors);
+    }
+
     let mut fresh_repos: Vec<String> = Vec::new();
-    for id in repo_refs.keys() {
-        if let Ok(p) = giturl::Parsed::from_identity(id) {
-            let mirror_dir = mirror::dir(&paths.mirrors_dir, &p);
-            if !git::ref_exists(&mirror_dir, &remote_ref) {
-                fresh_repos.push(id.clone());
-            }
+    for (id, mirror_dir) in &mirrors {
+        if !git::ref_exists(mirror_dir, &remote_ref) {
+            fresh_repos.push(id.clone());
         }
     }
 

--- a/crates/wsp/src/cli/doctor.rs
+++ b/crates/wsp/src/cli/doctor.rs
@@ -200,6 +200,15 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
             &mut fixed,
         );
 
+        // `cfg` was loaded before any fix ran, and registering a repo above
+        // writes the new entry straight to the config file. The
+        // origin-url-match check below compares each clone against
+        // `cfg.upstream_url()`, so on a stale snapshot it warns about the entry
+        // this run just created — and declines to fix it, because the stale
+        // registered URL is empty. That is why the warning used to survive the
+        // run that resolved it and clear only on a second `wsp doctor --fix`.
+        let cfg = config::Config::load_from(&paths.config_path).unwrap_or(cfg);
+
         // W9. AGENTS.md / CLAUDE.md validity
         check_agents_md_valid(&ws_dir, &meta, &ws_scope, fix, &mut checks, &mut fixed);
 
@@ -2909,9 +2918,11 @@ mod tests {
         git::run(Some(&clone_dir), &["remote", "add", "origin", origin_url]).unwrap();
 
         let paths = test_paths(tmp);
-        if let Ok(parsed) = giturl::parse(origin_url) {
-            fs::create_dir_all(mirror::dir(&paths.mirrors_dir, &parsed)).unwrap();
-        }
+        // Not `if let Ok(..)`: silently skipping this on a parse failure would
+        // turn the test from "mirror already exists" into "attempt a real clone
+        // over the network" — slow or flaky rather than a clear failure.
+        let parsed = giturl::parse(origin_url).expect("test origin URL must parse");
+        fs::create_dir_all(mirror::dir(&paths.mirrors_dir, &parsed)).unwrap();
 
         // Registry is empty, so the repo is unregistered.
         (ws_dir, meta, config::Config::default(), paths)
@@ -2992,11 +3003,14 @@ mod tests {
         assert_eq!(fixed, 0, "nothing was registered, so nothing was fixed");
         assert_eq!(checks.len(), 1);
         assert_eq!(checks[0].status, CheckStatus::Warn);
+        // Not `.unwrap_or(true)`: a failed load would then satisfy the
+        // assertion, so a broken registry would read as an empty one.
+        let saved = config::Config::load_from(&paths.config_path)
+            .expect("config must remain loadable after a no-op fix");
         assert!(
-            config::Config::load_from(&paths.config_path)
-                .map(|c| c.repos.is_empty())
-                .unwrap_or(true),
-            "registry must stay empty when there is no origin to read"
+            saved.repos.is_empty(),
+            "registry must stay empty when there is no origin to read, got: {:?}",
+            saved.repos.keys().collect::<Vec<_>>()
         );
     }
 

--- a/crates/wsp/src/cli/fetch.rs
+++ b/crates/wsp/src/cli/fetch.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Mutex;
 
 use anyhow::{Result, bail};
@@ -10,6 +11,46 @@ use wsp_core::giturl;
 use wsp_core::mirror;
 use wsp_core::output::{FetchOutput, FetchRepoResult, Output};
 use wsp_core::workspace;
+
+/// Fetch each mirror from upstream in parallel, reporting each result as it
+/// arrives.
+///
+/// `wsp new` and `wsp add` both build their clones from local bare mirrors, so
+/// without this they reproduce whatever the mirror last saw. That affects more
+/// than file contents: `wsp add` decides whether to track the workspace branch
+/// by looking for `refs/remotes/origin/<branch>` in the mirror, so a stale
+/// mirror makes a recently pushed branch look nonexistent and starts a fresh
+/// one from origin/default instead.
+///
+/// Failures are reported but not fatal — a mirror that cannot be reached still
+/// has its previous contents, which is better than refusing to create the
+/// workspace.
+pub(crate) fn prefetch_mirrors(mirrors: &[(String, PathBuf)]) {
+    if mirrors.is_empty() {
+        return;
+    }
+    eprintln!("Fetching {} mirrors...", mirrors.len());
+    let progress = Mutex::new(());
+    std::thread::scope(|s| {
+        let handles: Vec<_> = mirrors
+            .iter()
+            .map(|(id, mirror_dir)| {
+                let progress = &progress;
+                s.spawn(move || {
+                    let result = git::fetch(mirror_dir, true);
+                    let _lock = progress.lock().unwrap_or_else(|e| e.into_inner());
+                    match &result {
+                        Ok(()) => eprintln!("  ok    {}", id),
+                        Err(e) => eprintln!("  FAIL  {} ({})", id, e),
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            let _ = h.join();
+        }
+    });
+}
 
 pub fn cmd() -> Command {
     Command::new("fetch")
@@ -187,4 +228,100 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
     };
 
     Ok(Output::Fetch(output))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command as StdCommand;
+
+    fn git_in(dir: &std::path::Path, args: &[&str]) {
+        let out = StdCommand::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {:?}: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    /// An upstream repo with one commit on `main`, plus a bare mirror of it
+    /// built the same way `wsp` builds mirrors (`clone_bare` +
+    /// `configure_fetch_refspec`), so the refspec behaviour matches production.
+    fn upstream_and_mirror() -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        let upstream = tmp.path().join("upstream");
+        std::fs::create_dir_all(&upstream).unwrap();
+        git_in(&upstream, &["init", "--initial-branch=main"]);
+        git_in(&upstream, &["config", "user.email", "test@test.local"]);
+        git_in(&upstream, &["config", "user.name", "Test"]);
+        git_in(&upstream, &["config", "commit.gpgsign", "false"]);
+        git_in(&upstream, &["commit", "--allow-empty", "-m", "initial"]);
+
+        let mirror = tmp.path().join("mirror.git");
+        git::clone_bare(upstream.to_str().unwrap(), &mirror).unwrap();
+        git::configure_fetch_refspec(&mirror).unwrap();
+
+        (tmp, upstream, mirror)
+    }
+
+    /// The bug this guards: `wsp add` decides whether to track the workspace
+    /// branch by looking for `refs/remotes/origin/<branch>` in the mirror. On a
+    /// mirror that was never refreshed, a branch pushed since then is invisible,
+    /// so a tracking branch silently becomes a fresh one off origin/default.
+    #[test]
+    fn prefetch_picks_up_a_branch_pushed_after_the_mirror_was_made() {
+        let (_tmp, upstream, mirror) = upstream_and_mirror();
+        let remote_ref = "refs/remotes/origin/feature/x";
+
+        git_in(&upstream, &["checkout", "-q", "-b", "feature/x"]);
+        git_in(&upstream, &["commit", "--allow-empty", "-m", "later work"]);
+
+        assert!(
+            !git::ref_exists(&mirror, remote_ref),
+            "precondition: a stale mirror must not know the new branch"
+        );
+
+        prefetch_mirrors(&[("acme/repo".to_string(), mirror.clone())]);
+
+        assert!(
+            git::ref_exists(&mirror, remote_ref),
+            "after prefetch the mirror must see the branch that `wsp add` consults"
+        );
+    }
+
+    /// Also picks up new commits on an existing branch — the plainer symptom of
+    /// a stale mirror, where the clone is simply behind.
+    #[test]
+    fn prefetch_picks_up_new_commits_on_an_existing_branch() {
+        let (_tmp, upstream, mirror) = upstream_and_mirror();
+        let before = git::run(Some(&mirror), &["rev-parse", "refs/heads/main"]).unwrap();
+
+        git_in(&upstream, &["commit", "--allow-empty", "-m", "later work"]);
+        prefetch_mirrors(&[("acme/repo".to_string(), mirror.clone())]);
+
+        let after = git::run(Some(&mirror), &["rev-parse", "refs/heads/main"]).unwrap();
+        assert_ne!(
+            before, after,
+            "mirror should have advanced to the new commit"
+        );
+    }
+
+    #[test]
+    fn prefetch_on_empty_input_does_nothing() {
+        prefetch_mirrors(&[]);
+    }
+
+    /// Best-effort contract: an unreachable mirror is reported, not fatal, so a
+    /// single bad repo cannot block creating the workspace.
+    #[test]
+    fn prefetch_does_not_panic_when_a_mirror_is_unusable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("not-a-repo.git");
+        prefetch_mirrors(&[("acme/broken".to_string(), missing)]);
+    }
 }

--- a/crates/wsp/src/cli/new.rs
+++ b/crates/wsp/src/cli/new.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::sync::Mutex;
 use std::time::Instant;
 
 use anyhow::{Result, bail};
@@ -318,28 +317,8 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
     }
 
     // Pre-fetch mirrors (parallel) unless --no-fetch
-    if !no_fetch && !mirrors.is_empty() {
-        eprintln!("Fetching {} mirrors...", mirrors.len());
-        let progress = Mutex::new(());
-        std::thread::scope(|s| {
-            let handles: Vec<_> = mirrors
-                .iter()
-                .map(|(id, mirror_dir)| {
-                    let progress = &progress;
-                    s.spawn(move || {
-                        let result = git::fetch(mirror_dir, true);
-                        let _lock = progress.lock().unwrap_or_else(|e| e.into_inner());
-                        match &result {
-                            Ok(()) => eprintln!("  ok    {}", id),
-                            Err(e) => eprintln!("  FAIL  {} ({})", id, e),
-                        }
-                    })
-                })
-                .collect();
-            for h in handles {
-                let _ = h.join();
-            }
-        });
+    if !no_fetch {
+        super::fetch::prefetch_mirrors(&mirrors);
     }
 
     let branch_prefix = cfg.branch_prefix.as_deref();

--- a/skills/wsp-manage/SKILL.md
+++ b/skills/wsp-manage/SKILL.md
@@ -50,7 +50,7 @@ wsp cd <workspace>                              # Change directory into a worksp
 wsp rm [<workspace>] [-f] [-y]                  # Remove a workspace (alias: remove)
 wsp recover [<workspace>]                       # List, inspect, or restore recently removed workspaces [read-only without args]
 wsp rename <old> [<new>]                        # Rename a workspace, its directory, and git branches
-wsp repo add [<repos>]... [-t <template>] [--no-discover] # Add repos to current workspace
+wsp repo add [<repos>]... [-t <template>] [--no-discover] [--no-fetch] # Add repos to current workspace
 wsp repo rm <repos>... [-f]                     # Remove repo(s) from the current workspace (alias: remove)
 wsp repo fetch [--all] [--prune]                # Fetch updates for workspace repos
 wsp repo ls                                     # List repos in the current workspace [read-only] (alias: list)


### PR DESCRIPTION
## The bug

`wsp repo add` clones from the local bare mirror and never refreshed it. Adding an **already-registered** repo therefore reproduced whatever that mirror last saw — potentially weeks old.

`wsp new` has always pre-fetched (`new.rs:320`), which is exactly what makes this hard to notice: the tool looks like it refreshes.

The only `mirror::fetch` on the add path sits in the registration branch (`add.rs` phase 2), which is skipped via `continue` when the repo is already in the registry — the common case, since repos you have used before are the ones already registered.

| Path | Refreshed before clone? |
|---|---|
| `wsp new` | yes — parallel pre-fetch, `--no-fetch` to skip |
| `wsp repo add`, repo **not** registered | yes — mirror cloned fresh |
| `wsp repo add`, repo **already** registered | **no** |

Nothing downstream compensates: `add_repos` contains no fetch, and `clone_from_mirror` only does `clone_local` plus a `fetch_from_path` **from the local mirror** — its own comment says "local fetch, no network".

## It is worse than stale files

The tracking decision reads the same stale mirror:

```rust
if !git::ref_exists(&mirror_dir, &remote_ref) {
    fresh_repos.push(id.clone());   // "branch not found remotely"
}
```

So a workspace branch pushed since the mirror was last updated looks nonexistent, and the repo **silently starts a fresh branch off origin/default instead of tracking it**. That is a wrong result, not just an old one — and the printed note ("started from origin/default") reads as normal.

The pre-fetch is therefore placed before this check, not merely before the clone.

## The fix, and a simplification

There were already two copies of the parallel-fetch loop (`new.rs` inline, `fetch.rs:151`). Adding a third would be the wrong move, so the pre-fetch moves into `fetch::prefetch_mirrors` and both callers use it:

```
crates/wsp/src/cli/new.rs   | 25 +-------
```

`wsp repo add` gains `--no-fetch` to match `wsp new`. `wsp registry add` fetches on its own path and is unaffected.

I left `fetch.rs`'s own loop alone: it carries a different contract (`--prune`, per-repo shortnames, and structured `FetchOutput` results rather than progress lines). Folding it in would have meant generalising the helper past the point where it stays simple.

## Test coverage

Four tests on the shared helper, including the precise mechanism behind the tracking bug:

- **a branch pushed after the mirror was built** is invisible to `ref_exists` until the fetch runs — this is the ref `wsp repo add` consults
- **new commits on an existing branch** are picked up (the plainer "clone is behind" symptom)
- empty input is a no-op
- an unusable mirror is reported, not fatal — one bad repo must not block workspace creation

The fixture builds its mirror through the same calls production uses (`clone_bare` + `configure_fetch_refspec`) so refspec behaviour matches.

**Verified by mutation, not assumed.** Stubbing the fetch to `Ok(())`:

```
prefetch_picks_up_a_branch_pushed_after_the_mirror_was_made ... FAILED
prefetch_picks_up_new_commits_on_an_existing_branch         ... FAILED
prefetch_on_empty_input_does_nothing                        ... ok
prefetch_does_not_panic_when_a_mirror_is_unusable           ... ok
```

Both behavioural tests fail and neither best-effort test does — they are guarding the behaviour, not passing incidentally.

## Two things I accepted rather than fixed

**Newly registered repos get fetched twice** — once on the registration path (`clone` + `fetch`), then again by the pre-fetch. The second is an incremental no-op on a mirror cloned seconds earlier. Filtering those ids out is a few more lines and a branch; not worth it for a redundant round-trip on the uncommon path.

**The ordering itself is not covered by a test.** `add::run()` has the same shape as `doctor::run()` — it finds the workspace via `current_dir()` + `workspace::detect()` and does real registration and cloning — so asserting "pre-fetch happens before the ref check" needs the e2e harness from #69. Noted there. The fetch mechanism it depends on is unit-tested and mutation-verified above.

## Test plan

- [x] `just check` passes
- [x] 659 tests pass (655 + 4 new)
- [x] `SKILL.md` regenerated for the new flag
- [x] Mutation check as above
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)