### PR TITLE
ci: smoke-test built binaries before tagging a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,14 +215,24 @@ jobs:
           path: |
             ${{ steps.cargo-dist.outputs.paths }}
             ${{ env.BUILD_MANIFEST_NAME }}
+
+  custom-smoke:
+    needs:
+      - plan
+      - build-local-artifacts
+    uses: ./.github/workflows/smoke.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit
   # Determines if we should publish/announce
   host:
     needs:
       - plan
       - build-local-artifacts
       - build-global-artifacts
+      - custom-smoke
     # Only run if we're "publishing", and only if plan, local and global didn't fail (skipped is fine)
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.custom-smoke.result == 'skipped' || needs.custom-smoke.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: "ubuntu-22.04"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,84 @@
+name: smoke
+
+# Smoke-tests the built binaries before the release is tagged.
+#
+# Wired in via `global-artifacts-jobs` in dist-workspace.toml, which is the
+# hook that makes `host` depend on this job. `host-jobs` looks like the right
+# hook and is not: it produces a job with the same dependencies as `host`, so
+# the two race and the tag is created regardless of the result.
+#
+# A failure here means no tag and no release, which is the point — tags are
+# immutable, so a bad one cannot be withdrawn.
+on:
+  workflow_call:
+    inputs:
+      plan:
+        required: true
+        type: string
+
+jobs:
+  smoke:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            archive: wsp-x86_64-unknown-linux-gnu.tar.xz
+          - os: macos-latest
+            archive: wsp-aarch64-apple-darwin.tar.xz
+          - os: windows-latest
+            archive: wsp-x86_64-pc-windows-msvc.zip
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Same pattern build-global-artifacts uses to collect the per-target
+      # builds from this run.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: artifacts-*
+          path: dist/
+          merge-multiple: true
+
+      - name: Unpack ${{ matrix.archive }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist
+          ls -1
+          case "${{ matrix.archive }}" in
+            *.zip)    unzip -q "${{ matrix.archive }}" -d unpacked ;;
+            *.tar.xz) mkdir -p unpacked && tar -xf "${{ matrix.archive }}" -C unpacked ;;
+          esac
+          bin=$(find unpacked -type f \( -name wsp -o -name wsp.exe \) | head -1)
+          [ -n "$bin" ] || { echo "::error::no wsp binary inside ${{ matrix.archive }}"; exit 1; }
+          echo "WSP_BIN=$PWD/$bin" >> "$GITHUB_ENV"
+
+      # The tag is empty on a dry run, in which case skip the version
+      # assertion rather than assert against nothing.
+      - name: Resolve expected version
+        shell: bash
+        env:
+          TAG: ${{ fromJson(inputs.plan).announcement_tag }}
+        run: echo "EXPECT=${TAG#v}" >> "$GITHUB_ENV"
+
+      - name: Smoke (unix)
+        if: runner.os != 'Windows'
+        run: |
+          if [ -n "${EXPECT:-}" ]; then
+            ./scripts/smoke.sh --wsp "$WSP_BIN" --expect-version "$EXPECT"
+          else
+            ./scripts/smoke.sh --wsp "$WSP_BIN"
+          fi
+
+      - name: Smoke (windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          if ($env:EXPECT) {
+            ./scripts/smoke.ps1 -Wsp $env:WSP_BIN -ExpectVersion $env:EXPECT
+          } else {
+            ./scripts/smoke.ps1 -Wsp $env:WSP_BIN
+          }

--- a/Justfile
+++ b/Justfile
@@ -55,6 +55,17 @@ fix:
     cargo fmt --all
     cargo clippy --workspace --all-targets --fix --allow-dirty -- -D warnings
 
+# Runs the same script CI runs before tagging a release, against a real
+# binary in a sandboxed data dir. Pass a path to check a downloaded artifact.
+# smoke-test a built binary end to end
+[unix]
+smoke bin="./target/release/wsp":
+    ./scripts/smoke.sh --wsp {{bin}}
+
+[windows]
+smoke bin=".\\target\\release\\wsp.exe":
+    ./scripts/smoke.ps1 -Wsp {{bin}}
+
 # preview unreleased changelog
 changelog:
     git cliff --unreleased

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -10,6 +10,10 @@ cargo-dist-version = "0.32.0"
 # `gh release create --target <commit>`. Dispatching with the default input
 # ("dry-run") plans without publishing.
 dispatch-releases = true
+# Smoke-test the built binaries before the release is tagged. This hook (not
+# host-jobs) is the one that makes `host` wait: host-jobs produces a job with
+# the same dependencies as host, so they race and the tag lands regardless.
+global-artifacts-jobs = ["./smoke"]
 # CI backends to support
 ci = "github"
 # The installers to generate for each app

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,90 @@
+# scripts
+
+These run in CI before every release is tagged (`global-artifacts-jobs` in
+`dist-workspace.toml` makes `host` wait on them), and locally via `just smoke`.
+A failure means no tag and no release.
+
+They are deliberately shallow — "does the published binary work at all". Deep
+behavioural coverage belongs in the e2e suite (#69); as that grows, these
+should shrink to what only an artifact check can catch.
+
+Two scripts, same checks: `smoke.sh` (macOS/Linux) and `smoke.ps1` (Windows).
+
+    just smoke                       # against ./target/release/wsp
+    just smoke path/to/wsp           # against a downloaded artifact
+
+    ./scripts/smoke.sh  --wsp ./wsp     --expect-version 0.19.0-rc.1
+    ./scripts/smoke.ps1 -Wsp .\wsp.exe -ExpectVersion 0.19.0-rc.1
+
+`smoke.sh` has been run and passes. `smoke.ps1` has not — it was written
+without a PowerShell to check it against, so expect the possibility of a typo
+on first use.
+
+## What they do
+
+Run a real `wsp` binary end to end. Use it to check a release build before
+trusting it — especially on Windows, where CI builds the binary but never runs
+a workflow with it.
+
+Without cloning (Windows shown; adapt the URL for `smoke.sh`):
+
+```powershell
+gh release download v0.19.0-rc.1 -p "wsp-x86_64-pc-windows-msvc.zip"
+Expand-Archive wsp-x86_64-pc-windows-msvc.zip -DestinationPath .\wsp-rc
+irm https://raw.githubusercontent.com/jganoff/wsp/test/smoke-script/scripts/smoke.ps1 -OutFile smoke.ps1
+./smoke.ps1 -Wsp .\wsp-rc\wsp.exe -ExpectVersion 0.19.0-rc.1
+```
+
+| Flag | |
+|---|---|
+| `--wsp` / `-Wsp` | path to the binary (required) |
+| `--expect-version` / `-ExpectVersion` | fail unless `--version` and `wsp whatsnew` both mention it |
+| `--offline` / `-Offline` | skip the network half |
+
+One `ok`/`FAIL` line per check; non-zero exit if any fail.
+
+**They sandbox themselves.** `XDG_DATA_HOME` points at a temp directory and
+`workspaces-dir` is set inside it, so your registry, mirrors, and workspaces
+are untouched. Cleanup runs in a `finally`/`trap`, so a mid-run failure still
+leaves nothing behind.
+
+`XDG_DATA_HOME` alone is not enough: commands detect the workspace from the
+working directory, so the scripts also `cd` somewhere neutral. Without that,
+running from inside a real workspace makes `doctor` inspect *that* one.
+
+**Checks.** Offline: `--version`, `--help`, `doctor`, `ls`, and
+shell completion — asserting the output contains `wsp` *and* parses
+(`bash -n` / `zsh -n`, or the PowerShell parser), since a string match alone
+would accept malformed output. `smoke.sh` checks whichever of bash/zsh are
+installed and skips the rest. With `--expect-version`, also that
+`wsp whatsnew` mentions it, proving the notes were compiled into the binary.
+
+With network: register a repo, `new`, confirm the clone exists on disk, `st`,
+`repo add` a second repo (exercising the fetch-before-clone path), `doctor`
+inside a real workspace, `rm`.
+
+**The network half uses real remotes on purpose** — that is what a user does,
+and it is the point of validating a release. It clones `octocat/Hello-World`
+and `octocat/Spoon-Knife`: small, public, no auth.
+
+That is a choice, not a constraint. `registry add` needs a URL with a host, so
+it rejects local paths (`file://` gives "host cannot be empty" — see #91), but
+a `git daemon` on localhost satisfies it, and the registry can also be seeded
+directly. Both are hermetic and both are written up in #69 for the e2e suite,
+where flakiness would actually matter.
+
+Start with `--offline` / `-Offline` on a new platform. It is fast and separates
+"does this binary run at all" from "does the whole workflow work".
+
+### In CI
+
+`.github/workflows/smoke.yml` runs on ubuntu/macOS/Windows against the
+binaries built earlier in the same release run, before anything is tagged.
+
+It is wired in with `global-artifacts-jobs`, not `host-jobs`. That matters:
+`host-jobs` generates a job with the same dependencies as `host`, so the two
+race and the tag is created regardless of the outcome. `global-artifacts-jobs`
+inserts upstream, giving `host: needs [..., custom-smoke]`.
+
+Only three of the five build targets have runners, so `aarch64-unknown-linux-gnu`
+and `aarch64-pc-windows-msvc` are built but never smoke-tested.

--- a/scripts/smoke.ps1
+++ b/scripts/smoke.ps1
@@ -1,0 +1,171 @@
+#!/usr/bin/env pwsh
+# Smoke-test a wsp build end to end.
+#
+# Runs against a real binary, in a sandboxed data directory, so it never
+# touches your registry, mirrors, or workspaces.
+#
+#   ./scripts/smoke.ps1 -Wsp C:\path\to\wsp.exe -ExpectVersion 0.19.0-rc.1
+#   ./scripts/smoke.ps1 -Wsp ./wsp.exe -Offline      # skip network steps
+#
+# Exits non-zero if any check fails.
+
+param(
+    [Parameter(Mandatory = $true)][string]$Wsp,
+    [string]$ExpectVersion = "",
+    [switch]$Offline
+)
+
+$ErrorActionPreference = "Continue"
+$failures = New-Object System.Collections.ArrayList
+
+function Ok($msg) { Write-Host "  ok    $msg" }
+function Bad($msg) { Write-Host "  FAIL  $msg" -ForegroundColor Red; [void]$failures.Add($msg) }
+
+# Run wsp, capturing stdout+stderr. Returns the output; sets $global:LastRc.
+function Wsp {
+    $out = & $Wsp @args 2>&1 | Out-String
+    $global:LastRc = $LASTEXITCODE
+    return $out
+}
+
+# Resolve to an absolute path before any Push-Location changes the CWD.
+$Wsp = (Resolve-Path $Wsp -ErrorAction Stop).Path
+
+# --- sandbox -------------------------------------------------------------
+# XDG_DATA_HOME is honoured on every platform, so this isolates config,
+# mirrors, gc and templates. workspaces-dir is separate and set below.
+$sandbox = Join-Path ([System.IO.Path]::GetTempPath()) ("wsp-smoke-" + [guid]::NewGuid().ToString("N").Substring(0, 8))
+New-Item -ItemType Directory -Force -Path $sandbox | Out-Null
+$oldXdg = $env:XDG_DATA_HOME
+$env:XDG_DATA_HOME = Join-Path $sandbox "data"
+$workspaces = Join-Path $sandbox "workspaces"
+New-Item -ItemType Directory -Force -Path $workspaces | Out-Null
+
+# Point git at a minimal config so that user-level url.insteadOf rewrites
+# (e.g. https://github.com/ -> git@github.com:) don't redirect the test
+# clones to SSH, where the agent may not be available.
+$gitConfig = Join-Path $sandbox "gitconfig"
+@"
+[user]
+    email = smoke@test.local
+    name = Smoke Test
+"@ | Set-Content -Path $gitConfig -Encoding utf8
+$oldGitConfigGlobal = $env:GIT_CONFIG_GLOBAL
+$env:GIT_CONFIG_GLOBAL = $gitConfig
+
+# Commands detect the workspace from the working directory, which
+# XDG_DATA_HOME does not isolate. Run from inside a real workspace and doctor
+# will happily inspect *that* one. Move somewhere neutral.
+Push-Location $sandbox
+
+Write-Host "sandbox: $sandbox"
+Write-Host ""
+
+try {
+    # --- offline checks --------------------------------------------------
+    Write-Host "offline"
+
+    $v = (Wsp --version).Trim()
+    if ($global:LastRc -ne 0) { Bad "--version exited $($global:LastRc)" }
+    elseif ($ExpectVersion -and ($v -notmatch [regex]::Escape($ExpectVersion))) {
+        Bad "--version says '$v', expected to contain '$ExpectVersion'"
+    } else { Ok "--version: $v" }
+
+    $h = Wsp --help
+    if ($global:LastRc -ne 0) { Bad "--help exited $($global:LastRc)" } else { Ok "--help" }
+
+    # The headline feature of this release: PowerShell integration must emit
+    # a usable wrapper, not an empty file or an error.
+    $c = Wsp completion powershell
+    if ($global:LastRc -ne 0) { Bad "completion powershell exited $($global:LastRc)" }
+    elseif ($c -notmatch "function wsp") { Bad "completion powershell has no 'function wsp'" }
+    else { Ok "completion powershell" }
+
+    # It must also parse as PowerShell, which is the part a string check misses.
+    $errs = $null
+    [void][System.Management.Automation.Language.Parser]::ParseInput($c, [ref]$null, [ref]$errs)
+    if ($errs -and $errs.Count -gt 0) { Bad "completion output does not parse: $($errs[0].Message)" }
+    else { Ok "completion output parses as PowerShell" }
+
+    # --global is required: both are global-only keys. branch-prefix is set so
+    # doctor has nothing left to warn about, which lets the check below assert
+    # a clean bill of health rather than merely "it ran".
+    Wsp config set workspaces-dir $workspaces --global | Out-Null
+    if ($global:LastRc -ne 0) { Bad "config set workspaces-dir exited $($global:LastRc)" } else { Ok "config set workspaces-dir" }
+    Wsp config set branch-prefix smoke --global | Out-Null
+    if ($global:LastRc -ne 0) { Bad "config set branch-prefix exited $($global:LastRc)" }
+
+    # doctor exits non-zero on warnings, not just errors.
+    Wsp doctor | Out-Null
+    if ($global:LastRc -ne 0) { Bad "doctor reported problems in a fresh sandbox" } else { Ok "doctor (clean)" }
+
+    Wsp ls | Out-Null
+    if ($global:LastRc -ne 0) { Bad "ls exited $($global:LastRc)" } else { Ok "ls" }
+
+    if ($ExpectVersion) {
+        $w = Wsp whatsnew
+        if ($w -notmatch [regex]::Escape($ExpectVersion)) {
+            Bad "whatsnew does not mention $ExpectVersion (are the release notes in the build?)"
+        } else { Ok "whatsnew shows $ExpectVersion" }
+    }
+
+    # --- network checks --------------------------------------------------
+    # wsp cannot register a local path (the registry requires a host/user/repo
+    # identity and clones over the network), so these need connectivity.
+    if ($Offline) {
+        Write-Host ""
+        Write-Host "network: skipped (-Offline)"
+    } else {
+        Write-Host ""
+        Write-Host "network"
+
+        $repo1 = "https://github.com/octocat/Hello-World.git"
+        $repo2 = "https://github.com/octocat/Spoon-Knife.git"
+
+        Wsp registry add $repo1 | Out-Null
+        if ($global:LastRc -ne 0) { Bad "registry add exited $($global:LastRc)" } else { Ok "registry add" }
+
+        $ws = "smoke-$((Get-Date).ToString('HHmmss'))"
+        Wsp new $ws github.com/octocat/Hello-World | Out-Null
+        if ($global:LastRc -ne 0) { Bad "new exited $($global:LastRc)" } else { Ok "new $ws" }
+
+        $wsDir = Join-Path $workspaces $ws
+        if (-not (Test-Path (Join-Path $wsDir "Hello-World"))) { Bad "clone directory missing in $wsDir" }
+        else { Ok "repo cloned into the workspace" }
+
+        Push-Location $wsDir
+        try {
+            Wsp st | Out-Null
+            if ($global:LastRc -ne 0) { Bad "st exited $($global:LastRc)" } else { Ok "st" }
+
+            # Exercises the fetch-before-clone fix on the add path.
+            Wsp registry add $repo2 | Out-Null
+            Wsp repo add github.com/octocat/Spoon-Knife | Out-Null
+            if ($global:LastRc -ne 0) { Bad "repo add exited $($global:LastRc)" }
+            elseif (-not (Test-Path (Join-Path $wsDir "Spoon-Knife"))) { Bad "repo add did not clone Spoon-Knife" }
+            else { Ok "repo add" }
+
+            $d2 = Wsp doctor
+            if ($global:LastRc -ne 0) { Bad "doctor (in workspace) exited $($global:LastRc)" } else { Ok "doctor in a real workspace" }
+        } finally { Pop-Location }
+
+        Wsp rm $ws --yes | Out-Null
+        if ($global:LastRc -ne 0) { Bad "rm exited $($global:LastRc)" } else { Ok "rm $ws" }
+    }
+} finally {
+    # --- cleanup ---------------------------------------------------------
+    Pop-Location -ErrorAction SilentlyContinue
+    if ($null -eq $oldXdg) { Remove-Item Env:\XDG_DATA_HOME -ErrorAction SilentlyContinue }
+    else { $env:XDG_DATA_HOME = $oldXdg }
+    if ($null -eq $oldGitConfigGlobal) { Remove-Item Env:\GIT_CONFIG_GLOBAL -ErrorAction SilentlyContinue }
+    else { $env:GIT_CONFIG_GLOBAL = $oldGitConfigGlobal }
+    Remove-Item -Recurse -Force $sandbox -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+if ($failures.Count -gt 0) {
+    Write-Host "$($failures.Count) check(s) failed" -ForegroundColor Red
+    exit 1
+}
+Write-Host "all checks passed"
+exit 0

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Smoke-test a wsp build end to end. macOS/Linux twin of smoke.ps1.
+#
+#   ./scripts/smoke.sh --wsp ./wsp --expect-version 0.19.0-rc.1
+#   ./scripts/smoke.sh --wsp ./wsp --offline
+#
+# Runs against a sandboxed data directory, so it never touches your registry,
+# mirrors, or workspaces. Exits non-zero if any check fails.
+set -uo pipefail
+
+WSP="" EXPECT="" OFFLINE=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --wsp) WSP="$2"; shift 2;;
+        --expect-version) EXPECT="$2"; shift 2;;
+        --offline) OFFLINE=1; shift;;
+        *) echo "unknown argument: $1" >&2; exit 2;;
+    esac
+done
+[ -n "$WSP" ] || { echo "usage: $0 --wsp <path> [--expect-version V] [--offline]" >&2; exit 2; }
+# Resolve to an absolute path before the cd below moves us: a relative --wsp
+# would otherwise break every call. A bare name is left alone; PATH lookup
+# does not care about the working directory.
+case "$WSP" in
+    */*) WSP="$(cd "$(dirname "$WSP")" 2>/dev/null && pwd)/$(basename "$WSP")" ;;
+esac
+command -v "$WSP" >/dev/null 2>&1 || [ -x "$WSP" ] || { echo "not executable: $WSP" >&2; exit 2; }
+
+fails=0
+ok()  { echo "  ok    $1"; }
+bad() { echo "  FAIL  $1"; fails=$((fails + 1)); }
+
+# XDG_DATA_HOME isolates config, mirrors, gc and templates on every platform.
+# workspaces-dir lives outside that root, so it is set separately below.
+sandbox=$(mktemp -d "${TMPDIR:-/tmp}/wsp-smoke.XXXXXX")
+export XDG_DATA_HOME="$sandbox/data"
+workspaces="$sandbox/workspaces"
+mkdir -p "$workspaces"
+cleanup() { cd /; rm -rf "$sandbox"; }
+trap cleanup EXIT
+
+# Point git at a minimal config so user-level url.insteadOf rewrites (e.g.
+# https://github.com/ -> git@github.com:) do not redirect the test clones to
+# SSH, where the agent may not be available. Exported into this process only.
+cat > "$sandbox/gitconfig" <<'GITCFG'
+[user]
+	email = smoke@test.local
+	name = Smoke Test
+GITCFG
+export GIT_CONFIG_GLOBAL="$sandbox/gitconfig"
+
+# Commands detect the workspace from the working directory, which
+# XDG_DATA_HOME does not isolate. Running from inside a real workspace makes
+# doctor and friends inspect *that* one. Move somewhere neutral.
+cd "$sandbox" || exit 1
+
+echo "sandbox: $sandbox"
+echo
+echo "offline"
+
+if v=$("$WSP" --version 2>&1); then
+    if [ -n "$EXPECT" ] && ! printf '%s' "$v" | grep -qF "$EXPECT"; then
+        bad "--version says '$v', expected to contain '$EXPECT'"
+    else
+        ok "--version: $v"
+    fi
+else
+    bad "--version exited non-zero: $v"
+fi
+
+"$WSP" --help >/dev/null 2>&1 && ok "--help" || bad "--help exited non-zero"
+
+# Shell integration must emit a usable wrapper *and* parse — a grep alone
+# would accept syntactically broken output.
+for sh in bash zsh; do
+    if ! command -v "$sh" >/dev/null 2>&1; then
+        echo "  skip  completion $sh (not installed)"
+        continue
+    fi
+    out=$("$WSP" completion "$sh" 2>&1) || { bad "completion $sh exited non-zero"; continue; }
+    printf '%s' "$out" | grep -q "wsp" || { bad "completion $sh output has no 'wsp'"; continue; }
+    if printf '%s' "$out" | "$sh" -n 2>/dev/null; then
+        ok "completion $sh (parses)"
+    else
+        bad "completion $sh output does not parse as $sh"
+    fi
+done
+
+# --global is required: both are global-only keys. branch-prefix is set so
+# doctor has nothing left to warn about, letting the check below assert a
+# clean bill of health rather than merely "it ran".
+"$WSP" config set workspaces-dir "$workspaces" --global >/dev/null 2>&1 \
+    && ok "config set workspaces-dir" || bad "config set workspaces-dir exited non-zero"
+"$WSP" config set branch-prefix smoke --global >/dev/null 2>&1 \
+    || bad "config set branch-prefix exited non-zero"
+
+"$WSP" doctor >/dev/null 2>&1 && ok "doctor (clean)" || bad "doctor reported problems in a fresh sandbox"
+"$WSP" ls >/dev/null 2>&1 && ok "ls" || bad "ls exited non-zero"
+
+if [ -n "$EXPECT" ]; then
+    if "$WSP" whatsnew 2>&1 | grep -qF "$EXPECT"; then
+        ok "whatsnew shows $EXPECT"
+    else
+        bad "whatsnew does not mention $EXPECT (are the release notes in the build?)"
+    fi
+fi
+
+# wsp cannot register a local path — the registry needs a host/user/repo
+# identity and clones over the network — so these steps require connectivity.
+if [ "$OFFLINE" -eq 1 ]; then
+    echo
+    echo "network: skipped (--offline)"
+else
+    echo
+    echo "network"
+
+    "$WSP" registry add https://github.com/octocat/Hello-World.git >/dev/null 2>&1 \
+        && ok "registry add" || bad "registry add exited non-zero"
+
+    ws="smoke-$$"
+    "$WSP" new "$ws" github.com/octocat/Hello-World >/dev/null 2>&1 \
+        && ok "new $ws" || bad "new exited non-zero"
+
+    ws_dir="$workspaces/$ws"
+    [ -d "$ws_dir/Hello-World" ] && ok "repo cloned into the workspace" \
+        || bad "clone directory missing in $ws_dir"
+
+    if [ -d "$ws_dir" ]; then
+        (
+            cd "$ws_dir" || exit 1
+            "$WSP" st >/dev/null 2>&1 || exit 2
+            exit 0
+        ) && ok "st" || bad "st exited non-zero"
+
+        # Exercises the fetch-before-clone path on add.
+        "$WSP" registry add https://github.com/octocat/Spoon-Knife.git >/dev/null 2>&1
+        ( cd "$ws_dir" && "$WSP" repo add github.com/octocat/Spoon-Knife >/dev/null 2>&1 )
+        [ -d "$ws_dir/Spoon-Knife" ] && ok "repo add" || bad "repo add did not clone Spoon-Knife"
+
+        ( cd "$ws_dir" && "$WSP" doctor >/dev/null 2>&1 ) \
+            && ok "doctor in a real workspace" || bad "doctor (in workspace) exited non-zero"
+    fi
+
+    "$WSP" rm "$ws" --yes >/dev/null 2>&1 && ok "rm $ws" || bad "rm exited non-zero"
+fi
+
+echo
+if [ "$fails" -gt 0 ]; then
+    echo "$fails check(s) failed"
+    exit 1
+fi
+echo "all checks passed"


### PR DESCRIPTION
Smoke-tests the built binaries on ubuntu/macOS/Windows **before anything is tagged**. A failure means no tag and no release — which matters because tags here are immutable (the ruleset blocks delete and update, no bypass), so a bad one cannot be withdrawn.

Applies to prereleases and real releases alike; both go through `host`.

## The hook choice is the whole trick

Wired in with `global-artifacts-jobs`, **not** `host-jobs`. The intuitively-named one does not work:

```
# host-jobs
custom-smoke: needs [plan, build-local-artifacts, build-global-artifacts]
host:         needs [plan, build-local-artifacts, build-global-artifacts]   <- races

# global-artifacts-jobs
custom-smoke: needs [plan, build-local-artifacts]
host:         needs [plan, build-local-artifacts, build-global-artifacts, custom-smoke]   <- waits
```

With `host-jobs` the two run in parallel and the tag is created regardless of the outcome. Verified both against the generated graph rather than reasoned about.

`release.yml` is regenerated output, not hand-edited — `dist plan` in CI verifies that.

## Local

```
just smoke                 # ./target/release/wsp
just smoke path/to/wsp     # a downloaded artifact
```

Same scripts CI runs.

## Why now

Smoke-testing the `v0.19.0-rc.1` artifact by hand found **#92**: on git 2.43 (ubuntu 24.04, so a lot of user machines) `wsp new` leaves the workspace branch with no commits when the repo default branch is `master`. Every file reads as staged-added and `wsp rm` refuses with "unsaved work".

**This job would not have caught it.** GitHub runners carry git 2.55.0, where the bug does not reproduce — I found it in a container with git 2.43. So this gate catches artifact-level failures (corrupt archive, missing runtime dep, wrong version, binary will not launch) but not behaviour that depends on the user environment.

Closing that gap means a matrix leg pinned to an older git, e.g. running the ubuntu job inside a `ubuntu:24.04` container. Worth doing, but a deliberate addition rather than something to slip in here.

## Composing with #69

Deliberately shallow — "does the published binary work at all". As #69's e2e suite grows, this should **shrink** to what only an artifact check can catch: a corrupt archive, a missing runtime dependency, the wrong version compiled in. The two answer different questions and neither subsumes the other, which is written up in #69.

## Verification

- [x] Generated graph confirms `host` waits on `custom-smoke`
- [x] All four workflows parse
- [x] `just smoke` passes locally end to end (offline and network)
- [x] The unpack step's find-the-binary logic tested against a real `.tar.xz` artifact
- [x] `smoke.sh` verified on Linux in a container against the released aarch64 artifact — which is how #92 surfaced
- [x] `just check` passes
- [ ] CI green

Untested until a release actually runs: the artifact hand-off from `build-local-artifacts` (`pattern: artifacts-*`), since no PR produces those artifacts. The download pattern is copied verbatim from `build-global-artifacts`, which does exactly this.

Three of five targets have runners, so `aarch64-unknown-linux-gnu` and `aarch64-pc-windows-msvc` are built but not smoke-tested. Noted in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)