### PR TITLE
ci(release): release via reviewed PR and workflow dispatch

### DIFF
--- a/.claude/skills/wsp-release/SKILL.md
+++ b/.claude/skills/wsp-release/SKILL.md
@@ -33,6 +33,12 @@ Two settings make that work, and both matter:
 Dispatching with no version (input `dry-run`, the default) plans the release
 without publishing — useful for checking the pipeline.
 
+Tags here are immutable: the tag ruleset blocks delete and update with no
+bypass actors, so a wrong tag cannot be taken back. `just release-dispatch`
+therefore refuses to run unless `origin/main`'s version matches the version you
+asked for, which catches dispatching before the release PR has merged. It also
+accepts `0.19.0` or `v0.19.0` and always tags with the `v`.
+
 Note a tagging *action* using the default `GITHUB_TOKEN` would not work here:
 events raised by that token do not start new workflow runs, so a pushed tag
 would never trigger `release.yml`. Dispatch avoids the problem entirely rather

--- a/.claude/skills/wsp-release/SKILL.md
+++ b/.claude/skills/wsp-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wsp-release
-description: Cut a wsp release (dry-run, execute, verify)
+description: Cut a wsp release (prep PR, dispatch, verify)
 user_invocable: true
 ---
 
@@ -10,7 +10,38 @@ Cut a new wsp release using `cargo-release` and `git cliff`.
 
 ## Arguments
 
-- `<bump>` -- `patch`, `minor`, or `major`
+- `<bump>` -- `patch`, `minor`, `major`, or an explicit version for a
+  prerelease (e.g. `0.19.0-rc.1`)
+
+## How releases land
+
+Releases go through a reviewed PR, and **nobody pushes tags from a laptop**.
+
+    just release-prep <bump>          # bump + changelog, commit on a branch
+    <push branch, open PR, review, merge>
+    just release-dispatch <version>   # CI creates the tag and releases
+
+Two settings make that work, and both matter:
+
+- `release.toml` sets `push = false` and `tag = false`, so `cargo-release` only
+  prepares the commit. It must not tag: a squash merge rewrites the SHA, so a
+  locally created tag would point at a commit that never lands on `main`.
+- `dist-workspace.toml` sets `dispatch-releases = true`, so `release.yml`
+  triggers on `workflow_dispatch` with a `tag` input instead of on tag pushes.
+  CI creates the tag itself via `gh release create --target <commit>`.
+
+Dispatching with no version (input `dry-run`, the default) plans the release
+without publishing — useful for checking the pipeline.
+
+Note a tagging *action* using the default `GITHUB_TOKEN` would not work here:
+events raised by that token do not start new workflow runs, so a pushed tag
+would never trigger `release.yml`. Dispatch avoids the problem entirely rather
+than needing a PAT.
+
+Prereleases (any version with a suffix, e.g. `0.19.0-rc.1`) are marked as
+prereleases by `release.yml` and **skip the Homebrew publish**, so stable users
+are unaffected. Write `WHATSNEW.md` notes for them like any other release, and
+say in the first paragraph that it is a prerelease and not on Homebrew.
 
 ## Steps
 
@@ -48,37 +79,37 @@ bump is `minor`, the new version is 0.16.0). Use today's date.
 Show the draft to the user for review. Wait for approval before proceeding. The user
 may edit the notes directly.
 
-### 4. Dry-run
+### 4. Prepare the release PR
+
+Prepare the bump on a branch. `cargo-release` bumps `Cargo.toml`, regenerates
+`CHANGELOG.md`, and commits — it does not tag and does not push.
 
 ```bash
-just release <bump>
-```
-
-**Warning:** The dry-run executes the pre-release hook, which **modifies `CHANGELOG.md`**. After reviewing the dry-run output, restore it:
-
-```bash
-git checkout CHANGELOG.md
-```
-
-Show the user the dry-run output and ask for explicit confirmation before proceeding.
-
-If the release is aborted after step 3, restore both files:
-
-```bash
-git checkout CHANGELOG.md WHATSNEW.md
-```
-
-### 5. Commit release notes and execute
-
-Commit `WHATSNEW.md` so the tree is clean for `cargo-release`:
-
-```bash
+git switch -c release/v<version>
+just release-prep <bump>
 git add WHATSNEW.md
-git commit -m "docs(whatsnew): add v<version> release notes"
-just release-execute <bump>
+git commit --amend --no-edit
+git push -u origin release/v<version>
+gh pr create --title "chore(release): v<version>"
 ```
 
-This bumps `Cargo.toml`, regenerates `CHANGELOG.md`, commits, tags `v<version>`, and pushes. The tag push triggers `.github/workflows/release.yml` (cargo-dist) which builds binaries, creates a GitHub Release, and publishes to the Homebrew tap.
+Amending folds the release notes into the same commit, so the PR is one
+self-contained change. Get it reviewed and merged before continuing.
+
+### 5. Dispatch the release
+
+Once the PR is merged:
+
+```bash
+just release-dispatch <version>
+```
+
+CI creates the tag against the merged commit and runs `release.yml`, which
+builds binaries, creates the GitHub Release, and publishes to the Homebrew tap
+(skipped automatically for prereleases).
+
+Run `just release-dispatch` with no argument first if you want a dry run: it
+plans the release without publishing anything.
 
 ### 6. Verify
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ name: Release
 permissions:
   "contents": "write"
 
