### PR TITLE
ci: fail a release PR that has no WHATSNEW entry

### DIFF
--- a/.claude/skills/wsp-release/SKILL.md
+++ b/.claude/skills/wsp-release/SKILL.md
@@ -33,11 +33,27 @@ Two settings make that work, and both matter:
 Dispatching with no version (input `dry-run`, the default) plans the release
 without publishing — useful for checking the pipeline.
 
+You can dispatch from the GitHub Actions UI instead of a laptop — the Justfile
+recipe is only a convenience wrapper.
+
 Tags here are immutable: the tag ruleset blocks delete and update with no
-bypass actors, so a wrong tag cannot be taken back. `just release-dispatch`
-therefore refuses to run unless `origin/main`'s version matches the version you
-asked for, which catches dispatching before the release PR has merged. It also
-accepts `0.19.0` or `v0.19.0` and always tags with the `v`.
+bypass actors, so a wrong tag cannot be taken back. Two things guard against
+that, and the second covers the UI as well:
+
+- `just release-dispatch` refuses unless `origin/main`'s version matches the
+  version asked for, which catches dispatching before the release PR has
+  merged. It accepts `0.19.0` or `v0.19.0` and always tags with the `v`.
+- cargo-dist refuses any tag that does not match a package version, and says
+  which tag is correct. This happens in the `plan` job, and every other job
+  declares `needs: plan`, so a typo fails *before* `gh release create` makes
+  the tag. Nothing permanent happens.
+
+        $ dist plan --tag=v9.9.9
+        × This workspace doesn't have anything for dist to Release!
+        help: --tag=v0.18.0 will Announce: wsp
+
+Only the first check knows about the release PR, so dispatching a *valid but
+not-yet-merged* version is the one mistake the UI will not catch for you.
 
 Note a tagging *action* using the default `GITHUB_TOKEN` would not work here:
 events raised by that token do not start new workflow runs, so a pushed tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,43 @@ jobs:
       # --all-targets so test code is linted too; mirrors `just check`.
       - run: cargo clippy --workspace --all-targets -- -D warnings
 
+  # A release PR must carry its release notes. Nothing else enforces this:
+  # cargo-release writes CHANGELOG.md from commit subjects, but the prose in
+  # WHATSNEW.md is hand-written and easy to forget — and once the release is
+  # dispatched the tag is immutable, so "fix it in the next one" is the only
+  # remedy. A no-op on every PR that does not change the version.
+  whatsnew:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: require release notes when the version changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          read_version() { sed -n 's/^version[[:space:]]*=[[:space:]]*"\(.*\)".*/\1/p' | head -1; }
+          old=$(git show "$BASE_SHA:Cargo.toml" | read_version)
+          new=$(read_version < Cargo.toml)
+          if [ -z "$new" ]; then
+            echo "::error::could not read the version from Cargo.toml; this check did not run"
+            exit 1
+          fi
+          if [ "$old" = "$new" ]; then
+            echo "version unchanged ($new) — release notes not required"
+            exit 0
+          fi
+          if ! grep -q "^## \[$new\]" WHATSNEW.md; then
+            echo "::error::Cargo.toml moves $old -> $new but WHATSNEW.md has no '## [$new]' section. Add the release notes before merging."
+            exit 1
+          fi
+          echo "release notes present for $new"
+
   # Linux runs first. If logic is broken it shows up here cheaply before we
   # spin up macOS and Windows runners.
   test-linux:


### PR DESCRIPTION
Follow-up to #84. These two commits were pushed to that branch after it had already been merged, so they never made it in.

## The gate

`cargo-release` writes `CHANGELOG.md` from commit subjects, but `WHATSNEW.md` is hand-written prose and nothing enforced it. Forgetting is easy, and the consequence is permanent: once a release is dispatched the tag cannot be deleted or moved (the tag ruleset blocks both, with no bypass actors), so the only remedy is a note in the *next* release.

A `whatsnew` job compares `Cargo.toml`'s version against the PR base:

- version unchanged → no notes required, so it is a **no-op on every ordinary PR**
- version changed → requires a matching `## [<version>]` section in `WHATSNEW.md`

```
::error::Cargo.toml moves 0.18.0 -> 0.19.0-rc.1 but WHATSNEW.md has no
'## [0.19.0-rc.1]' section. Add the release notes before merging.
```

It fails loudly if the version cannot be read at all, so a broken check never looks like a satisfied one.

Verified in all three cases before committing: unchanged passes, changed-without-notes fails, changed-with-notes passes.

## Also: cargo-dist validates the tag too

The Justfile guard added in #84 is not the only thing between a typo and a permanent tag, and the skill now says so. cargo-dist refuses any tag that does not match a package version:

```
$ dist plan --tag=v9.9.9
× This workspace doesn't have anything for dist to Release!
help: --tag=v0.18.0 will Announce: wsp
```

That runs in the `plan` job, and every other job declares `needs: plan`, so a typo fails *before* `gh release create` makes the tag. This matters because dispatching from the Actions UI bypasses the Justfile guard entirely.

Documented alongside it: the one mistake the UI will not catch is dispatching a valid-but-not-yet-merged version, since only the local guard knows about the release PR.

## Follow-up

`whatsnew` is not in the ruleset's required-checks list yet, so it is advisory until added. I deliberately left that until it has run green at least once — adding a broken check to the required list would wedge every merge, including the fix for the check itself.

## Test plan

- [x] `ci.yml` parses; jobs are `check`, `whatsnew`, `test-linux`, `test-cross`
- [x] Gate logic verified in all three cases
- [x] `just check` passes
- [ ] CI green, and `whatsnew` reports as a check

🤖 Generated with [Claude Code](https://claude.com/claude-code)