### PR TITLE
docs(tenets): add a Speed section

### DIFF
--- a/docs/design-tenets.md
+++ b/docs/design-tenets.md
@@ -17,6 +17,12 @@ Principles that guide wsp's design. When tenets conflict, higher-ranked tenets w
 3. **Surface hidden state.** If the user's checkout doesn't match what wsp expects (wrong branch, detached HEAD), say so loudly. Silent "clean" status that hides at-risk work is a bug.
 4. **Fail closed on ambiguity.** When safety checks can't determine if work is saved (fetch fails, branch detection is ambiguous), block the operation rather than guess.
 
+## Speed
+
+1. **Fast is invisible.** Local operations finish before the user notices. Never show progress for work already done.
+2. **Slow is legible.** Say what you are fetching, and how much, before waiting on it. Silence past a second is a bug.
+3. **Reads stay local.** Status, list, and completion answer from local state. Network work is opt-in.
+
 ## Agent Use
 
 1. **Self-discoverable.** An agent dropped into a workspace can discover and operate wsp without human guidance.


### PR DESCRIPTION
The tenets had nothing about latency. The closest were "Mirrors are invisible infrastructure" — a different sense of invisible, about management — and CLAUDE.md's "completion must never fail at shell startup," which is about degradation. So the principle kept losing design arguments it should have won, most recently one in this repo about whether a completer could afford an extra config read.

```markdown
## Speed

1. **Fast is invisible.** Local operations finish before the user notices. Never show progress for work already done.
2. **Slow is legible.** Say what you are fetching, and how much, before waiting on it. Silence past a second is a bug.
3. **Reads stay local.** Status, list, and completion answer from local state. Network work is opt-in.
```

## Why three and not one

"Be fast" is unfalsifiable. Fast and slow paths need **opposite** instructions — shut up versus speak up — and each tenet resolves something the others don't:

| Tenet | Uniquely resolves |
|---|---|
| Fast is invisible | ceremony on paths the user can't perceive |
| Slow is legible | silence on paths they can |
| Reads stay local | *what counts as* a fast path |

## Why not two

Dropping #3 was the serious attempt. It fails:

> Someone adds a GitHub existence check to `wsp ls`. It prints `Checking 12 repos…` before waiting. Tenet 2 satisfied; tenet 1 no longer applies because it isn't a local operation. `wsp ls` now takes two seconds and the tenets bless it.

Without #3, "slow is legible" is a loophole that legalizes any slow operation so long as it narrates. #3 is what keeps work in the fast bucket so #1 has something to apply to.

Folding #3 into #1 was also tried — it forces dropping a clause, and the anti-ceremony clause is the one that resolved a real decision this week.

## Placement

Its own section after Safety, not folded into Human Use. Ranking is only within a section, and speed must not read as outranking "fail closed on ambiguity."

## Measured, not asserted

Completion is **~4.3ms and flat** on a release build. `wsp config set <TAB>` — which resolves paths and reads `config.yaml` — costs the same as `wsp <TAB>`, which does neither. It's all process spawn. macOS, warm cache, one config; Windows is unmeasured.

## Checked against the existing 20

No overlap. Offline-first bootstrapping covers only `wsp new`; mirror-as-cache routes network work rather than avoiding it; safe-to-explore is about side effects; surface-hidden-state is about state, not waiting; muscle-memory is about keystrokes.

## Names one existing gap

`wsp st` with `pr.source = github` fires N GitHub calls and prints nothing unless a thread panics — tenet 2 says that's a bug. Filed separately. `wsp new` and `wsp fetch` already comply.

Docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)