### PR TITLE
fix(release): run release-notes on workflow_run, not a dist hook

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -7,34 +7,65 @@ name: release-notes
 # page is every commit, including CI and release-process churn. The prose stays
 # above it; the generated log and install table remain below.
 #
-# Runs via post-announce-jobs, so the release already exists and this only
-# edits it.
+# Why workflow_run and not a dist job hook: none of them can express "after the
+# release exists, including on prereleases".
+#
+#   plan-jobs, global-artifacts-jobs   run before the release exists
+#   host-jobs                          share host's dependencies, so they race it
+#   publish-jobs                       dist stamps every one with a
+#                                      `!announcement_is_prerelease` guard
+#   post-announce-jobs                 announce depends on
+#                                      publish-homebrew-formula, which skips on
+#                                      prereleases; GitHub propagates that skip
+#                                      to downstream jobs lacking `always()`,
+#                                      and dist emits custom hooks without one
+#
+# As a post-announce job this silently never ran on v0.19.0-rc.2 while the
+# workflow still reported success. workflow_run fires on Release completion
+# regardless of any skip inside it, and lives outside the dist-generated file
+# so `dist generate` cannot clobber it.
 on:
-  workflow_call:
-    inputs:
-      plan:
-        required: true
-        type: string
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
 
 jobs:
   release-notes:
+    # Only real dispatches. release.yml also runs on pull_request, and those
+    # never produce a release.
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
+      # The commit that was released, not the tip of main — main may already
+      # have moved, and WHATSNEW.md must be read as it was at release time.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Prepend release notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ fromJson(inputs.plan).announcement_tag }}
         run: |
           set -euo pipefail
-          if [ -z "${TAG:-}" ]; then
-            echo "no tag (dry run) — nothing to edit"
+
+          # The tag dist created is v<version> for the version at this commit;
+          # `just release-dispatch` guarantees they agree.
+          version=$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\(.*\)".*/\1/p' Cargo.toml | head -1)
+          if [ -z "$version" ]; then
+            echo "::error::could not read the version from Cargo.toml"
+            exit 1
+          fi
+          tag="v$version"
+
+          # A dry-run dispatch completes successfully without creating anything.
+          if ! gh release view "$tag" >/dev/null 2>&1; then
+            echo "no release for $tag — dry run, nothing to edit"
             exit 0
           fi
