### PR TITLE
docs: make RELEASING.md the single source for the release process

### DIFF
--- a/.claude/skills/wsp-release/SKILL.md
+++ b/.claude/skills/wsp-release/SKILL.md
@@ -6,107 +6,22 @@ user_invocable: true
 
 # Release wsp
 
-`<bump>` is `patch`, `minor`, `major`, or an explicit prerelease version
-(`0.19.0-rc.1`).
+**Read `RELEASING.md` first — it is the process. This file only covers what an
+agent should do differently from a human following it.**
 
-## Flow
+Argument: `<bump>` — `patch`, `minor`, `major`, or an explicit prerelease
+version.
 
-```
-just release-prep <bump>          # bump + CHANGELOG, commit on a branch
-<push, open PR, review, merge>
-just release-dispatch <version>   # CI creates the tag and releases
-```
+1. Stop if the tree is dirty. Run `just build` so later checks use current code.
+2. `just changelog`, show the user the unreleased entries, and confirm the bump
+   level matches them.
+3. Draft the `WHATSNEW.md` notes per the rules in `RELEASING.md`. **Show the
+   draft and wait for approval** before continuing; the user may rewrite it.
+4. Work through the flow in `RELEASING.md`. Do not merge the release PR
+   yourself.
+5. After it merges, run `just release-dispatch <version>` and report each job.
+   Say plainly whether `publish-homebrew-formula` ran or skipped.
+6. Update the GitHub release body as described there.
 
-Nobody pushes tags from a laptop. `release.toml` sets `push=false tag=false`
-(a squash merge rewrites the SHA, so a local tag would point at a commit that
-never lands); `dist-workspace.toml` sets `dispatch-releases=true`, so
-`release.yml` runs on `workflow_dispatch` and CI creates the tag via
-`gh release create --target`. Dispatching is also possible from the Actions UI.
-
-Do not replace this with a tagging action: tags pushed by the default
-`GITHUB_TOKEN` do not trigger workflows, so `release.yml` would never run.
-
-Tags are immutable (ruleset blocks delete/update, no bypass). Two guards:
-`release-dispatch` refuses unless `origin/main`'s version matches, and
-cargo-dist rejects any tag not matching a package version — in `plan`, which
-every job needs, so a typo fails before the tag exists. Only the first guard
-knows whether the PR merged, so that is the one mistake the UI won't catch.
-
-## Prereleases
-
-Any suffixed version is flagged prerelease and **skips the Homebrew publish**.
-That is the only skipped job, so the tap publish stays untested until the real
-release; it runs after `host`, so if it fails, re-run that job rather than
-re-cutting.
-
-**Rebuild the final version, don't promote the rc.** `wsp --version` comes from
-`CARGO_PKG_VERSION` at compile time, so rc artifacts report `-rc.1` forever and
-`wsp whatsnew` would look up the wrong entry. cargo-dist has no promote command.
-
-## Steps
-
-1. **Clean tree + fresh build.** `git status`; stop if dirty. `just build`.
-2. **Changelog.** `just changelog`. Show the user; confirm the bump level.
-3. **Notes.** Write them (see below), prepend to `WHATSNEW.md` under
-   `# What's New`, with the post-bump version and today's date. Show the draft
-   and wait for approval.
-4. **Release PR.**
-   ```bash
-   git switch -c release/v<version>
-   just release-prep <bump>
-   git add WHATSNEW.md && git commit --amend --no-edit
-   git push -u origin release/v<version>
-   gh pr create --title "chore(release): v<version>"
-   ```
-   Amending keeps the PR one self-contained change. Merge before continuing.
-5. **Dispatch.** `just release-dispatch <version>`. With no argument it dry-runs
-   (plans, publishes nothing).
-6. **Verify.** `gh run list --limit 5`, `gh release list --limit 3`.
-7. **Release body.** Prepend the `WHATSNEW.md` section for this version to the
-   existing body (which holds cargo-dist's install table):
-   `gh release view v<version> --json body -q .body`, combine, then
-   `gh release edit v<version> --notes-file <file>`.
-
-## Writing release notes
-
-For people who **use** wsp. Technical, impatient, want to know what to try and
-what got fixed. Second person, active voice, no hype, no emoji — Fish or Rust
-release notes, not a launch announcement.
-
-**Read the last few `WHATSNEW.md` entries first.** Re-announcing shipped work
-makes the old release look empty and this one padded. 0.18.0 already announced
-Windows, so "wsp now runs on Windows" was wrong despite being true — the new
-thing was PowerShell shell integration, the rest were fixes.
-
-Leave out:
-
-- Maintainer-only changes: CI, release process, refactors, tests, deps,
-  internal APIs. If a user can't observe it by running `wsp`, it isn't a note.
-  Expect to drop most of the changelog — that's the full record, this is the
-  useful subset.
-- Proof of work: "passes its full test suite", "now has 600 tests".
-- Implementation detail. Not "cloned from whatever the mirror last saw" but
-  "gave you whatever was last fetched, which could be weeks old".
-- Install instructions, including for prereleases.
-- Why the release exists ("cut to validate the pipeline").
-
-Structure, omitting what doesn't apply: **Breaking Changes** (first; what to
-do, before/after) → **Highlights** (only for 3+ features; one paragraph) →
-**What's New** (`###` per user-facing theme, 1-2 sentences + a command to try;
-themes need 2+ entries; under 3 features use a flat list) → **Fixes** (flat,
-most impactful first, each starting with the command) → **Internal** (only
-removals or deprecations a user could hit).
-
-Format: ATX headings; fenced blocks with no language tag (`wsp whatsnew` dims
-them, so don't rely on column alignment); backtick commands, flags, files; no
-HTML, tables, or color; wrap ~78 chars; `wsp st`, not "the status command". No
-"This release…", commit hashes, PR numbers, or version numbers in headings.
-
-**Verify every command exists** with `wsp --help` before finalizing.
-
-`WHATSNEW.md`'s v0.15.0 entry is a good full-structure example.
-
-## Notes
-
-- Changed `dist-workspace.toml`? Run `dist generate` before releasing.
-- `HOMEBREW_TAP_TOKEN` must be set for the Homebrew publish job.
+Verify every `wsp <cmd>` in the notes against `wsp --help` before showing the
+draft — do not rely on memory for command names.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 | All CLI commands | [`skills/wsp-manage/SKILL.md`](skills/wsp-manage/SKILL.md) (auto-generated) |
 | Architecture & module map | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) |
 | Removal safety algorithm | [`docs/features/removal-safety.md`](docs/features/removal-safety.md) |
