### PR TITLE
test(completion): assert wrapper cd behavior in real shells

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       # missing shell would skip that dialect silently, so install them and set
       # WSP_SHELL_TESTS_REQUIRE_ALL to turn a skip into a failure.
       - name: install shells for wrapper tests
-        run: sudo apt-get update && sudo apt-get install -y zsh fish
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends zsh fish
       - run: cargo build --release
       - run: cargo test
         env:
@@ -129,7 +129,10 @@ jobs:
       # which is always present, so it needs no install step.
       - name: install fish for wrapper tests
         if: runner.os == 'macOS'
-        run: brew install fish
+        # `brew install` exits non-zero when the formula is already present, so
+        # check first — a preinstalled fish in a future runner image would
+        # otherwise fail the job.
+        run: brew list fish >/dev/null 2>&1 || brew install fish
       - run: cargo build --release
       - run: cargo test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,8 +98,15 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      # The shell_cd tests exercise the generated wrapper in each dialect. A
+      # missing shell would skip that dialect silently, so install them and set
+      # WSP_SHELL_TESTS_REQUIRE_ALL to turn a skip into a failure.
+      - name: install shells for wrapper tests
+        run: sudo apt-get update && sudo apt-get install -y zsh fish
       - run: cargo build --release
       - run: cargo test
+        env:
+          WSP_SHELL_TESTS_REQUIRE_ALL: "1"
 
   # Cross-platform jobs run in parallel only after Linux passes. fail-fast:false
   # keeps both running so a single CI pass reveals all platform issues at once.
@@ -118,5 +125,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      # macOS ships bash and zsh; fish is not preinstalled. Windows uses pwsh,
+      # which is always present, so it needs no install step.
+      - name: install fish for wrapper tests
+        if: runner.os == 'macOS'
+        run: brew install fish
       - run: cargo build --release
       - run: cargo test
+        env:
+          WSP_SHELL_TESTS_REQUIRE_ALL: "1"

--- a/crates/wsp/src/cli/completion.rs
+++ b/crates/wsp/src/cli/completion.rs
@@ -811,44 +811,6 @@ mod tests {
         }
     }
 
-    /// Every visible alias of a cd-ing command must appear in the wrapper, or
-    /// it silently falls through to the catch-all and never cds.
-    #[test]
-    fn test_wrapper_covers_new_alias() {
-        let posix = output(|w| {
-            write_posix(
-                w,
-                "/usr/bin/wsp",
-                "/home/user/dev",
-                "zsh",
-                ShellHookOpts::default(),
-            )
-        });
-        assert!(
-            posix.contains("new|create)"),
-            "posix wrapper must match the `create` alias"
-        );
-
-        let fish = output(|w| {
-            write_fish(
-                w,
-                "/usr/bin/wsp",
-                "/home/user/dev",
-                ShellHookOpts::default(),
-            )
-        });
-        assert!(
-            fish.contains("case new create"),
-            "fish wrapper must match the `create` alias"
-        );
-
-        let pwsh = output(|w| write_powershell(w, "/usr/bin/wsp", "/home/user/dev"));
-        assert!(
-            pwsh.contains("$_ -in 'new', 'create'"),
-            "powershell wrapper must match the `create` alias"
-        );
-    }
-
     /// Guards against the wrapper and clap drifting apart: if `new` gains or
     /// loses a visible alias, the hardcoded shell patterns must be updated.
     #[test]