-# This task will run whenever you push a git tag that looks like a version
+# This task will run whenever you workflow_dispatch with a tag that looks like a version
 # like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
 # Various formats will be parsed into a VERSION and an optional PACKAGE_NAME, where
 # PACKAGE_NAME must be the name of a Cargo package in your workspace, and VERSION
@@ -40,9 +40,13 @@ permissions:
 # will be marked as a prerelease.
 on:
   pull_request:
-  push:
-    tags:
-      - '**[0-9]+.[0-9]+.[0-9]+*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release Tag
+        required: true
+        default: dry-run
+        type: string
 
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
@@ -50,9 +54,9 @@ jobs:
     runs-on: "ubuntu-22.04"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
-      tag: ${{ !github.event.pull_request && github.ref_name || '' }}
-      tag-flag: ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }}
-      publishing: ${{ !github.event.pull_request }}
+      tag: ${{ (inputs.tag != 'dry-run' && inputs.tag) || '' }}
+      tag-flag: ${{ inputs.tag && inputs.tag != 'dry-run' && format('--tag={0}', inputs.tag) || '' }}
+      publishing: ${{ inputs.tag && inputs.tag != 'dry-run' }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -77,7 +81,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
+          dist ${{ (inputs.tag && inputs.tag != 'dry-run' && format('host --steps=create --tag={0}', inputs.tag)) || 'plan' }} --output-format=json > plan-dist-manifest.json
           echo "dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
@@ -93,7 +97,7 @@ jobs:
     # Let the initial task tell us to not run (currently very blunt)
     needs:
       - plan
-    if: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') }}
+    if: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') || inputs.tag == 'dry-run' }}
     strategy:
       fail-fast: false
       # Target platforms/runners are computed by dist in create-release.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,9 @@ Product: binary `wsp`, metadata `.wsp.yaml`, env `WSP_SHELL`, shell vars `wsp_bi
 
 ## Releasing
 
-See `/wsp-release` skill for the multi-step process. Key gotcha: dry-run modifies `CHANGELOG.md` — run `git checkout CHANGELOG.md` before executing.
+See `/wsp-release` skill for the multi-step process.
+
+**Releases go through a reviewed PR, and nobody pushes tags from a laptop.** `just release-prep <bump>` bumps the version and changelog into a commit on a branch; that PR is reviewed and merged; then `just release-dispatch <version>` triggers CI, which creates the tag itself against the merged commit. `release.toml` sets `push = false` and `tag = false`, and `dist-workspace.toml` sets `dispatch-releases = true`, so `release.yml` runs on `workflow_dispatch` rather than a tag push. Tagging before the merge would be wrong anyway — a squash merge rewrites the SHA.
 
 **Do not manually edit `release.yml`.** It is fully owned by `cargo-dist` — any hand-edits (e.g. SHA-pinning actions) will be overwritten the next time `dist generate` runs, and the `dist plan` freshness check in CI will fail on every PR until they are reverted.
 

--- a/Justfile
+++ b/Justfile
@@ -67,10 +67,28 @@ release-prep level:
 
 # CI creates the tag itself against the merged commit, so no one pushes tags
 # from a laptop. With no version it dispatches a dry run that plans only.
+# Tags are immutable here (the tag ruleset blocks delete and update, with no
+# bypass), so a wrong tag cannot be taken back — hence the checks below.
 # release step 2 — after the PR merges, trigger the release from CI
 release-dispatch version="dry-run":
-    gh workflow run Release --ref main -f tag={{version}}
-    @echo "dispatched Release with tag={{version}} — watch: gh run list --workflow Release"
+    #!/usr/bin/env sh
+    set -eu
+    if [ "{{version}}" = "dry-run" ]; then
+        gh workflow run Release --ref main -f tag=dry-run
+        echo "dispatched a dry run — plans, publishes nothing"
+        exit 0
+    fi
+    # Accept 0.19.0 or v0.19.0; always tag with the v, matching every existing tag.
+    want=$(printf '%s' "{{version}}" | sed 's/^v//')
+    git fetch -q origin main
+    have=$(git show origin/main:Cargo.toml | sed -n 's/^version[[:space:]]*=[[:space:]]*"\(.*\)".*/\1/p' | head -1)
+    if [ "$want" != "$have" ]; then
+        echo "refusing to release v$want: origin/main is at $have" >&2
+        echo "has the release PR been merged?" >&2
+        exit 1
+    fi
+    gh workflow run Release --ref main -f tag="v$want"
+    echo "dispatched Release with tag=v$want — watch: gh run list --workflow Release"
 
 # install git pre-commit hook
 [unix]

--- a/Justfile
+++ b/Justfile
@@ -59,13 +59,18 @@ fix:
 changelog:
     git cliff --unreleased
 
-# dry-run a release (patch, minor, or major)
-release level:
-    cargo release {{level}}
-
-# execute a release (patch, minor, or major)
-release-execute level:
+# Bumps versions and regenerates CHANGELOG.md into a commit, then stops:
+# release.toml sets push=false and tag=false. Push the branch and open a PR.
+# release step 1 — prepare the version bump on a branch, for review
+release-prep level:
     cargo release {{level}} --execute
+
+# CI creates the tag itself against the merged commit, so no one pushes tags
+# from a laptop. With no version it dispatches a dry run that plans only.
+# release step 2 — after the PR merges, trigger the release from CI
+release-dispatch version="dry-run":
+    gh workflow run Release --ref main -f tag={{version}}
+    @echo "dispatched Release with tag={{version}} — watch: gh run list --workflow Release"
 
 # install git pre-commit hook
 [unix]

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -5,6 +5,11 @@ members = ["cargo:crates/wsp"]
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
 cargo-dist-version = "0.32.0"
+# Release by dispatching the workflow, not by pushing a tag, so nobody needs
+# push access to tags from a laptop. CI creates the tag itself via
+# `gh release create --target <commit>`. Dispatching with the default input
+# ("dry-run") plans without publishing.
+dispatch-releases = true
 # CI backends to support
 ci = "github"
 # The installers to generate for each app

--- a/release.toml
+++ b/release.toml
@@ -1,5 +1,12 @@
 publish = false
-push = true
+
+# Releases go through a reviewed PR, so cargo-release only prepares the commit:
+# it must not push to main, and must not tag. Tagging here would be actively
+# wrong — a squash merge rewrites the SHA, so the tag has to be created against
+# the *merged* commit afterwards (`just release-tag`), not this local one.
+push = false
+tag = false
+
 push-remote = "origin"
 tag-name = "v{{version}}"
 tag-message = "v{{version}}"


### PR DESCRIPTION
## Why

Releasing ran `cargo release --execute` from a laptop: it pushed the version bump straight to `main` and pushed a tag. Two problems.

The bump bypassed review entirely — the one commit that changes what users install was the only one nobody looked at. And it only worked because the branch-protection ruleset still grants admins bypass; turning that off would have broken releases with no warning.

## What it looks like now

```
just release-prep <bump>          # bump + changelog, commit on a branch
<push, open PR, review, merge>
just release-dispatch <version>   # CI creates the tag and releases
```

Two settings carry it:

- **`release.toml`**: `push = false`, `tag = false`. `cargo-release` only prepares the commit. It must not tag either — a squash merge rewrites the SHA, so a locally created tag would point at a commit that never lands on `main`.
- **`dist-workspace.toml`**: `dispatch-releases = true`. cargo-dist regenerates `release.yml` to trigger on `workflow_dispatch` with a `tag` input instead of on tag pushes, and CI creates the tag itself via `gh release create --target <commit>`.

```yaml
on:
  pull_request:
  workflow_dispatch:
    inputs:
      tag:
        description: Release Tag
        required: true
        default: dry-run
```

`default: dry-run` means an accidental dispatch plans without publishing.

## The obvious alternative does not work

A "tag it from an Action" workflow is the intuitive fix, and it fails silently: **events raised by the default `GITHUB_TOKEN` do not start new workflow runs**, so a tag pushed by CI would never trigger `release.yml`. Making it work needs a PAT or a GitHub App token — another secret to own and rotate. `dispatch-releases` is cargo-dist's supported answer and avoids the problem instead of paying for it.

## Simplifications

Dropped the `just release` dry-run recipe and its step in the skill. It executed the pre-release hook, **mutated `CHANGELOG.md`**, and required a manual `git checkout CHANGELOG.md` to undo — a footgun that only existed because releases used to be irreversible once executed. The PR is now the review artifact, and dispatch provides a non-destructive dry run.

Net: three release recipes become two, and the skill loses a step and its cleanup warning.

Also fixed the `just --list` rendering — `just` shows only the last comment line before a recipe, so multi-line comments were surfacing mid-sentence fragments:

```
release-dispatch version="dry-run" # merged commit. Omit the version for a dry run...   (before)
release-dispatch version="dry-run" # release step 2 — after the PR merges, trigger...   (after)
```

## Verification

- [x] `release.yml` is unmodified `dist generate` output — the `plan` check in CI verifies this
- [x] Both workflows parse; triggers are `pull_request` + `workflow_dispatch`
- [x] `gh workflow run Release` matches `name: Release` in the workflow
- [x] `just --list` renders both recipes correctly
- [x] `just check` passes
- [ ] CI green

**Note the new flow cannot be exercised until this merges** — `workflow_dispatch` only appears once the workflow is on the default branch. The first real use is the `0.19.0-rc.1` prerelease, which is the point: it validates both this and the cargo-dist 0.32.0 upgrade from #77 before a stable release depends on them.

Docs updated: the `/wsp-release` skill and the Releasing section of AGENTS.md, both of which still described pushing to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)