-          version="${TAG#v}"
 
           # Section for this version, up to the next "## [" heading.
           notes=$(awk -v want="## [$version]" '
@@ -51,7 +82,20 @@ jobs:
             exit 1
           fi
 
-          gh release view "$TAG" --json body -q .body > /tmp/body.md
+          # Drop the blank line the awk leaves after the heading.
+          notes=$(printf '%s\n' "$notes" | sed '/./,$!d')
+
+          # Idempotent: re-running must not stack the prose twice. Compare the
+          # first non-blank line of each -- comparing raw first lines matches an
+          # empty pattern against everything and always reports "present".
+          gh release view "$tag" --json body -q .body > /tmp/body.md
+          first_note=$(printf '%s\n' "$notes" | grep -m1 -v '^[[:space:]]*$')
+          first_body=$(grep -m1 -v '^[[:space:]]*$' /tmp/body.md || true)
+          if [ -n "$first_note" ] && [ "$first_note" = "$first_body" ]; then
+            echo "notes already present on $tag — nothing to do"
+            exit 0
+          fi
+
           { printf '%s\n\n---\n\n' "$notes"; cat /tmp/body.md; } > /tmp/new-body.md
-          gh release edit "$TAG" --notes-file /tmp/new-body.md
-          echo "prepended $(printf '%s' "$notes" | wc -l) lines of notes to $TAG"
+          gh release edit "$tag" --notes-file /tmp/new-body.md
+          echo "prepended $(printf '%s' "$notes" | wc -l) lines of notes to $tag"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -355,12 +355,3 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-
-  custom-release-notes:
-    needs:
-      - plan
-      - announce
-    uses: ./.github/workflows/release-notes.yml
-    with:
-      plan: ${{ needs.plan.outputs.val }}
-    secrets: inherit

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -101,7 +101,7 @@ full-structure example.
 
 ## After the release
 
-Nothing to do by hand. `release-notes.yml` runs after announce and prepends the
+Nothing to do by hand. `release-notes.yml` runs as a publish job and prepends the
 `WHATSNEW.md` section for the version to the release body, above the generated
 commit log and install table. It fails loudly if the section is missing, which
 the `whatsnew` CI gate should already have prevented.

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -14,9 +14,8 @@ dispatch-releases = true
 # host-jobs) is the one that makes `host` wait: host-jobs produces a job with
 # the same dependencies as host, so they race and the tag lands regardless.
 global-artifacts-jobs = ["./smoke"]
-# Put the WHATSNEW prose above cargo-dist's generated commit log in the release
-# body. Runs after announce, so it only edits an existing release.
-post-announce-jobs = ["./release-notes"]
+# NOTE: release-notes is deliberately NOT a dist job hook. See
+# .github/workflows/release-notes.yml for why none of them work.
 # CI backends to support
 ci = "github"
 # The installers to generate for each app


### PR DESCRIPTION
`custom-release-notes` was **skipped** on `v0.19.0-rc.2` while the release run reported `success`. The WHATSNEW prose never reached the release body, and nothing failed. The mechanism added in #98 has therefore still never executed.

## Why it skipped

```yaml
announce:
  needs: [plan, host, publish-homebrew-formula]
  # use "always() && ..." to allow us to wait for all publish jobs while
  # still allowing individual publish jobs to skip themselves (for prereleases).
  if: ${{ always() && needs.host.result == 'success' && (...) }}
```

`publish-homebrew-formula` skips on prereleases — that is our policy, and correct. `announce` survives it with `always()`. But `custom-release-notes` is generated with **no `if:` at all**, so its implicit condition is `success()`, and GitHub propagates a skipped transitive dependency straight through to it.

cargo-dist applies the workaround to its own `announce` job and not to the hooks it generates for users.

## No hook works

| Hook | Why not |
|---|---|
| `plan-jobs`, `global-artifacts-jobs` | run before the release exists |
| `host-jobs` | share `host`'s dependencies, so they race it |
| `publish-jobs` | dist stamps every one with a `!announcement_is_prerelease` guard |
| `post-announce-jobs` | inherit the homebrew skip (the current bug) |

I tried `publish-jobs` first — it looked ideal, since publish jobs need only `plan` + `host` and the release exists by then. Regenerating showed dist adds the prerelease guard to custom publish jobs too:

```yaml
custom-release-notes:
  needs: [plan, host]
  if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || ... }}
```

That skips prereleases *explicitly* — worse than the transitive skip. Rejected on inspection of the generated output rather than on assumption.

## The fix

Move out of the dist-generated file entirely. `workflow_run` fires on Release completion regardless of what skipped inside it, and `dist generate` cannot clobber a workflow it does not own — which also retires a standing hazard, since `release.yml` is hand-edit-forbidden.

It checks out `github.event.workflow_run.head_sha`, not main, so `WHATSNEW.md` is read as it was at release time even if main has already moved.

`release: published` was not an option: the release is created by `GITHUB_TOKEN`, which does not trigger workflows — the same constraint `RELEASING.md` records for tags.

## A bug in my own fix, caught before pushing

I ran the logic against the real rc.2 release. It reported *"notes already present"* against a body that plainly had none.

The extracted section begins with a blank line, so `printf '%s' "$notes" | head -1` was empty and `grep -qF ""` matched everything. The idempotence guard would have suppressed the job on **every** run — replacing a silent skip with a different silent skip.

Now compares first non-blank lines. Verified both directions: prepends when absent, exits cleanly when present, no double-stacking.

## Verification

- [x] YAML parses; trigger and job structure confirmed
- [x] `dist generate --check` clean — the `plan` freshness gate will pass
- [x] Logic dry-run against the live rc.2 release: extracts 17 lines, produces prose → `---` → generated log
- [x] Idempotence verified against the prepended output
- [x] Dry-run dispatch path exits 0; missing WHATSNEW section still fails loudly
- [ ] **Unproven until a real release runs.** `workflow_run` cannot be exercised by a PR — same limitation as the smoke gate, and the reason this bug survived to rc.2.

`0.19.0` final will be the first genuine execution. Given the history, worth checking the body by hand that once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