-| Release workflow | `/wsp-release` skill |
+| Release workflow | [`RELEASING.md`](RELEASING.md) |
 
 ## After Cloning
 
@@ -103,9 +103,7 @@ Product: binary `wsp`, metadata `.wsp.yaml`, env `WSP_SHELL`, shell vars `wsp_bi
 
 ## Releasing
 
-See `/wsp-release` skill for the multi-step process.
-
-**Releases go through a reviewed PR, and nobody pushes tags from a laptop.** `just release-prep <bump>` bumps the version and changelog into a commit on a branch; that PR is reviewed and merged; then `just release-dispatch <version>` triggers CI, which creates the tag itself against the merged commit. `release.toml` sets `push = false` and `tag = false`, and `dist-workspace.toml` sets `dispatch-releases = true`, so `release.yml` runs on `workflow_dispatch` rather than a tag push. Tagging before the merge would be wrong anyway — a squash merge rewrites the SHA.
+See [`RELEASING.md`](RELEASING.md) for the process, or `/wsp-release` to be walked through it. In short: releases go through a reviewed PR and nobody pushes tags from a laptop. The rules below are the ones that bite during ordinary work, not at release time.
 
 **Do not manually edit `release.yml`.** It is fully owned by `cargo-dist` — any hand-edits (e.g. SHA-pinning actions) will be overwritten the next time `dist generate` runs, and the `dist plan` freshness check in CI will fail on every PR until they are reverted.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,93 +1,123 @@
 # Releasing
 
-Use the `/wsp-release` skill for the full guided workflow. This document
-is the reference for what happens and why.
+The whole process lives here. `/wsp-release` drives it but adds no rules of
+its own.
 
-## Quick Start
+## Flow
 
 ```bash
