### PR TITLE
chore(release): v0.19.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,68 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.19.0-rc.1] - 2026-08-22
 
 ### Features
 
-- *(windows)* Add Windows platform support — `wsp` now builds and passes its full test suite on Windows. Where Windows cannot create symlinks (Developer Mode disabled and the process not elevated), `wsp` degrades gracefully instead of failing: the `CLAUDE.md` link is skipped, `wsp doctor` reports how to resolve it, and `wsp gc` copies the rest of the workspace
+- *(completion)* Add PowerShell shell integration
+- Add Windows platform support
 
 ### Bug Fixes
 
-- *(workspace)* Fix `wsp new` and `wsp repo add` failing when a repo's default branch is not `main` (e.g. `master`, `develop`, `release/2.x`)
-- *(workspace)* Fix workspace creation silently using the wrong branch name for repos whose default branch contains a slash (e.g. `release/2.x`)
+- *(workspace)* Handle non-main default branches and slash branch names
+- Address second code review findings on non-main default branch fix
+- Address review findings — tests, inline refspec guard
+- *(test)* Write corrupted symref directly to bypass git ref validation
+- *(git)* Fall back to direct file read when git symbolic-ref rejects invalid target
+- *(completion)* Address review findings in PowerShell shell integration
+- *(mirror)* Actionable warnings when ref propagation is skipped
+- *(windows)* Centralize symlink fallback and harden Windows paths
+- *(doctor)* Refresh the registry snapshot after registering a repo (#82)
+- *(repo add)* Refresh mirrors before cloning into a workspace (#83)
+- *(release)* Make release-prep runnable without a TTY
+
+### Refactor
+
+- *(git)* Extract strip_ref_branch helper; fix fetch error handling
+
+### Documentation
+
+- *(completion)* Add persistent setup instructions to help text
+- Record the release.yml, prerelease and toolchain decisions (#79)
+- *(release)* Record what does not belong in WHATSNEW (#86)
+
+### Testing
+
+- *(windows)* Un-gate run_commands_continues_after_failure
+- *(doctor)* Cover --fix registering repos from clone origin (#65) (#80)
+
+### Miscellaneous
+
+- Apply cargo fmt
+- *(changelog)* Add unreleased entries for issue #60 fix
+- *(changelog)* Rewrite unreleased entries for user audience
+- *(lint)* Flatten Option iteration in legacy-ref-field fix
+
+### Build
+
+- Pin rust-toolchain to 1.97.1, and fail when the pin goes stale (#74)
+- Bump pinned toolchain to 1.98.0 (#76)
+- Bump cargo-dist to 0.32.0 and regenerate release.yml (#77)
+
+### Ci
+
+- Add macOS and Windows to the test matrix
+- Pipeline check → test-linux → test-cross (macOS + Windows)
+- Grant checks:write so audit-check can report findings
+- Add nightly dependency audit
+- Offset audit cron off the top of the hour
+- Warn before scheduled workflows are auto-disabled
+- Add Dependabot for SHA-pinned workflow actions (#73)
+- Update pinned action SHAs in ci.yml and audit.yml (#78)
+- Lint test code and enforce it with --all-targets (#81)
+- *(release)* Release via reviewed PR and workflow dispatch (#84)
+- Fail a release PR that has no WHATSNEW entry (#85)
 
 ## [0.18.0] - 2026-05-29
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,7 +1540,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wsp"
-version = "0.18.0"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "wsp-core"
-version = "0.18.0"
+version = "0.19.0-rc.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version    = "0.18.0"
+version    = "0.19.0-rc.1"
 edition    = "2024"
 license    = "MIT"
 repository = "https://github.com/jganoff/wsp"

--- a/Justfile
+++ b/Justfile
@@ -63,7 +63,7 @@ changelog:
 # release.toml sets push=false and tag=false. Push the branch and open a PR.
 # release step 1 — prepare the version bump on a branch, for review
 release-prep level:
-    cargo release {{level}} --execute
+    cargo release {{level}} --execute --no-confirm
 
 # CI creates the tag itself against the merged commit, so no one pushes tags
 # from a laptop. With no version it dispatches a dry run that plans only.

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -1,5 +1,34 @@
 # What's New
 
+## [0.19.0-rc.1] - 2026-08-22
+
+### PowerShell shell integration
+
+`wsp completion powershell` sets up tab completion and the `wsp cd` wrapper,
+bringing PowerShell in line with zsh, bash, and fish.
+
+```
+wsp completion powershell
+```
+
+### Fixes
+
+- Per-repo setup commands now run on Windows. They were invoked through `sh`,
+  which is not there by default, so they failed.
+- If Windows will not let `wsp` create symlinks — Developer Mode off, and not
+  running elevated — it keeps going instead of failing. The `CLAUDE.md` link
+  is skipped, and `wsp doctor` tells you what to turn on.
+- `wsp repo add` now fetches before cloning. Adding a repo you had added
+  before gave you whatever was last fetched, which could be weeks old. It also
+  made a branch you had just pushed look missing, so the repo quietly started a
+  new branch instead of tracking yours. Pass `--no-fetch` to skip the fetch.
+- `wsp doctor --fix` no longer warns that a repo's origin URL differs from the
+  registry right after registering that repo itself.
+- `wsp new` and `wsp repo add` work with repos whose default branch is not
+  `main`, including branch names containing slashes.
+- `wsp repo fetch` now says why it skipped propagating refs instead of staying
+  silent.
+
 ## [0.18.0] - 2026-05-29
 
 `wsp` now works properly on Windows: a PowerShell one-liner installs it,


### PR DESCRIPTION
First release cut through the reviewed-PR flow, and the first prerelease.

## What this contains

- `Cargo.toml` / `Cargo.lock`: 0.18.0 → 0.19.0-rc.1
- `CHANGELOG.md`: regenerated by git-cliff
- `WHATSNEW.md`: user-facing notes for the release

Plus one fix found while running the flow for real: `just release-prep` had no `--no-confirm`, so `cargo-release` hit its confirmation prompt, took the no-TTY default of "No", and silently did nothing. Safe to skip — the recipe only writes a local commit, and this PR is the actual gate.

## What happens after merge

```
just release-dispatch 0.19.0-rc.1
```

CI creates the tag against the merged commit and runs `release.yml`. Because the version is suffixed, the GitHub release is flagged prerelease and **`publish-homebrew-formula` is skipped**, so `brew upgrade` users are unaffected.

## Why a prerelease

It exercises the parts of the pipeline that no PR can: cargo-dist 0.32.0 (#77), the `workflow_dispatch` trigger (#84), tag creation by CI, and all five target builds. The one job it will not cover is the Homebrew tap publish, which is skipped for prereleases — that stays untested until the real 0.19.0.

Per the skill, a prerelease that tests well is **rebuilt** as 0.19.0, not promoted: `wsp --version` bakes in `CARGO_PKG_VERSION` at compile time, so these artifacts would report `0.19.0-rc.1` forever.

## Note

This is also the first real test of the `whatsnew` gate (#85) against an actual version bump — every prior run took the no-op path. Simulated locally against this diff and it passes; CI is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)