### PR TITLE
ci: hand pwsh a native path for the Windows smoke binary

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -54,7 +54,15 @@ jobs:
           esac
           bin=$(find unpacked -type f \( -name wsp -o -name wsp.exe \) | head -1)
           [ -n "$bin" ] || { echo "::error::no wsp binary inside ${{ matrix.archive }}"; exit 1; }
-          echo "WSP_BIN=$PWD/$bin" >> "$GITHUB_ENV"
+          abs="$PWD/$bin"
+          # This step is bash even on Windows, where $PWD is an MSYS path
+          # (/d/a/wsp/...). The smoke step below is pwsh, which reads that as
+          # drive-relative and resolves it to D:\d\a\wsp\... Hand pwsh a
+          # native path instead.
+          if command -v cygpath >/dev/null 2>&1; then
+            abs=$(cygpath -w "$abs")
+          fi
+          echo "WSP_BIN=$abs" >> "$GITHUB_ENV"
 
       # The tag is empty on a dry run, in which case skip the version
       # assertion rather than assert against nothing.


### PR DESCRIPTION
The `v0.19.0-rc.2` dispatch failed in `custom-smoke` on Windows. **No tag was created** — `host` was skipped, so `v0.19.0-rc.2` is still an unused version and the re-cut needs no version bump.

## What broke

```
Resolve-Path: D:\a\wsp\wsp\scripts\smoke.ps1:32
Cannot find path 'D:\d\a\wsp\wsp\dist\unpacked\wsp.exe' because it does not exist.
```

Note the doubled `D:\d\`. The unpack step is `shell: bash`, which on a Windows runner is Git Bash, so `$PWD` is `/d/a/wsp/wsp/dist`. That got exported verbatim as `WSP_BIN`, and the smoke step is `pwsh`, which reads a leading slash as drive-relative and pins it to the current drive.

Everything either side of the handoff was fine: the archive downloaded, `unzip` succeeded, and `find` located `wsp.exe`. Only the path translation between the two shells was wrong.

## The fix

`cygpath -w` when it's on PATH — true on Windows runners, never on Linux or macOS, so the unix legs are untouched.

## Why the gate is worth having

This is the failure mode the smoke job was added for. A binary that can't be located is indistinguishable from a binary that can't run, and either way the release shouldn't be tagged. It fired before `host`, so there's nothing to withdraw — tags are immutable, and this is precisely the case where that would have hurt.

Worth being clear about the scope of what it caught, though: this was a bug in the **gate's own plumbing**, not in `wsp`. The Linux and macOS legs passed, so the shipped binary was never in question. The gate's first real run found a bug in the gate.

## Verification

- [x] `smoke.yml` parses; all six steps intact
- [ ] CI green
- [ ] **Unverifiable by this PR** — `smoke.yml` is `workflow_call`-only, invoked from `release.yml`. Like the original, it can only be exercised by a dispatch. The next one is the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)