### PR TITLE
docs(release): consolidate rc sections when the final version ships

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -53,6 +53,13 @@ re-run that job rather than re-cutting.
 `CARGO_PKG_VERSION` at compile time, so rc artifacts report `-rc.1` forever and
 `wsp whatsnew` would look up the wrong entry. cargo-dist has no promote command.
 
+**Consolidate the rc sections when the final version ships.** Every rc needs its
+own `## [x.y.z-rc.N]` heading while it exists — the `whatsnew` CI job requires a
+section matching the version being released, and `wsp whatsnew` looks up the
+running binary's version. But when `x.y.z` ships, replace all of them with a
+single `## [x.y.z]` section. They describe one release; leaving three
+near-identical entries makes the file read as though three things shipped.
+
 ## Writing release notes
 
 `WHATSNEW.md` is compiled into the binary and shown by `wsp whatsnew`. Prepend


### PR DESCRIPTION
A wrinkle in the process we built, spotted while planning `0.19.0-rc.2`.

Every rc needs its own `## [x.y.z-rc.N]` section while it exists — the `whatsnew` CI job requires one matching the version being released, and `wsp whatsnew` looks up the running binary's version, so an rc user must find their own entry.

The consequence is accumulation. `0.19.0-rc.1`, `0.19.0-rc.2` and `0.19.0` would each get a section describing the same release, and the file would read as though three things shipped.

This says to collapse them into a single `## [x.y.z]` section when the final version goes out. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)