### PR TITLE
ci: lead the release body with the WHATSNEW prose

### DIFF
--- a/.claude/skills/wsp-release/SKILL.md
+++ b/.claude/skills/wsp-release/SKILL.md
@@ -20,8 +20,7 @@ version.
 4. Work through the flow in `RELEASING.md`. Do not merge the release PR
    yourself.
 5. After it merges, run `just release-dispatch <version>` and report each job.
-   Say plainly whether `publish-homebrew-formula` ran or skipped.
-6. Update the GitHub release body as described there.
-
+   Say plainly whether `publish-homebrew-formula` ran or skipped. The release
+   body is filled in automatically; no manual edit.
 Verify every `wsp <cmd>` in the notes against `wsp --help` before showing the
 draft — do not rely on memory for command names.

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,57 @@
+name: release-notes
+
+# Puts the WHATSNEW.md prose at the top of the GitHub release body.
+#
+# cargo-dist builds that body from CHANGELOG.md, which git-cliff generates from
+# commit subjects — so without this the first thing a user sees on the release
+# page is every commit, including CI and release-process churn. The prose stays
+# above it; the generated log and install table remain below.
+#
+# Runs via post-announce-jobs, so the release already exists and this only
+# edits it.
+on:
+  workflow_call:
+    inputs:
+      plan:
+        required: true
+        type: string
+
+jobs:
+  release-notes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Prepend release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ fromJson(inputs.plan).announcement_tag }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TAG:-}" ]; then
+            echo "no tag (dry run) — nothing to edit"
+            exit 0
+          fi
+          version="${TAG#v}"
+
+          # Section for this version, up to the next "## [" heading.
+          notes=$(awk -v want="## [$version]" '
+            index($0, want) == 1 { found = 1; next }
+            found && /^## \[/     { exit }
+            found                 { print }
+          ' WHATSNEW.md)
+
+          # The whatsnew CI gate should have guaranteed this on the release PR,
+          # so absence means something upstream went wrong. Say so rather than
+          # silently publishing the commit log alone.
+          if [ -z "$(printf '%s' "$notes" | tr -d '[:space:]')" ]; then
+            echo "::error::WHATSNEW.md has no '## [$version]' section; release body left as generated"
+            exit 1
+          fi
+
+          gh release view "$TAG" --json body -q .body > /tmp/body.md
+          { printf '%s\n\n---\n\n' "$notes"; cat /tmp/body.md; } > /tmp/new-body.md
+          gh release edit "$TAG" --notes-file /tmp/new-body.md
+          echo "prepended $(printf '%s' "$notes" | wc -l) lines of notes to $TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -355,3 +355,12 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+
+  custom-release-notes:
+    needs:
+      - plan
+      - announce
+    uses: ./.github/workflows/release-notes.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -101,13 +101,10 @@ full-structure example.
 
 ## After the release
 
-Prepend the `WHATSNEW.md` section to the GitHub release body, which otherwise
-holds only cargo-dist's install table:
-
-```bash
-gh release view v<version> --json body -q .body   # combine with the notes
-gh release edit v<version> --notes-file <file>
-```
+Nothing to do by hand. `release-notes.yml` runs after announce and prepends the
+`WHATSNEW.md` section for the version to the release body, above the generated
+commit log and install table. It fails loudly if the section is missing, which
+the `whatsnew` CI gate should already have prevented.
 
 Verify with `gh run list --limit 5` and `gh release list --limit 3`.
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -14,6 +14,9 @@ dispatch-releases = true
 # host-jobs) is the one that makes `host` wait: host-jobs produces a job with
 # the same dependencies as host, so they race and the tag lands regardless.
 global-artifacts-jobs = ["./smoke"]
+# Put the WHATSNEW prose above cargo-dist's generated commit log in the release
+# body. Runs after announce, so it only edits an existing release.
+post-announce-jobs = ["./release-notes"]
 # CI backends to support
 ci = "github"
 # The installers to generate for each app


### PR DESCRIPTION
The release page currently opens with the raw commit log. cargo-dist builds the body from `CHANGELOG.md`, which git-cliff generates from commit subjects, so the top of **v0.19.0-rc.1** reads:

```
## Release Notes
### Features
- *(completion)* Add PowerShell shell integration
...
- *(release)* Make release-prep runnable without a TTY
- Record what does not belong in WHATSNEW (#86)
```

The prose written for exactly this audience was not on the page at all.

## Change

A post-announce job prepends the `WHATSNEW.md` section for the version. The generated log and install table stay below it, separated by a rule.

`post-announce-jobs` is the correct hook — it runs after `announce`, which runs after `host`, so the release exists and this only edits it. Verified against the generated graph:

```
custom-notes: needs [plan, announce]
```

It **fails loudly** if the section is missing rather than quietly leaving the commit log alone. The `whatsnew` gate should already have prevented that on the release PR, so absence means something upstream broke.

## Verification

Section extraction tested against the real `WHATSNEW.md`:

| version | result |
|---|---|
| `0.19.0-rc.1` | 22 lines, starts at `### PowerShell shell integration` |
| `0.18.0` | 24 lines, correct section |
| `9.9.9` | empty → triggers the loud failure |

Also confirmed it stops cleanly at the next `## [` heading rather than bleeding into the previous release.

Untestable until a release runs: the `gh release edit` itself, since no PR produces a release to edit. Same limitation as the smoke job's artifact hand-off.

## Also corrects a wrong doc claim

`RELEASING.md` said the release body "otherwise holds only cargo-dist's install table". It holds the entire generated changelog — I wrote that description without checking, and the rc.1 body disproves it. The manual `gh release edit` step it documented is now removed, since this replaces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)