@@ -1351,7 +1313,7 @@ mod tests {
     #[test]
     fn test_ps_contains_all_cases() {
         let out = output(|w| write_powershell(w, r"C:\wsp.exe", r"C:\dev"));
-        assert!(out.contains("'new'"), "missing new case");
+        assert!(out.contains("'new', 'create'"), "missing new/create case");
         assert!(out.contains("'cd'"), "missing cd case");
         assert!(out.contains("'rm', 'remove'"), "missing rm/remove case");
         assert!(out.contains("'recover'"), "missing recover case");

--- a/crates/wsp/tests/shell_cd.rs
+++ b/crates/wsp/tests/shell_cd.rs
@@ -38,6 +38,11 @@ const WSP: &str = env!("CARGO_BIN_EXE_wsp");
 #[allow(dead_code)]
 enum Quote {
     /// Close, escape, reopen: `'` → `'\''`
+    ///
+    /// Covers fish too. The generator escapes fish differently (`'` → `\'`,
+    /// see the security notes in AGENTS.md) because it quotes *inside* a
+    /// single-quoted string, but this form closes the quote first and fish
+    /// concatenates adjacent tokens exactly as POSIX shells do.
     Posix,
     /// Double the quote: `'` → `''`
     PowerShell,

--- a/crates/wsp/tests/shell_cd.rs
+++ b/crates/wsp/tests/shell_cd.rs
@@ -128,6 +128,10 @@ enum Expect {
 }
 
 /// Whether the scenario currently holds.
+///
+/// `StaysPut` is unused on Windows, where the only platform-dependent row
+/// (`LEADING_FLAG`) resolves to `Works`.
+#[allow(dead_code)]
 enum Status {
     /// `expect` holds today; a regression should fail the build.
     Works,
@@ -138,6 +142,23 @@ enum Status {
     /// wrapper cd'd somewhere unrelated.
     StaysPut(&'static str),
 }
+
+/// Status of the "leading flag" scenario, which is the one place the dialects
+/// genuinely disagree today.
+///
+/// PowerShell's `new` case iterates `$restArgs` to find the first non-flag
+/// argument (guarded by `test_ps_new_skips_flag_args_when_cding`), so it lands
+/// in the right place. The posix and fish cases read `$1` / `$args[1]`
+/// positionally and so cd to `<root>/--empty`, which fails and leaves the shell
+/// where it started.
+///
+/// That divergence is itself worth fixing — the same command should not move
+/// the shell differently depending on the platform — and #105 removes the
+/// argv parsing that causes it.
+#[cfg(unix)]
+const LEADING_FLAG: Status = Status::StaysPut("posix/fish read argv positionally; see #105");
+#[cfg(windows)]
+const LEADING_FLAG: Status = Status::Works;
 
 struct Scenario {
     name: &'static str,
@@ -170,15 +191,14 @@ const SCENARIOS: &[Scenario] = &[
         status: Status::Works,
     },
     Scenario {
-        // The wrapper reads the workspace name positionally, so a leading flag
-        // is mistaken for the name and it cds to `<root>/--empty`, which fails.
-        // The workspace *is* created; only the cd is wrong.
+        // Platform-dependent today — see LEADING_FLAG. The workspace is always
+        // created correctly; only the cd differs.
         name: "new with a leading flag still cds",
         setup: &[],
         start: Start::Root,
         cmd: &["new", "--empty", "w"],
         expect: Expect::Ws("w"),
-        status: Status::StaysPut("wrapper parses argv positionally; see #105"),
+        status: LEADING_FLAG,
     },
     Scenario {
         name: "cd enters the workspace",

--- a/crates/wsp/tests/shell_cd.rs
+++ b/crates/wsp/tests/shell_cd.rs
@@ -30,53 +30,74 @@ const WSP: &str = env!("CARGO_BIN_EXE_wsp");
 // Shell definitions
 // ---------------------------------------------------------------------------
 
+/// How to wrap a path in single quotes for this dialect.
+///
+/// `SHELLS` is `cfg`-split, so exactly one variant is unused on any given
+/// platform — `Posix` on Windows, `PowerShell` everywhere else.
+#[derive(Clone, Copy)]
+#[allow(dead_code)]
+enum Quote {
+    /// Close, escape, reopen: `'` → `'\''`
+    Posix,
+    /// Double the quote: `'` → `''`
+    PowerShell,
+}
+
+/// Everything that differs between dialects lives here, so adding a shell means
+/// adding a row rather than threading `cfg!` checks through the harness.
 struct Shell {
     /// Executable name.
     bin: &'static str,
-    /// Name passed to `wsp completion <name>`.
-    completion: &'static str,
     /// Flags that disable rc/profile loading, plus the "run this string" flag.
     /// The script is appended as the final argument.
     args: &'static [&'static str],
-    /// Snippet that loads the wrapper into the current shell.
+    /// Snippet that loads the wrapper. `WSPBIN` is replaced with the quoted
+    /// path to the binary under test.
     load: &'static str,
     /// Prints the current directory followed by a newline.
     print_pwd: &'static str,
+    /// Where to send the command's own output.
+    null: &'static str,
+    quote: Quote,
 }
 
 #[cfg(unix)]
 const SHELLS: &[Shell] = &[
     Shell {
         bin: "bash",
-        completion: "bash",
         args: &["--noprofile", "--norc", "-c"],
         load: r#"eval "$(WSPBIN completion bash)" 2>/dev/null"#,
         print_pwd: r#"printf '%s\n' "$PWD""#,
+        null: "/dev/null",
+        quote: Quote::Posix,
     },
     Shell {
         bin: "zsh",
-        completion: "zsh",
         // -f == NO_RCS: skip .zshenv/.zshrc entirely.
         args: &["-f", "-c"],
         load: r#"eval "$(WSPBIN completion zsh)" 2>/dev/null"#,
         print_pwd: r#"printf '%s\n' "$PWD""#,
+        null: "/dev/null",
+        quote: Quote::Posix,
     },
     Shell {
         bin: "fish",
-        completion: "fish",
         args: &["--no-config", "-c"],
         load: r#"WSPBIN completion fish 2>/dev/null | source"#,
         print_pwd: r#"printf '%s\n' "$PWD""#,
+        null: "/dev/null",
+        quote: Quote::Posix,
     },
 ];
 
 #[cfg(windows)]
 const SHELLS: &[Shell] = &[Shell {
     bin: "pwsh",
-    completion: "powershell",
     args: &["-NoProfile", "-NonInteractive", "-Command"],
     load: r#"Invoke-Expression ((& WSPBIN completion powershell) -join "`n")"#,
     print_pwd: r#"Write-Output $PWD.Path"#,
+    null: "$null",
+    quote: Quote::PowerShell,
 }];
 
 // ---------------------------------------------------------------------------
@@ -103,12 +124,14 @@ enum Expect {
 
 /// Whether the scenario currently holds.
 enum Status {
-    /// Passes today; a regression should fail the build.
+    /// `expect` holds today; a regression should fail the build.
     Works,
-    /// Known-broken. The test asserts the *wrong* behavior so CI stays green,
-    /// and fails loudly if the behavior starts matching `expect` — at which
-    /// point the row should be promoted to `Works`.
-    KnownBroken(&'static str),
+    /// Known-broken: the wrapper leaves the shell where it started instead of
+    /// reaching `expect`. Asserted *exactly* rather than as "not `expect`", so
+    /// the row fails loudly whether the bug gets fixed or gets worse — a bare
+    /// `assert_ne!` would also pass if the fixture stopped being created or the
+    /// wrapper cd'd somewhere unrelated.
+    StaysPut(&'static str),
 }
 
 struct Scenario {
@@ -150,7 +173,7 @@ const SCENARIOS: &[Scenario] = &[
         start: Start::Root,
         cmd: &["new", "--empty", "w"],
         expect: Expect::Ws("w"),
-        status: Status::KnownBroken("wrapper parses argv positionally; see #105"),
+        status: Status::StaysPut("wrapper parses argv positionally; see #105"),
     },
     Scenario {
         name: "cd enters the workspace",
@@ -285,27 +308,41 @@ fn canon(p: &Path) -> PathBuf {
 }
 
 /// Returns `None` if the shell is not installed on this machine.
-fn run_in_shell(shell: &Shell, env: &Env, start: &Path, cmd: &[&str]) -> Option<PathBuf> {
-    let bin_quoted = shell_quote(shell, WSP);
-    let load = shell.load.replace("WSPBIN", &bin_quoted);
-    let start_quoted = shell_quote(shell, &start.to_string_lossy());
+/// Is this shell installed? Probed once per shell so a missing one does not
+/// waste a fixture setup (which spawns the binary several times).
+fn is_installed(shell: &Shell) -> bool {
+    match Command::new(shell.bin)
+        .args(shell.args)
+        .arg(shell.print_pwd)
+        .output()
+    {
+        Ok(_) => true,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
+        Err(e) => panic!("spawning {} failed: {e}", shell.bin),
+    }
+}
 
-    // Discard the command's own output; only the trailing $PWD line is read.
+fn run_in_shell(shell: &Shell, env: &Env, start: &Path, cmd: &[&str]) -> PathBuf {
+    let load = shell.load.replace("WSPBIN", &quote(shell.quote, WSP));
+
+    // Scenario args are static identifiers and flags, so joining them without
+    // per-arg quoting is safe here. Discard the command's own output; only the
+    // trailing $PWD line is read.
     let script = format!(
-        "{load}\ncd {start_quoted}\nwsp {} >{null} 2>{null}\n{}",
+        "{load}\ncd {}\nwsp {} >{null} 2>{null}\n{}",
+        quote(shell.quote, &start.to_string_lossy()),
         cmd.join(" "),
         shell.print_pwd,
-        null = null_device(),
+        null = shell.null,
     );
 
     let mut c = Command::new(shell.bin);
     apply_env(&mut c, env);
-    let out = match c.args(shell.args).arg(&script).output() {
-        Ok(o) => o,
-        // Shell not present (fish is commonly absent); skip rather than fail.
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
-        Err(e) => panic!("spawning {} failed: {e}", shell.bin),
-    };
+    let out = c
+        .args(shell.args)
+        .arg(&script)
+        .output()
+        .unwrap_or_else(|e| panic!("spawning {} failed: {e}", shell.bin));
 
     let stdout = String::from_utf8_lossy(&out.stdout);
     let last = stdout
@@ -318,19 +355,14 @@ fn run_in_shell(shell: &Shell, env: &Env, start: &Path, cmd: &[&str]) -> Option<
                 String::from_utf8_lossy(&out.stderr)
             )
         });
-    Some(PathBuf::from(last.trim()))
+    PathBuf::from(last.trim())
 }
 
-fn shell_quote(shell: &Shell, s: &str) -> String {
-    if shell.completion == "powershell" {
-        format!("'{}'", s.replace('\'', "''"))
-    } else {
-        format!("'{}'", s.replace('\'', r"'\''"))
+fn quote(style: Quote, s: &str) -> String {
+    match style {
+        Quote::Posix => format!("'{}'", s.replace('\'', r"'\''")),
+        Quote::PowerShell => format!("'{}'", s.replace('\'', "''")),
     }
-}
-
-fn null_device() -> &'static str {
-    if cfg!(windows) { "$null" } else { "/dev/null" }
 }
 
 #[test]
@@ -339,7 +371,10 @@ fn shell_wrapper_cd_behavior_matches_across_shells() {
     let mut skipped: Vec<&str> = Vec::new();
 
     for shell in SHELLS {
-        let mut shell_available = true;
+        if !is_installed(shell) {
+            skipped.push(shell.bin);
+            continue;
+        }
 
         for sc in SCENARIOS {
             let env = make_env();
@@ -357,13 +392,9 @@ fn shell_wrapper_cd_behavior_matches_across_shells() {
                 Expect::Unchanged => start.clone(),
             };
 
-            let Some(actual) = run_in_shell(shell, &env, &start, sc.cmd) else {
-                shell_available = false;
-                break;
-            };
+            let actual = canon(&run_in_shell(shell, &env, &start, sc.cmd));
             ran += 1;
 
-            let (actual, expected) = (canon(&actual), canon(&expected));
             let ctx = format!(
                 "shell={} scenario={:?} cmd=`wsp {}`",
                 shell.bin,
@@ -374,24 +405,21 @@ fn shell_wrapper_cd_behavior_matches_across_shells() {
             match sc.status {
                 Status::Works => assert_eq!(
                     actual,
-                    expected,
+                    canon(&expected),
                     "{ctx}\n  expected cwd: {}\n  actual cwd:   {}",
-                    expected.display(),
+                    canon(&expected).display(),
                     actual.display(),
                 ),
-                Status::KnownBroken(why) => assert_ne!(
+                Status::StaysPut(why) => assert_eq!(
                     actual,
-                    expected,
-                    "{ctx}\n  This scenario is marked KnownBroken ({why}) but now \
-                     produces the correct directory ({}). The fix landed — promote \
-                     this row to Status::Works.",
-                    expected.display(),
+                    canon(&start),
+                    "{ctx}\n  Marked StaysPut ({why}), so the shell was expected to \
+                     remain at {}. If it is now at {}, the fix landed — promote this \
+                     row to Status::Works.",
+                    canon(&start).display(),
+                    canon(&expected).display(),
                 ),
             }
-        }
-
-        if !shell_available {
-            skipped.push(shell.bin);
         }
     }
 

--- a/crates/wsp/tests/shell_cd.rs
+++ b/crates/wsp/tests/shell_cd.rs
@@ -1,0 +1,423 @@
+//! Behavioral tests for the shell wrapper's directory-changing logic.
+//!
+//! These spawn real shells, source the generated wrapper, run a command, and
+//! assert on the resulting `$PWD`. They deliberately assert on *behavior*
+//! rather than on the generated shell text, because every prior guarantee
+//! about the wrapper was a string assertion — which is precisely how the
+//! `wsp create` alias came to be missing from the cd path while the unit tests
+//! stayed green.
+//!
+//! Two properties matter and are easy to get wrong:
+//!
+//! 1. **No-rc invocation.** Shells are launched with rc files disabled
+//!    (`zsh -f`, `bash --norc`, ...). A user's `~/.zshenv` that exports
+//!    `XDG_DATA_HOME` will otherwise clobber the test environment — and since
+//!    that variable selects the config that selects `workspaces_dir`, the test
+//!    would create and *delete* workspaces in the developer's real
+//!    `~/dev/workspaces`. This is not hypothetical; it happened while writing
+//!    these tests.
+//!
+//! 2. **Hermetic scenarios.** Each case gets a fresh data dir and workspaces
+//!    dir, and performs its own setup by calling the binary directly (not
+//!    through a shell). No case depends on another's leftovers.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const WSP: &str = env!("CARGO_BIN_EXE_wsp");
+
+// ---------------------------------------------------------------------------
+// Shell definitions
+// ---------------------------------------------------------------------------
+
+struct Shell {
+    /// Executable name.
+    bin: &'static str,
+    /// Name passed to `wsp completion <name>`.
+    completion: &'static str,
+    /// Flags that disable rc/profile loading, plus the "run this string" flag.
+    /// The script is appended as the final argument.
+    args: &'static [&'static str],
+    /// Snippet that loads the wrapper into the current shell.
+    load: &'static str,
+    /// Prints the current directory followed by a newline.
+    print_pwd: &'static str,
+}
+
+#[cfg(unix)]
+const SHELLS: &[Shell] = &[
+    Shell {
+        bin: "bash",
+        completion: "bash",
+        args: &["--noprofile", "--norc", "-c"],
+        load: r#"eval "$(WSPBIN completion bash)" 2>/dev/null"#,
+        print_pwd: r#"printf '%s\n' "$PWD""#,
+    },
+    Shell {
+        bin: "zsh",
+        completion: "zsh",
+        // -f == NO_RCS: skip .zshenv/.zshrc entirely.
+        args: &["-f", "-c"],
+        load: r#"eval "$(WSPBIN completion zsh)" 2>/dev/null"#,
+        print_pwd: r#"printf '%s\n' "$PWD""#,
+    },
+    Shell {
+        bin: "fish",
+        completion: "fish",
+        args: &["--no-config", "-c"],
+        load: r#"WSPBIN completion fish 2>/dev/null | source"#,
+        print_pwd: r#"printf '%s\n' "$PWD""#,
+    },
+];
+
+#[cfg(windows)]
+const SHELLS: &[Shell] = &[Shell {
+    bin: "pwsh",
+    completion: "powershell",
+    args: &["-NoProfile", "-NonInteractive", "-Command"],
+    load: r#"Invoke-Expression ((& WSPBIN completion powershell) -join "`n")"#,
+    print_pwd: r#"Write-Output $PWD.Path"#,
+}];
+
+// ---------------------------------------------------------------------------
+// Scenario table
+// ---------------------------------------------------------------------------
+
+/// Where the shell starts before running the command under test.
+enum Start {
+    /// The workspaces root itself.
+    Root,
+    /// Inside workspace `<name>`.
+    Ws(&'static str),
+}
+
+/// Where the shell is expected to end up.
+enum Expect {
+    /// The workspaces root.
+    Root,
+    /// Inside workspace `<name>`.
+    Ws(&'static str),
+    /// Wherever it started — the command must not move the shell.
+    Unchanged,
+}
+
+/// Whether the scenario currently holds.
+enum Status {
+    /// Passes today; a regression should fail the build.
+    Works,
+    /// Known-broken. The test asserts the *wrong* behavior so CI stays green,
+    /// and fails loudly if the behavior starts matching `expect` — at which
+    /// point the row should be promoted to `Works`.
+    KnownBroken(&'static str),
+}
+
+struct Scenario {
+    name: &'static str,
+    /// Run with the binary directly (no shell) to build the fixture.
+    setup: &'static [&'static [&'static str]],
+    start: Start,
+    /// The `wsp ...` invocation under test, as it would be typed.
+    cmd: &'static [&'static str],
+    expect: Expect,
+    status: Status,
+}
+
+const SCENARIOS: &[Scenario] = &[
+    Scenario {
+        name: "new cds into the new workspace",
+        setup: &[],
+        start: Start::Root,
+        cmd: &["new", "w", "--empty"],
+        expect: Expect::Ws("w"),
+        status: Status::Works,
+    },
+    Scenario {
+        // The regression that motivated this file: `create` is a visible alias
+        // for `new`, and the wrapper used to dispatch on the literal name only.
+        name: "create alias cds like new",
+        setup: &[],
+        start: Start::Root,
+        cmd: &["create", "w", "--empty"],
+        expect: Expect::Ws("w"),
+        status: Status::Works,
+    },
+    Scenario {
+        // The wrapper reads the workspace name positionally, so a leading flag
+        // is mistaken for the name and it cds to `<root>/--empty`, which fails.
+        // The workspace *is* created; only the cd is wrong.
+        name: "new with a leading flag still cds",
+        setup: &[],
+        start: Start::Root,
+        cmd: &["new", "--empty", "w"],
+        expect: Expect::Ws("w"),
+        status: Status::KnownBroken("wrapper parses argv positionally; see #105"),
+    },
+    Scenario {
+        name: "cd enters the workspace",
+        setup: &[&["new", "w", "--empty"]],
+        start: Start::Root,
+        cmd: &["cd", "w"],
+        expect: Expect::Ws("w"),
+        status: Status::Works,
+    },
+    Scenario {
+        // Guards the "does this cd for every command?" worry: read-only
+        // commands must leave the shell where it is.
+        name: "st does not move the shell",
+        setup: &[&["new", "w", "--empty"]],
+        start: Start::Ws("w"),
+        cmd: &["st"],
+        expect: Expect::Unchanged,
+        status: Status::Works,
+    },
+    Scenario {
+        // Must escape before the directory is removed underneath us. On Windows
+        // a live process's cwd cannot be deleted at all, so this is load-bearing
+        // rather than cosmetic.
+        name: "rm escapes the workspace being removed",
+        setup: &[&["new", "w", "--empty"]],
+        start: Start::Ws("w"),
+        cmd: &["rm", "w", "--force"],
+        expect: Expect::Root,
+        status: Status::Works,
+    },
+    Scenario {
+        name: "remove alias escapes like rm",
+        setup: &[&["new", "w", "--empty"]],
+        start: Start::Ws("w"),
+        cmd: &["remove", "w", "--force"],
+        expect: Expect::Root,
+        status: Status::Works,
+    },
+    Scenario {
+        name: "recover cds into the restored workspace",
+        setup: &[&["new", "w", "--empty"], &["rm", "w", "--force"]],
+        start: Start::Root,
+        cmd: &["recover", "w"],
+        expect: Expect::Ws("w"),
+        status: Status::Works,
+    },
+    Scenario {
+        // `recover ls` is a subcommand, not a workspace name — it must not be
+        // treated as one and cd'd into.
+        name: "recover ls does not move the shell",
+        setup: &[&["new", "w", "--empty"], &["rm", "w", "--force"]],
+        start: Start::Root,
+        cmd: &["recover", "ls"],
+        expect: Expect::Unchanged,
+        status: Status::Works,
+    },
+];
+
+// Deliberately absent: `wsp new -b <branch>` derives the workspace name from
+// the branch's last segment, so the wrapper has no positional to read and cds
+// nowhere. It cannot be covered hermetically — `-b` requires the branch to
+// exist in a real repo, and local-path repos are not supported yet (#91), so
+// there is no way to build the fixture offline. Revisit alongside #69.
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+/// An isolated data dir + workspaces dir. Both live under one tempdir so a
+/// misconfigured lookup cannot escape into the developer's real state.
+struct Env {
+    _tmp: tempfile::TempDir,
+    data: PathBuf,
+    ws_root: PathBuf,
+}
+
+fn make_env() -> Env {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let data = tmp.path().join("data");
+    let ws_root = tmp.path().join("ws");
+    std::fs::create_dir_all(data.join("wsp")).expect("create data dir");
+    std::fs::create_dir_all(&ws_root).expect("create ws root");
+    // Point workspaces_dir at the tempdir. Without this the binary would fall
+    // back to $HOME/dev/workspaces.
+    std::fs::write(
+        data.join("wsp").join("config.yaml"),
+        format!("workspaces_dir: {}\n", ws_root.display()),
+    )
+    .expect("write config");
+    Env {
+        _tmp: tmp,
+        data,
+        ws_root,
+    }
+}
+
+/// Apply the isolating environment. `HOME` is redirected too, so even a lookup
+/// that ignores `XDG_DATA_HOME` lands inside the tempdir rather than in real
+/// user state.
+fn apply_env(cmd: &mut Command, env: &Env) {
+    cmd.env("XDG_DATA_HOME", &env.data);
+    cmd.env("HOME", env._tmp.path());
+    cmd.env("USERPROFILE", env._tmp.path());
+    // Advice hints go to stderr (discarded) and their cooldown state is written
+    // under the redirected data dir, so no suppression is needed.
+}
+
+/// Run the binary directly, no shell. Used for fixture setup.
+fn run_setup(env: &Env, args: &[&str]) {
+    let mut cmd = Command::new(WSP);
+    apply_env(&mut cmd, env);
+    let out = cmd
+        .args(args)
+        .current_dir(&env.ws_root)
+        .output()
+        .expect("spawn wsp for setup");
+    assert!(
+        out.status.success(),
+        "setup `wsp {}` failed\nstdout: {}\nstderr: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+/// Canonicalize for comparison. Needed because macOS `TMPDIR` lives under
+/// `/var`, a symlink to `/private/var`, so a shell's `$PWD` and Rust's view of
+/// the same directory are spelled differently. Falls back to the input when the
+/// path no longer exists (e.g. a directory that was just removed).
+fn canon(p: &Path) -> PathBuf {
+    std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf())
+}
+
+/// Returns `None` if the shell is not installed on this machine.
+fn run_in_shell(shell: &Shell, env: &Env, start: &Path, cmd: &[&str]) -> Option<PathBuf> {
+    let bin_quoted = shell_quote(shell, WSP);
+    let load = shell.load.replace("WSPBIN", &bin_quoted);
+    let start_quoted = shell_quote(shell, &start.to_string_lossy());
+
+    // Discard the command's own output; only the trailing $PWD line is read.
+    let script = format!(
+        "{load}\ncd {start_quoted}\nwsp {} >{null} 2>{null}\n{}",
+        cmd.join(" "),
+        shell.print_pwd,
+        null = null_device(),
+    );
+
+    let mut c = Command::new(shell.bin);
+    apply_env(&mut c, env);
+    let out = match c.args(shell.args).arg(&script).output() {
+        Ok(o) => o,
+        // Shell not present (fish is commonly absent); skip rather than fail.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => panic!("spawning {} failed: {e}", shell.bin),
+    };
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let last = stdout
+        .lines()
+        .rfind(|l| !l.trim().is_empty())
+        .unwrap_or_else(|| {
+            panic!(
+                "{} produced no output\nscript:\n{script}\nstderr: {}",
+                shell.bin,
+                String::from_utf8_lossy(&out.stderr)
+            )
+        });
+    Some(PathBuf::from(last.trim()))
+}
+
+fn shell_quote(shell: &Shell, s: &str) -> String {
+    if shell.completion == "powershell" {
+        format!("'{}'", s.replace('\'', "''"))
+    } else {
+        format!("'{}'", s.replace('\'', r"'\''"))
+    }
+}
+
+fn null_device() -> &'static str {
+    if cfg!(windows) { "$null" } else { "/dev/null" }
+}
+
+#[test]
+fn shell_wrapper_cd_behavior_matches_across_shells() {
+    let mut ran = 0usize;
+    let mut skipped: Vec<&str> = Vec::new();
+
+    for shell in SHELLS {
+        let mut shell_available = true;
+
+        for sc in SCENARIOS {
+            let env = make_env();
+            for args in sc.setup {
+                run_setup(&env, args);
+            }
+
+            let start = match sc.start {
+                Start::Root => env.ws_root.clone(),
+                Start::Ws(n) => env.ws_root.join(n),
+            };
+            let expected = match sc.expect {
+                Expect::Root => env.ws_root.clone(),
+                Expect::Ws(n) => env.ws_root.join(n),
+                Expect::Unchanged => start.clone(),
+            };
+
+            let Some(actual) = run_in_shell(shell, &env, &start, sc.cmd) else {
+                shell_available = false;
+                break;
+            };
+            ran += 1;
+
+            let (actual, expected) = (canon(&actual), canon(&expected));
+            let ctx = format!(
+                "shell={} scenario={:?} cmd=`wsp {}`",
+                shell.bin,
+                sc.name,
+                sc.cmd.join(" ")
+            );
+
+            match sc.status {
+                Status::Works => assert_eq!(
+                    actual,
+                    expected,
+                    "{ctx}\n  expected cwd: {}\n  actual cwd:   {}",
+                    expected.display(),
+                    actual.display(),
+                ),
+                Status::KnownBroken(why) => assert_ne!(
+                    actual,
+                    expected,
+                    "{ctx}\n  This scenario is marked KnownBroken ({why}) but now \
+                     produces the correct directory ({}). The fix landed — promote \
+                     this row to Status::Works.",
+                    expected.display(),
+                ),
+            }
+        }
+
+        if !shell_available {
+            skipped.push(shell.bin);
+        }
+    }
+
+    if !skipped.is_empty() {
+        eprintln!(
+            "note: shells not installed, skipped: {}",
+            skipped.join(", ")
+        );
+    }
+
+    // Locally a missing shell is a convenience skip. In CI it is a silent loss
+    // of coverage for an entire dialect — exactly the blind spot that let the
+    // wrapper drift in the first place — so CI sets this and demands all of
+    // them. See the fish/zsh install steps in .github/workflows/ci.yml.
+    if std::env::var_os("WSP_SHELL_TESTS_REQUIRE_ALL").is_some() {
+        assert!(
+            skipped.is_empty(),
+            "WSP_SHELL_TESTS_REQUIRE_ALL is set but these shells are missing: {}. \
+             Install them or unset the variable.",
+            skipped.join(", ")
+        );
+    }
+
+    assert!(
+        ran > 0,
+        "no shell was available to test; expected at least one of {:?}",
+        SHELLS.iter().map(|s| s.bin).collect::<Vec<_>>()
+    );
+}

--- a/crates/wsp/tests/shell_cd.rs
+++ b/crates/wsp/tests/shell_cd.rs
@@ -295,8 +295,9 @@ fn real_path(p: &Path) -> PathBuf {
 
 fn make_env() -> Env {
     let tmp = tempfile::tempdir().expect("create tempdir");
-    let data = real_path(tmp.path()).join("data");
-    let ws_root = real_path(tmp.path()).join("ws");
+    let root = real_path(tmp.path());
+    let data = root.join("data");
+    let ws_root = root.join("ws");
     std::fs::create_dir_all(data.join("wsp")).expect("create data dir");
     std::fs::create_dir_all(&ws_root).expect("create ws root");
     // Point workspaces_dir at the tempdir. Without this the binary would fall

--- a/crates/wsp/tests/shell_cd.rs
+++ b/crates/wsp/tests/shell_cd.rs
@@ -275,10 +275,28 @@ struct Env {
     ws_root: PathBuf,
 }
 
+/// Canonicalize without the Windows `\\?\` verbatim prefix.
+///
+/// This matters for more than tidiness. `std::env::temp_dir()` on Windows can
+/// hand back an 8.3 short path (`C:\Users\RUNNER~1\...`), and that value ends up
+/// baked into the wrapper as `$wspRoot`. PowerShell reports `$PWD.Path` in long
+/// form, so the wrapper's `$PWD.Path -eq $wspDir` guard compares a short path
+/// against a long one, never matches, and `wsp rm` runs with the shell still
+/// inside the workspace it is removing. Normalizing here keeps the config, the
+/// wrapper, and the shell talking about the same spelling.
+///
+/// The `\\?\` prefix has to go: PowerShell's `$PWD.Path` never uses it, so
+/// leaving it on would reintroduce the same mismatch from the other direction.
+fn real_path(p: &Path) -> PathBuf {
+    let c = std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
+    let s = c.to_string_lossy().into_owned();
+    PathBuf::from(s.strip_prefix(r"\\?\").unwrap_or(&s))
+}
+
 fn make_env() -> Env {
     let tmp = tempfile::tempdir().expect("create tempdir");
-    let data = tmp.path().join("data");
-    let ws_root = tmp.path().join("ws");
+    let data = real_path(tmp.path()).join("data");
+    let ws_root = real_path(tmp.path()).join("ws");
     std::fs::create_dir_all(data.join("wsp")).expect("create data dir");
     std::fs::create_dir_all(&ws_root).expect("create ws root");
     // Point workspaces_dir at the tempdir. Without this the binary would fall
@@ -351,14 +369,17 @@ fn is_installed(shell: &Shell) -> bool {
     }
 }
 
-fn run_in_shell(shell: &Shell, env: &Env, start: &Path, cmd: &[&str]) -> PathBuf {
+/// Returns the shell's final `$PWD` plus whatever the command wrote to stderr,
+/// so an assertion failure can explain *why* the shell ended up where it did.
+/// Without this a Windows-only failure is just two paths and no cause.
+fn run_in_shell(shell: &Shell, env: &Env, start: &Path, cmd: &[&str]) -> (PathBuf, String) {
     let load = shell.load.replace("WSPBIN", &quote(shell.quote, WSP));
 
     // Scenario args are static identifiers and flags, so joining them without
-    // per-arg quoting is safe here. Discard the command's own output; only the
-    // trailing $PWD line is read.
+    // per-arg quoting is safe here. Only stdout is discarded, so the trailing
+    // $PWD line is the sole stdout content; stderr is kept for diagnostics.
     let script = format!(
-        "{load}\ncd {}\nwsp {} >{null} 2>{null}\n{}",
+        "{load}\ncd {}\nwsp {} >{null}\n{}",
         quote(shell.quote, &start.to_string_lossy()),
         cmd.join(" "),
         shell.print_pwd,
@@ -384,7 +405,10 @@ fn run_in_shell(shell: &Shell, env: &Env, start: &Path, cmd: &[&str]) -> PathBuf
                 String::from_utf8_lossy(&out.stderr)
             )
         });
-    PathBuf::from(last.trim())
+    (
+        PathBuf::from(last.trim()),
+        String::from_utf8_lossy(&out.stderr).trim().to_string(),
+    )
 }
 
 fn quote(style: Quote, s: &str) -> String {
@@ -421,15 +445,17 @@ fn shell_wrapper_cd_behavior_matches_across_shells() {
                 Expect::Unchanged => start.clone(),
             };
 
-            let actual = canon(&run_in_shell(shell, &env, &start, sc.cmd));
+            let (actual, stderr) = run_in_shell(shell, &env, &start, sc.cmd);
+            let actual = canon(&actual);
             let (start, expected) = (canon(&start), canon(&expected));
             ran += 1;
 
             let ctx = format!(
-                "shell={} scenario={:?} cmd=`wsp {}`",
+                "shell={} scenario={:?} cmd=`wsp {}`\n  command stderr: {}",
                 shell.bin,
                 sc.name,
-                sc.cmd.join(" ")
+                sc.cmd.join(" "),
+                if stderr.is_empty() { "<none>" } else { &stderr },
             );
 
             match sc.status {

--- a/crates/wsp/tests/shell_cd.rs
+++ b/crates/wsp/tests/shell_cd.rs
@@ -263,9 +263,14 @@ fn make_env() -> Env {
     std::fs::create_dir_all(&ws_root).expect("create ws root");
     // Point workspaces_dir at the tempdir. Without this the binary would fall
     // back to $HOME/dev/workspaces.
+    // Single-quoted so a Windows temp path (`C:\Users\...`) stays a literal
+    // scalar rather than relying on YAML plain-scalar rules around `:` and `\`.
     std::fs::write(
         data.join("wsp").join("config.yaml"),
-        format!("workspaces_dir: {}\n", ws_root.display()),
+        format!(
+            "workspaces_dir: '{}'\n",
+            ws_root.display().to_string().replace('\'', "''")
+        ),
     )
     .expect("write config");
     Env {
@@ -398,6 +403,7 @@ fn shell_wrapper_cd_behavior_matches_across_shells() {
             };
 
             let actual = canon(&run_in_shell(shell, &env, &start, sc.cmd));
+            let (start, expected) = (canon(&start), canon(&expected));
             ran += 1;
 
             let ctx = format!(
@@ -410,19 +416,19 @@ fn shell_wrapper_cd_behavior_matches_across_shells() {
             match sc.status {
                 Status::Works => assert_eq!(
                     actual,
-                    canon(&expected),
+                    expected,
                     "{ctx}\n  expected cwd: {}\n  actual cwd:   {}",
-                    canon(&expected).display(),
+                    expected.display(),
                     actual.display(),
                 ),
                 Status::StaysPut(why) => assert_eq!(
                     actual,
-                    canon(&start),
+                    start,
                     "{ctx}\n  Marked StaysPut ({why}), so the shell was expected to \
                      remain at {}. If it is now at {}, the fix landed — promote this \
                      row to Status::Works.",
-                    canon(&start).display(),
-                    canon(&expected).display(),
+                    start.display(),
+                    expected.display(),
                 ),
             }
         }

--- a/crates/wsp/tests/shell_cd.rs
+++ b/crates/wsp/tests/shell_cd.rs
@@ -337,7 +337,6 @@ fn canon(p: &Path) -> PathBuf {
     std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf())
 }
 
-/// Returns `None` if the shell is not installed on this machine.
 /// Is this shell installed? Probed once per shell so a missing one does not
 /// waste a fixture setup (which spawns the binary several times).
 fn is_installed(shell: &Shell) -> bool {


### PR DESCRIPTION
## Why

Every guarantee about the generated shell wrapper was a string assertion on the generated *text*. That is exactly how #103 happened: the wrapper dispatched on the literal subcommand name, `create` fell through to the catch-all, and all 33 completion unit tests stayed green because none of them looked at where the shell actually ended up.

This adds the missing layer — assert on **behavior**, not on generated strings.

## What

A table-driven harness that spawns real shells, sources the wrapper, runs a command, and checks the resulting `$PWD`. Nine scenarios per dialect (bash/zsh/fish on unix, pwsh on Windows):

| Scenario | Expected | Guards |
|---|---|---|
| `new w --empty` | `<root>/w` | baseline |
| `create w --empty` | `<root>/w` | **the #103 regression** |
| `new --empty w` | `<root>/w` | **broken on posix/fish, works on pwsh** — see below |
| `cd w` | `<root>/w` | |
| `st` from inside | unchanged | that read-only commands don't move the shell |
| `rm w --force` from inside | `<root>` | escaping a directory being deleted |
| `remove w --force` from inside | `<root>` | the `rm` alias |
| `recover w` | `<root>/w` | |
| `recover ls` | unchanged | subcommand not mistaken for a workspace name |

## The harness actually fails

Reverting the `new|create` fix produces:

```
assertion `left == right` failed: shell=bash scenario="create alias cds like new" cmd=`wsp create w --empty`
  expected cwd: /private/var/.../ws/w
  actual cwd:   /private/var/.../ws
```

## Two things that make it trustworthy

**Shells run with rc files disabled** (`zsh -f`, `bash --norc`, `fish --no-config`). This is not cosmetic: a developer's `~/.zshenv` exporting `XDG_DATA_HOME` clobbers the test environment, and since that variable selects the config that selects `workspaces_dir`, the tests would create and **delete** workspaces in the developer's real `~/dev/workspaces`. That happened while writing this, hence the comment in the module docs.

**Each scenario is hermetic** — fresh data dir and workspaces dir, fixture built by calling the binary directly rather than through a shell. `HOME` is redirected too, so even a lookup ignoring `XDG_DATA_HOME` stays inside the tempdir.

## CI

A missing shell is a convenience skip locally, but in CI it silently drops a whole dialect — the same blind spot in a new place. CI installs `zsh`/`fish` and sets `WSP_SHELL_TESTS_REQUIRE_ALL=1`, which turns a skip into a failure.

⚠️ **This gives the fish wrapper its first-ever behavioral coverage.** If the fish generator has a latent bug, this PR's CI run is where it surfaces. That's the point, but it means a red run here is informative rather than a problem with the harness.

## Known gaps, stated explicitly

- **`new --empty <name>`** is platform-dependent, via a `cfg`'d `LEADING_FLAG` const. PowerShell's `new` case scans `$restArgs` for the first non-flag argument (guarded by `test_ps_new_skips_flag_args_when_cding`) so it cds correctly; posix and fish read `$1` / `$args[1]` positionally and cd to `<root>/--empty`, which fails. On unix the row asserts the *current wrong* behavior exactly (`StaysPut`) and fails loudly if it starts passing, so #105 cannot land without promoting it. The workspace is created correctly on every platform; only the cd differs.

  Worth calling out on its own: **the same command moves the shell differently depending on the platform.** The flag-scanning fix was applied to one dialect and never backported to the other two. Recorded in #105.
- **`new -b <branch>`** is absent. It derives the name from the branch's last segment, so the wrapper has no positional to read, but it can't be covered hermetically: `-b` requires the branch to exist in a real repo, and local-path repos aren't supported yet (#91). Revisit with #69.

Refs #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)