-# 1. Preview unreleased changes
-just changelog
-
-# 2. Write prose release notes in WHATSNEW.md (or let /wsp-release generate them)
-
-# 3. Dry-run (validates but modifies CHANGELOG.md -- restore after)
-just release minor
-git checkout CHANGELOG.md
-
-# 4. Commit release notes and execute
-git add WHATSNEW.md
-git commit -m "docs(whatsnew): add v0.x.0 release notes"
-just release-execute minor
+git switch -c release/v<version>
+just release-prep <bump>          # bump + CHANGELOG, commit; no tag, no push
+# write WHATSNEW.md notes, then fold them into that commit:
+git add WHATSNEW.md && git commit --amend --no-edit
+git push -u origin release/v<version>
+gh pr create --title "chore(release): v<version>"
+# ...review, merge...
+just release-dispatch <version>   # CI creates the tag and releases
 ```
 
-Replace `minor` with `patch` or `major` as appropriate.
+`<bump>` is `patch`, `minor`, `major`, or an explicit prerelease version
+(`0.19.0-rc.1`). Notes must be written *after* `release-prep`: cargo-release
+requires a clean tree.
 
-## What Happens
+## Why it works this way
 
-1. `cargo-release` bumps the version in both `Cargo.toml` files
-2. Pre-release hook runs `git cliff -o CHANGELOG.md --tag v<version>`
-3. Commits `chore(release): v<version>` (auto-stages `Cargo.toml`,
-   `Cargo.lock`, and `CHANGELOG.md`)
-4. Creates git tag `v<version>`
-5. Pushes branch and tag to origin
-6. Tag push triggers `.github/workflows/release.yml`
-7. `cargo-dist` builds cross-platform binaries and creates a GitHub Release
-8. The GitHub Release body is updated with prose notes from `WHATSNEW.md`
-   (done by `/wsp-release` step 7, or manually via `gh release edit`)
+Nobody pushes tags from a laptop, and the version bump gets reviewed like any
+other change.
 
-## Release Notes (WHATSNEW.md)
+- `release.toml` sets `push=false tag=false`, so cargo-release only prepares a
+  commit. It must not tag: a squash merge rewrites the SHA, so a local tag
+  would point at a commit that never lands on `main`.
+- `dist-workspace.toml` sets `dispatch-releases=true`, so `release.yml` runs on
+  `workflow_dispatch` and CI creates the tag via `gh release create --target`.
+  You can dispatch from the Actions UI; the Justfile recipe is a convenience.
 
-`WHATSNEW.md` contains user-facing prose release notes, embedded in the
-binary at compile time and shown by `wsp whatsnew`. Each release gets a
-new section prepended after the `# What's New` header.
+Do not replace this with a tagging action. Tags pushed by the default
+`GITHUB_TOKEN` do not trigger workflows, so `release.yml` would never run.
 
-The `/wsp-release` skill generates a draft for review before executing.
-For manual releases, write the section yourself following the style of
-existing entries.
+Tags are immutable (the ruleset blocks delete and update, no bypass). Two
+guards: `release-dispatch` refuses unless `origin/main`'s version matches, and
+cargo-dist rejects any tag not matching a package version — in `plan`, which
+every job needs, so a typo fails before the tag exists. Only the first knows
+whether the PR merged, so a valid-but-unmerged version is the one mistake the
+UI won't catch.
 
-## Gotchas
+## Prereleases
 
-- **Dry-run modifies `CHANGELOG.md`.** Always run `git checkout CHANGELOG.md`
-  after a dry-run before executing. If you abort after writing `WHATSNEW.md`,
-  restore both: `git checkout CHANGELOG.md WHATSNEW.md`.
-- **Commit `WHATSNEW.md` before executing.** `cargo-release` requires a clean
-  tree. Commit the release notes before running `just release-execute`.
-- **`dist-workspace.toml` changes** require running `dist generate` before
-  releasing to regenerate `.github/workflows/release.yml`.
+Any suffixed version is flagged prerelease and **skips the Homebrew publish** —
+the only skipped job, so the tap publish stays untested until a real release.
+It runs after `host`, so if it fails the release and binaries already exist;
+re-run that job rather than re-cutting.
 
-## Tools
+**Rebuild the final version, don't promote the rc.** `wsp --version` comes from
+`CARGO_PKG_VERSION` at compile time, so rc artifacts report `-rc.1` forever and
+`wsp whatsnew` would look up the wrong entry. cargo-dist has no promote command.
 
