### PR TITLE
chore(release): v0.19.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.19.0-rc.2] - 2026-08-22
+
+### Features
+
+- *(cli)* Add create alias for new (#89)
+
+### Bug Fixes
+
+- *(git)* Fall back to the mirror's HEAD when origin/HEAD is absent (#95)
+- *(workspace)* Ignore prunable linked worktrees on removal (#94)
+
+### Documentation
+
+- Make RELEASING.md the single source for the release process (#90)
+- *(release)* Consolidate rc sections when the final version ships (#96)
+
+### Ci
+
+- Smoke-test built binaries before tagging a release (#93)
+- Move audit-check past v2.0.0 for the Node 24 runtime (#97)
+- Lead the release body with the WHATSNEW prose (#98)
+
 ## [0.19.0-rc.1] - 2026-08-22
 
 ### Features
@@ -21,7 +43,6 @@ All notable changes to this project will be documented in this file.
 - *(windows)* Centralize symlink fallback and harden Windows paths
 - *(doctor)* Refresh the registry snapshot after registering a repo (#82)
 - *(repo add)* Refresh mirrors before cloning into a workspace (#83)
-- *(release)* Make release-prep runnable without a TTY
 
 ### Refactor
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,7 +1540,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wsp"
-version = "0.19.0-rc.1"
+version = "0.19.0-rc.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "wsp-core"
-version = "0.19.0-rc.1"
+version = "0.19.0-rc.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version    = "0.19.0-rc.1"
+version    = "0.19.0-rc.2"
 edition    = "2024"
 license    = "MIT"
 repository = "https://github.com/jganoff/wsp"

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -1,5 +1,25 @@
 # What's New
 
+## [0.19.0-rc.2] - 2026-08-22
+
+### `wsp create`
+
+`create` is now an alias for `new`.
+
+```
+wsp create my-feature github.com/acme/api
+```
+
+### Fixes
+
+- `wsp new` no longer leaves a repo with no commits when its default branch is
+  not `main`. On some versions of git the workspace branch was created from
+  nothing, so every file showed as staged and `wsp rm` refused with "unsaved
+  work" that did not exist.
+- `wsp rm` no longer blocks on linked worktrees that git has already marked
+  prunable. Live worktrees still block, since removing the workspace would
+  orphan them.
+
 ## [0.19.0-rc.1] - 2026-08-22
 
 ### PowerShell shell integration


### PR DESCRIPTION
Second release candidate for 0.19.0. rc.1 shipped with #92 — `wsp new` left a repo with no commits on older git — so this is the re-cut with that fixed.

## Contents

- `Cargo.toml` / `Cargo.lock`: 0.19.0-rc.1 → 0.19.0-rc.2
- `CHANGELOG.md`: regenerated by git-cliff
- `WHATSNEW.md`: a new `## [0.19.0-rc.2]` section

## The notes are a delta

The section covers only what changed since rc.1 — the `wsp create` alias and two fixes — rather than restating the whole release, so a tester tracking the candidates sees exactly what moved. Both rc sections get replaced by a single clean `## [0.19.0]` when the final ships, per `RELEASING.md`.

Excluded as maintainer-only: the smoke gate, the release-body automation, the audit-check Node 24 bump, and the docs consolidation. Four of the seven merged PRs — most of the changelog, as expected.

## First run of two new mechanisms

This exercises both hooks added since rc.1, neither of which any PR can test:

- **`custom-smoke`** gates `host`, so the binaries are smoke-tested on ubuntu/macOS/Windows *before* the tag exists. A failure means no tag and no release.
- **`custom-notes`** runs after announce and prepends this `WHATSNEW.md` section to the release body, above cargo-dist's generated commit log.

Two parts are genuinely unproven until this runs: the smoke job's `artifacts-*` download from `build-local-artifacts`, and the `gh release edit` call. Both are structurally copied from working code, but neither has executed.

## Verification

- [x] `just check`
- [x] `just smoke` passes locally against this build
- [x] `whatsnew` gate simulated against the diff: finds `## [0.19.0-rc.2]`
- [x] Release-notes extraction simulated: 14 lines pulled from that section
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)