### PR TITLE
perf(ci): run tests in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,13 @@ jobs:
 
   # Linux runs first. If logic is broken it shows up here cheaply before we
   # spin up macOS and Windows runners.
+  #
+  # Tests run in parallel. They needed --test-threads=1 only because completer
+  # tests mutated XDG_DATA_HOME to steer Paths::resolve(). Completers now take
+  # their inputs as parameters, and env mutation can no longer compile at all:
+  # set_var is unsafe in edition 2024 and both crate roots deny unsafe_code.
+  # If this flag ever looks necessary again, something reintroduced shared
+  # process state — fix that instead of serializing the suite.
   test-linux:
     needs: check
     runs-on: ubuntu-latest
@@ -92,7 +99,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - run: cargo build --release
-      - run: cargo test -- --test-threads=1
+      - run: cargo test
 
   # Cross-platform jobs run in parallel only after Linux passes. fail-fast:false
   # keeps both running so a single CI pass reveals all platform issues at once.
@@ -112,4 +119,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - run: cargo build --release
-      - run: cargo test -- --test-threads=1
+      - run: cargo test

--- a/Justfile
+++ b/Justfile
@@ -32,7 +32,7 @@ build: check build-bin
 
 # run all tests
 test:
-    cargo test --workspace -- --test-threads=1
+    cargo test --workspace
 
 # audit dependencies for known vulnerabilities
 audit:


### PR DESCRIPTION
Second of three. #104 removed the reason for `--test-threads=1`; this removes the flag.

Three lines — two in `ci.yml`, one in the `Justfile` — plus a comment explaining why it should not come back.

## Why it was there

Exactly one reason: completer tests mutated `XDG_DATA_HOME` to steer `Paths::resolve()`. #104 gave completers explicit parameters instead, and made the old approach **uncompilable** — `set_var` is `unsafe` in edition 2024 and both crate roots declare `#![deny(unsafe_code)]`. A test cannot reach for the environment now without deliberately re-opening that hole.

## What it buys

Local, full workspace:

| | |
|---|---|
| `wsp-core` serial | 29.6s |
| `wsp-core` parallel | **8.5s** |
| whole suite parallel | 667 tests, 12.8s wall, 879% CPU |

CI's Windows leg is the real target. From the run that prompted this work:

| | |
|---|---|
| `cargo test` step | 3m44s |
| └ `wsp-core` alone | 188.56s |
| everything else | ~17s |

Every one of those tests shells out to `git`, and Windows process spawn is far more expensive than Linux. Serialized, none of that cost overlaps. Windows runners have 4 vCPU against the ~7 cores I measured on, so expect ~2.5–3× rather than 3.5× — call it **188s → ~65s**, and the Windows job roughly 5m12s → 3m10s.

That estimate is the part to check against reality once this runs, not to trust in advance.

## Risk

**I cannot prove the suite is free of races.** What I have: 12 consecutive clean parallel runs of the full workspace, 665–667 tests each, zero failures.

All of them on macOS. Windows has a different timing profile and is precisely where a latent race would surface first. Twelve clean runs on the wrong platform is weak evidence about the platform in question.

This PR is deliberately three lines so that reverting it is trivial and costs none of #104's cleanup. If Windows flakes, revert this and the seam work stands on its own merits.

## Verification

- [x] `ci.yml` parses; all four jobs and their step counts intact
- [x] `just test` passes in parallel — 667 tests
- [x] 12/12 clean consecutive parallel runs (macOS)
- [x] No `--test-threads` references remain anywhere in the repo
- [ ] CI green — and this PR's own Windows leg is the first real datapoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
