### PR TITLE
DO NOT MERGE — verify the whatsnew gate fails without release notes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version    = "0.18.0"
+version    = "0.19.0-rc.1"
 edition    = "2024"
 license    = "MIT"
 repository = "https://github.com/jganoff/wsp"


### PR DESCRIPTION
Throwaway, opened to see the `whatsnew` gate (#85) actually go red. Will be closed and the branch deleted once it does.

Bumps `Cargo.toml` to `0.19.0-rc.1` and deliberately leaves `WHATSNEW.md` alone, so the gate should fail with:

```
::error::Cargo.toml moves 0.18.0 -> 0.19.0-rc.1 but WHATSNEW.md has no
'## [0.19.0-rc.1]' section. Add the release notes before merging.
```

**Why bother:** every run of that job so far has either taken the no-op path (version unchanged) or the passing path (#87, notes present). The failing branch — the entire reason the job exists — has only ever been verified by running the logic locally. A check that cannot be seen failing is not yet known to work.

Doing this on a scratch branch rather than by sabotaging #87 keeps the release PR clean.

Expect the other jobs to be irrelevant here; only `whatsnew` matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)