-| Tool | Purpose |
+## Writing release notes
+
+`WHATSNEW.md` is compiled into the binary and shown by `wsp whatsnew`. Prepend
+a section under `# What's New` using the post-bump version and today's date.
+
+Written for people who **use** wsp: technical, impatient, want to know what to
+try and what got fixed. Second person, active voice, no hype, no emoji.
+
+**Read the last few entries first.** Re-announcing shipped work makes the old
+release look empty and this one padded. 0.18.0 already announced Windows, so
+"wsp now runs on Windows" was wrong despite being true — the new thing was
+PowerShell shell integration, the rest were fixes.
+
+Leave out:
+
+- Maintainer-only changes: CI, release process, refactors, tests, deps,
+  internal APIs. If a user can't observe it by running `wsp`, it isn't a note.
+  Expect to drop most of the changelog — that's the full record, this is the
+  useful subset.
+- Proof of work: "passes its full test suite", "now has 600 tests".
+- Implementation detail. Not "cloned from whatever the mirror last saw" but
+  "gave you whatever was last fetched, which could be weeks old".
+- Install instructions, including for prereleases.
+- Why the release exists ("cut to validate the pipeline").
+
+Structure, omitting what doesn't apply: **Breaking Changes** (first; what to
+do, before/after) → **Highlights** (only for 3+ features; one paragraph) →
+**What's New** (`###` per user-facing theme, 1-2 sentences + a command to try;
+themes need 2+ entries; under 3 features use a flat list) → **Fixes** (flat,
+most impactful first, each starting with the command) → **Internal** (only
+removals or deprecations a user could hit).
+
+Format: ATX headings; fenced blocks with no language tag (`wsp whatsnew` dims
+them, so don't rely on column alignment); backtick commands, flags, files; no
+HTML, tables, or color; wrap ~78 chars; `wsp st`, not "the status command". No
+"This release…", commit hashes, PR numbers, or version numbers in headings.
+**Verify every command exists** with `wsp --help`. The v0.15.0 entry is a good
+full-structure example.
+
+## After the release
+
+Prepend the `WHATSNEW.md` section to the GitHub release body, which otherwise
+holds only cargo-dist's install table:
+
+```bash
+gh release view v<version> --json body -q .body   # combine with the notes
+gh release edit v<version> --notes-file <file>
+```
+
+Verify with `gh run list --limit 5` and `gh release list --limit 3`.
+
+## Setup and gotchas
+
+```bash
+cargo install cargo-release git-cliff cargo-dist
+```
+
+- Changed `dist-workspace.toml`? Run `dist generate` before releasing.
+- `HOMEBREW_TAP_TOKEN` must be set for the Homebrew publish job.
+- Binaries are built for five targets: macOS x86_64/aarch64, Linux
+  x86_64/aarch64, Windows x86_64/aarch64 (see `dist-workspace.toml`).
+
+| File | Purpose |
 |---|---|
-| [cargo-release](https://github.com/crate-ci/cargo-release) | Version bumping, tagging, pushing |
-| [git-cliff](https://github.com/orhun/git-cliff) | Changelog generation from conventional commits |
-| [cargo-dist](https://opensource.axo.dev/cargo-dist/) | Cross-platform binary builds + GitHub Releases |
-
-## Install Prerequisites
-
-```bash
-cargo install cargo-dist cargo-release git-cliff
-```
-
-## Configuration Files
-
-- `release.toml` -- cargo-release config (tag format, pre-release hooks, publish settings)
-- `cliff.toml` -- git-cliff config (commit grouping, tag pattern, changelog template)
-- `WHATSNEW.md` -- user-facing prose release notes (embedded in binary, shown by `wsp whatsnew`)
-- `.github/workflows/release.yml` -- GitHub Actions workflow generated by cargo-dist
-
-## Changelog
-
-The changelog is auto-generated from conventional commits. The `chore(release)` and `chore(deps)` commits are excluded. To preview unreleased changes:
-
-```bash
-git cliff --unreleased
-```
-
-## Targets
-
-Binaries are built for:
-- macOS (x86_64 + aarch64)
-- Linux (x86_64)
-- Windows (x86_64)
+| `release.toml` | cargo-release: tag format, hooks, `push`/`tag`/`publish` off |
+| `cliff.toml` | git-cliff: commit grouping, changelog template |
+| `dist-workspace.toml` | cargo-dist: targets, installers, `dispatch-releases` |
+| `.github/workflows/release.yml` | generated by `dist generate` — never hand-edit |


### PR DESCRIPTION
The release process was documented in **three** places — `RELEASING.md`, the `/wsp-release` skill, and `AGENTS.md` — and all three had drifted apart during today's changes.

## RELEASING.md was actively wrong

It still described the flow we replaced:

- `just release-execute` — a recipe that no longer exists
- "Creates git tag / Pushes branch and tag to origin" — cargo-release does neither now
- "Dry-run modifies `CHANGELOG.md`. Always run `git checkout CHANGELOG.md`" — that step and its recipe are gone
- Four target platforms listed; we build five

Anyone following it would have done the wrong thing.

## One source

`RELEASING.md` now owns the process end to end: the flow, why tags are created by CI, the `GITHUB_TOKEN` tagging trap, the immutability guards, prerelease behaviour, rebuild-don't-promote, and the release-notes rules. Root of the repo, so a human finds it — and a human writing notes by hand needs those rules as much as an agent does.

The skill becomes a pointer plus only what an agent should do *differently*: confirm the bump level with the user, show the notes draft and wait for approval, don't self-merge the release PR, and say plainly whether `publish-homebrew-formula` ran or skipped.

`AGENTS.md` keeps the `release.yml` ownership and Dependabot rules — those bite during ordinary PR work, not at release time — and links out for the rest.

## Size

205 lines across two files → 150, and the third copy is gone. Nothing was dropped: I checked the stale phrases are absent and that no `##`/`###` heading appears in both files.

## Test plan

- [x] No references remain to `release-execute`, `git checkout CHANGELOG`, `just release <bump>`, or tag pushing
- [x] No heading duplicated between `RELEASING.md` and the skill
- [x] Every `just` recipe referenced exists (`build`, `changelog`, `release-prep`, `release-dispatch`)
- [x] `CLAUDE.md` still a symlink to `AGENTS.md`
- [x] `just check` passes

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)