### PR TITLE
ci: move audit-check past v2.0.0 for the Node 24 runtime

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -38,7 +38,15 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
 
-      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+      # Pinned past v2.0.0: that release still declares node20, which runners
+      # now force onto node24 with a deprecation warning. Upstream fixed it in
+      # 858dc40 but has not cut a release. Only three commits separate them —
+      # two README edits and the runtime bump.
+      #
+      # Dependabot tracks SHA pins by their latest *tag*, so it may propose
+      # moving this back to v2.0.0. That would reintroduce the warning; take
+      # the bump only once a release newer than v2.0.0 exists.
+      - uses: rustsec/audit-check@858dc40f52ca2b8570b7a997c1c4e35c6fc9a432 # main, post-v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,15 @@ jobs:
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
-      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+      # Pinned past v2.0.0: that release still declares node20, which runners
+      # now force onto node24 with a deprecation warning. Upstream fixed it in
+      # 858dc40 but has not cut a release. Only three commits separate them —
+      # two README edits and the runtime bump.
+      #
+      # Dependabot tracks SHA pins by their latest *tag*, so it may propose
+      # moving this back to v2.0.0. That would reintroduce the warning; take
+      # the bump only once a release newer than v2.0.0 exists.
+      - uses: rustsec/audit-check@858dc40f52ca2b8570b7a997c1c4e35c6fc9a432 # main, post-v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Fixes the warning on every `check` run:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: rustsec/audit-check@69366f33...
```

## Why a commit and not a tag

Upstream already fixed it — their default branch declares `using: 'node24'` — but the newest release is still **v2.0.0 from September 2024**, so there is no tag carrying the fix.

Only three commits separate them:

```
858dc40  2026-03-20  Update to use Node 24 (#48)     <- pinning here
3ae0128  2025-10-30  docs: Fix README typo
dd2c7de  2025-02-23  Update action version in README examples
69366f3  2024-09-23  Prep for v2.0.0 release          <- was here
```

Two README edits and the runtime bump. `dist/index.js` is committed, so the action runs from that tree. We pin by SHA regardless, so a tag was never buying us anything beyond a readable comment.

## The part worth knowing

Dependabot tracks SHA pins by their latest **tag**, so it may well propose moving this *back* to v2.0.0 — reintroducing the exact warning this removes. That is recorded in a comment next to both pins: take the bump only once a release newer than v2.0.0 exists.

Applied in `ci.yml` and `audit.yml`, the two places the action is used.

## Test plan

- [x] Both workflows parse
- [x] Confirmed upstream default branch declares `node24` and the pinned release declares `node20`
- [x] `just check` passes
- [ ] CI green, and the deprecation warning is gone from the `check` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)