### PR TITLE
fix(completion): take `new`'s cd destination from the binary

### DIFF
--- a/crates/wsp/src/cli/completion.rs
+++ b/crates/wsp/src/cli/completion.rs
@@ -258,12 +258,24 @@ fn build_posix_cases() -> Vec<ShellCase> {
     ]
 }
 
+/// Shell body for `wsp new`: run the command, then cd to wherever it says it
+/// landed.
+///
+/// The destination comes from the binary via `WSP_CD_FILE` rather than from
+/// argv. `new` has five value-taking flags and can derive the workspace name
+/// from `-b`, so no positional scan here can be correct — see `shellcd`.
 fn build_posix_cd_into(cmd_name: &str) -> String {
     format!(
         "shift\n\
-         \x20     command \"$wsp_bin\" {cmd_name} \"$@\" || return\n\
-         \x20     local wsp_dir=\"$wsp_root/$1\"\n\
-         \x20     cd \"$wsp_dir\"",
+         \x20     local _wsp_cd _wsp_rc\n\
+         \x20     _wsp_cd=$(mktemp) || return\n\
+         \x20     WSP_CD_FILE=\"$_wsp_cd\" command \"$wsp_bin\" {cmd_name} \"$@\"\n\
+         \x20     _wsp_rc=$?\n\
+         \x20     if [[ $_wsp_rc -eq 0 && -s \"$_wsp_cd\" ]]; then\n\
+         \x20       cd -- \"$(<\"$_wsp_cd\")\"\n\
+         \x20     fi\n\
+         \x20     rm -f \"$_wsp_cd\"\n\
+         \x20     return $_wsp_rc",
     )
 }
 
@@ -422,9 +434,14 @@ function wsp\n\
     switch $argv[1]\n\
         case new create\n\
             set -l args $argv[2..]\n\
-            command $wsp_bin new $args; or return\n\
-            set -l wsp_dir \"$wsp_root/$args[1]\"\n\
-            cd $wsp_dir\n\
+            set -l cdfile (mktemp); or return\n\
+            WSP_CD_FILE=$cdfile command $wsp_bin new $args\n\
+            set -l rc $status\n\
+            if test $rc -eq 0 -a -s $cdfile\n\
+                cd (cat $cdfile)\n\
+            end\n\
+            rm -f $cdfile\n\
+            return $rc\n\
 \n\
         case cd\n\
             set -l args $argv[2..]\n\
@@ -570,29 +587,41 @@ fn write_powershell(w: &mut dyn Write, bin_str: &str, wsp_root: &str) -> Result<
     writeln!(w, "    $wspRoot = '{root_esc}'")?;
     writeln!(w)?;
     writeln!(w, "    switch ($args[0]) {{")?;
+    // The destination comes from the binary via WSP_CD_FILE, not from argv.
+    // `new` has five value-taking flags and can derive the name from -b, so no
+    // scan here can be correct — the previous "first non-flag arg" version sent
+    // `wsp new -w existing new-ws` into `existing`. See the shellcd module.
     writeln!(w, "        {{ $_ -in 'new', 'create' }} {{")?;
     writeln!(
         w,
         "            $restArgs = @($args | Select-Object -Skip 1)"
     )?;
+    writeln!(
+        w,
+        "            $cdFile = [System.IO.Path]::GetTempFileName()"
+    )?;
+    writeln!(w, "            $env:WSP_CD_FILE = $cdFile")?;
     writeln!(w, "            & $wspBin new @restArgs")?;
+    writeln!(w, "            $rc = $LASTEXITCODE")?;
     writeln!(
         w,
-        "            if ($LASTEXITCODE -eq 0 -and $restArgs.Count -gt 0) {{"
+        "            Remove-Item Env:\\WSP_CD_FILE -ErrorAction SilentlyContinue"
     )?;
-    writeln!(w, "                $wspName = $null")?;
-    writeln!(w, "                foreach ($a in $restArgs) {{")?;
     writeln!(
         w,
-        "                    if (-not $a.StartsWith('-')) {{ $wspName = $a; break }}"
+        "            $dest = if (Test-Path -LiteralPath $cdFile) {{ (Get-Content -LiteralPath $cdFile -Raw) }} else {{ '' }}"
     )?;
-    writeln!(w, "                }}")?;
-    writeln!(w, "                if ($wspName) {{")?;
     writeln!(
         w,
-        "                    Set-Location (Join-Path $wspRoot $wspName)"
+        "            Remove-Item -LiteralPath $cdFile -ErrorAction SilentlyContinue"
     )?;
-    writeln!(w, "                }}")?;
+    // Get-Content -Raw yields $null for an empty file, and $null.Trim() throws,
+    // so test with IsNullOrWhiteSpace rather than calling a method on $dest.
+    writeln!(
+        w,
+        "            if ($rc -eq 0 -and -not [string]::IsNullOrWhiteSpace($dest)) {{"
+    )?;
+    writeln!(w, "                Set-Location $dest.Trim()")?;
     writeln!(w, "            }}")?;
     writeln!(w, "        }}")?;
     writeln!(w, "        'cd' {{")?;
@@ -1320,18 +1349,83 @@ mod tests {
         assert!(out.contains("default"), "missing default case");
     }
 
+    /// Slice the generated script from `start` up to `end`, so an assertion
+    /// about one `case` branch cannot accidentally be satisfied by another.
+    ///
+    /// Without this, `!out.contains(...)` reads as a guard on the branch you
+    /// have in mind while actually matching a sibling branch — which is how
+    /// `test_ps_new_skips_flag_args_when_cding` kept passing after the code it
+    /// described had been deleted.
+    fn case_body<'a>(out: &'a str, start: &str, end: &str) -> &'a str {
+        let i = out
+            .find(start)
+            .unwrap_or_else(|| panic!("case marker not found: {start}"));
+        let rest = &out[i..];
+        let j = rest
+            .find(end)
+            .unwrap_or_else(|| panic!("end marker not found after {start}: {end}"));
+        &rest[..j]
+    }
+
+    /// `new` must take its destination from the binary, never from argv.
+    ///
+    /// Both argv strategies are wrong: `$1` mistakes a leading flag for the
+    /// name, and scanning for the first non-flag token mistakes a flag's value
+    /// for it, sending `wsp new -w existing new-ws` into `existing`. This
+    /// asserts the argv derivation is gone from every dialect, not merely that
+    /// one spelling of it is absent.
     #[test]
-    fn test_ps_new_skips_flag_args_when_cding() {
-        let out = output(|w| write_powershell(w, r"C:\wsp.exe", r"C:\dev"));
-        // Must iterate restArgs to find the workspace name, not blindly use restArgs[0],
-        // so that `wsp new --template foo my-workspace` cds into my-workspace not --template.
+    fn test_new_takes_destination_from_binary() {
+        let posix = output(|w| {
+            write_posix(
+                w,
+                "/usr/bin/wsp",
+                "/home/user/dev",
+                "zsh",
+                ShellHookOpts::default(),
+            )
+        });
+        let posix_new = case_body(&posix, "new|create)", "    cd)");
         assert!(
-            !out.contains("Set-Location (Join-Path $wspRoot $restArgs[0])"),
-            "new must not use restArgs[0] directly as workspace name"
+            posix_new.contains("WSP_CD_FILE"),
+            "posix new must pass WSP_CD_FILE"
         );
         assert!(
-            out.contains("$a.StartsWith('-')"),
-            "new must skip flag arguments when looking for workspace name"
+            !posix_new.contains("$wsp_root/$"),
+            "posix new must not build the destination from a positional arg"
+        );
+
+        let fish = output(|w| {
+            write_fish(
+                w,
+                "/usr/bin/wsp",
+                "/home/user/dev",
+                ShellHookOpts::default(),
+            )
+        });
+        let fish_new = case_body(&fish, "case new create", "case cd");
+        assert!(
+            fish_new.contains("WSP_CD_FILE"),
+            "fish new must pass WSP_CD_FILE"
+        );
+        assert!(
+            !fish_new.contains("$wsp_root/$"),
+            "fish new must not build the destination from a positional arg"
+        );
+
+        let pwsh = output(|w| write_powershell(w, r"C:\wsp.exe", r"C:\dev"));
+        let pwsh_new = case_body(&pwsh, "$_ -in 'new', 'create'", "'cd' {");
+        assert!(
+            pwsh_new.contains("$env:WSP_CD_FILE"),
+            "powershell new must pass WSP_CD_FILE"
+        );
+        assert!(
+            !pwsh_new.contains("$wspName"),
+            "powershell new must not scan argv for the workspace name"
+        );
+        assert!(
+            !pwsh_new.contains("Join-Path $wspRoot"),
+            "powershell new must not build the destination from $wspRoot"
         );
     }
 

--- a/crates/wsp/src/cli/new.rs
+++ b/crates/wsp/src/cli/new.rs
@@ -530,6 +530,11 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
         .map(|m| m.branch.as_str())
         .unwrap_or(ws_name);
 
+    // Tell the shell wrapper where we landed. ws_dir is authoritative here —
+    // it already accounts for a name derived from -b and for flags appearing
+    // before the positional, neither of which the wrapper can work out itself.
+    crate::shellcd::request(&ws_dir);
+
     Ok(Output::Mutation(
         MutationOutput::new(format!("Workspace created: {}", ws_dir.display()))
             .with_duration(duration_ms)

--- a/crates/wsp/src/main.rs
+++ b/crates/wsp/src/main.rs
@@ -4,6 +4,7 @@ mod cli;
 mod hints;
 mod output;
 mod pr;
+mod shellcd;
 
 use std::process;
 

--- a/crates/wsp/src/shellcd.rs
+++ b/crates/wsp/src/shellcd.rs
@@ -1,0 +1,32 @@
+//! Shell cd requests.
+//!
+//! The wrapper function cannot learn a destination from the binary's stdout —
+//! human-readable progress output shares that channel — so it passes the path
+//! of a scratch file in `WSP_CD_FILE` and reads the directory back after the
+//! process exits.
+//!
+//! This exists because the wrapper cannot correctly re-derive the destination
+//! from argv. `wsp new` has five value-taking flags (`-b`, `-t`, `-w`, `-f`,
+//! `-d`) and may omit the workspace name entirely, deriving it from the branch
+//! given to `-b`. No positional scan in shell gets that right: taking `$1`
+//! mistakes a leading flag for the name, and taking the first non-flag token
+//! mistakes a flag's *value* for it — so `wsp new -w existing new-ws` lands in
+//! `existing`. Reporting the resolved directory from the one place that already
+//! knows it removes the guesswork.
+
+use std::path::Path;
+
+/// Ask the calling shell to change directory to `dir`.
+///
+/// A no-op when `WSP_CD_FILE` is unset, so piping, scripts, and shells without
+/// the wrapper loaded are unaffected.
+///
+/// Write failures are ignored on purpose. By the time this is called the
+/// command has already done its work; not moving the shell is a cosmetic loss
+/// and not worth failing an otherwise successful operation over.
+pub fn request(dir: &Path) {
+    let Some(file) = std::env::var_os("WSP_CD_FILE") else {
+        return;
+    };
+    let _ = std::fs::write(file, dir.to_string_lossy().as_bytes());
+}

--- a/crates/wsp/tests/shell_cd.rs
+++ b/crates/wsp/tests/shell_cd.rs
@@ -127,39 +127,6 @@ enum Expect {
     Unchanged,
 }
 
-/// Whether the scenario currently holds.
-///
-/// `StaysPut` is unused on Windows, where the only platform-dependent row
-/// (`LEADING_FLAG`) resolves to `Works`.
-#[allow(dead_code)]
-enum Status {
-    /// `expect` holds today; a regression should fail the build.
-    Works,
-    /// Known-broken: the wrapper leaves the shell where it started instead of
-    /// reaching `expect`. Asserted *exactly* rather than as "not `expect`", so
-    /// the row fails loudly whether the bug gets fixed or gets worse — a bare
-    /// `assert_ne!` would also pass if the fixture stopped being created or the
-    /// wrapper cd'd somewhere unrelated.
-    StaysPut(&'static str),
-}
-
-/// Status of the "leading flag" scenario, which is the one place the dialects
-/// genuinely disagree today.
-///
-/// PowerShell's `new` case iterates `$restArgs` to find the first non-flag
-/// argument (guarded by `test_ps_new_skips_flag_args_when_cding`), so it lands
-/// in the right place. The posix and fish cases read `$1` / `$args[1]`
-/// positionally and so cd to `<root>/--empty`, which fails and leaves the shell
-/// where it started.
-///
-/// That divergence is itself worth fixing — the same command should not move
-/// the shell differently depending on the platform — and #105 removes the
-/// argv parsing that causes it.
-#[cfg(unix)]
-const LEADING_FLAG: Status = Status::StaysPut("posix/fish read argv positionally; see #105");
-#[cfg(windows)]
-const LEADING_FLAG: Status = Status::Works;
-
 struct Scenario {
     name: &'static str,
     /// Run with the binary directly (no shell) to build the fixture.
@@ -168,7 +135,6 @@ struct Scenario {
     /// The `wsp ...` invocation under test, as it would be typed.
     cmd: &'static [&'static str],
     expect: Expect,
-    status: Status,
 }
 
 const SCENARIOS: &[Scenario] = &[
@@ -178,7 +144,6 @@ const SCENARIOS: &[Scenario] = &[
         start: Start::Root,
         cmd: &["new", "w", "--empty"],
         expect: Expect::Ws("w"),
-        status: Status::Works,
     },
     Scenario {
         // The regression that motivated this file: `create` is a visible alias
@@ -188,17 +153,31 @@ const SCENARIOS: &[Scenario] = &[
         start: Start::Root,
         cmd: &["create", "w", "--empty"],
         expect: Expect::Ws("w"),
-        status: Status::Works,
     },
     Scenario {
-        // Platform-dependent today — see LEADING_FLAG. The workspace is always
-        // created correctly; only the cd differs.
-        name: "new with a leading flag still cds",
+        // Was broken on posix/fish (cd to `<root>/--empty`) and correct on
+        // pwsh. Fixed for all dialects by taking the destination from the
+        // binary instead of argv.
+        name: "new with a leading flag cds",
         setup: &[],
         start: Start::Root,
         cmd: &["new", "--empty", "w"],
         expect: Expect::Ws("w"),
-        status: LEADING_FLAG,
+    },
+    Scenario {
+        // A value-taking flag's *value* must never be mistaken for the
+        // workspace name. pwsh's old "first non-flag arg" scan picked `notaws`
+        // here and cd'd to `<root>/notaws`.
+        //
+        // `-d` is used rather than `-w`/`-t`/`-f` because those need a source
+        // with repos in it, which cannot be built offline (#91). The argv
+        // hazard is identical either way: a flag that consumes the token after
+        // it.
+        name: "new does not cd to a flag value",
+        setup: &[],
+        start: Start::Root,
+        cmd: &["new", "-d", "notaws", "w", "--empty"],
+        expect: Expect::Ws("w"),
     },
     Scenario {
         name: "cd enters the workspace",
@@ -206,7 +185,6 @@ const SCENARIOS: &[Scenario] = &[
         start: Start::Root,
         cmd: &["cd", "w"],
         expect: Expect::Ws("w"),
-        status: Status::Works,
     },
     Scenario {
         // Guards the "does this cd for every command?" worry: read-only
@@ -216,7 +194,6 @@ const SCENARIOS: &[Scenario] = &[
         start: Start::Ws("w"),
         cmd: &["st"],
         expect: Expect::Unchanged,
-        status: Status::Works,
     },
     Scenario {
         // Must escape before the directory is removed underneath us. On Windows
@@ -227,7 +204,6 @@ const SCENARIOS: &[Scenario] = &[
         start: Start::Ws("w"),
         cmd: &["rm", "w", "--force"],
         expect: Expect::Root,
-        status: Status::Works,
     },
     Scenario {
         name: "remove alias escapes like rm",
@@ -235,7 +211,6 @@ const SCENARIOS: &[Scenario] = &[
         start: Start::Ws("w"),
         cmd: &["remove", "w", "--force"],
         expect: Expect::Root,
-        status: Status::Works,
     },
     Scenario {
         name: "recover cds into the restored workspace",
@@ -243,7 +218,6 @@ const SCENARIOS: &[Scenario] = &[
         start: Start::Root,
         cmd: &["recover", "w"],
         expect: Expect::Ws("w"),
-        status: Status::Works,
     },
     Scenario {
         // `recover ls` is a subcommand, not a workspace name — it must not be
@@ -253,7 +227,6 @@ const SCENARIOS: &[Scenario] = &[
         start: Start::Root,
         cmd: &["recover", "ls"],
         expect: Expect::Unchanged,
-        status: Status::Works,
     },
 ];
 
@@ -448,7 +421,7 @@ fn shell_wrapper_cd_behavior_matches_across_shells() {
 
             let (actual, stderr) = run_in_shell(shell, &env, &start, sc.cmd);
             let actual = canon(&actual);
-            let (start, expected) = (canon(&start), canon(&expected));
+            let expected = canon(&expected);
             ran += 1;
 
             let ctx = format!(
@@ -459,24 +432,13 @@ fn shell_wrapper_cd_behavior_matches_across_shells() {
                 if stderr.is_empty() { "<none>" } else { &stderr },
             );
 
-            match sc.status {
-                Status::Works => assert_eq!(
-                    actual,
-                    expected,
-                    "{ctx}\n  expected cwd: {}\n  actual cwd:   {}",
-                    expected.display(),
-                    actual.display(),
-                ),
-                Status::StaysPut(why) => assert_eq!(
-                    actual,
-                    start,
-                    "{ctx}\n  Marked StaysPut ({why}), so the shell was expected to \
-                     remain at {}. If it is now at {}, the fix landed — promote this \
-                     row to Status::Works.",
-                    start.display(),
-                    expected.display(),
-                ),
-            }
+            assert_eq!(
+                actual,
+                expected,
+                "{ctx}\n  expected cwd: {}\n  actual cwd:   {}",
+                expected.display(),
+                actual.display(),
+            );
         }
     }
 


### PR DESCRIPTION
Fixes a shipped bug: `wsp new` does not reliably cd into the new workspace, and **the three dialects are wrong in different ways.**

## The bug

The wrapper re-derives the destination from argv. There are two strategies in the tree and both are broken:

| Invocation | posix / fish | powershell |
|---|---|---|
| `wsp new w --empty` | ✅ | ✅ |
| `wsp new --empty w` | ❌ cds to `<root>/--empty`, fails, stays put | ✅ |
| `wsp new -w src new-ws` | ❌ stays put | ❌ **cds into `src`** — the source workspace |
| `wsp new -b feat/x` | ❌ no positional to read | ❌ no positional to read |

posix and fish read `$1` positionally, so a leading flag is mistaken for the name. PowerShell scans for the first non-flag token, which is wrong in a worse way: `new` has five value-taking flags (`-b`, `-t`, `-w`, `-f`, `-d`), so it picks up a flag's *value* and silently moves you into a different, existing workspace.

Neither can be made correct. `new` can omit the name entirely and derive it from the branch given to `-b`, leaving nothing to read. Getting this right in shell means reimplementing clap's parser three times.

## The fix

`new` writes its resolved `ws_dir` to the path named by `WSP_CD_FILE`; the wrapper cds to whatever it finds there. `ws_dir` is computed after clap has parsed, so it already accounts for flag order, flag values, and names derived from `-b`.

This is #105's mechanism applied to **one command**. `cd`, `rm`, and `recover` are untouched — the goal is fixing a shipped bug in 0.19, not landing the refactor. It also serves as a low-risk trial of that mechanism with rc testers before the full change.

## Not a behavior change without the wrapper

`shellcd::request()` is a no-op when `WSP_CD_FILE` is unset, so piping, scripts, and unwrapped shells are unaffected. Verified by running the binary directly with the variable unset — output identical.

## Also fixed along the way

- **The PowerShell branch would have thrown on an empty cd file.** `Get-Content -Raw` returns `$null` there, and `$null.Trim()` is an error. Guarded with `IsNullOrWhiteSpace`.
- **`test_ps_new_skips_flag_args_when_cding` was vacuous.** It asserted on `$a.StartsWith('-')`, which still matches the `rm` branch's scan, so it kept passing after the `new` code it described was deleted. Replaced with assertions scoped to a single case body via a `case_body()` helper — that vacuity is the same failure mode that let the `create` alias regress in #103.

## Scope note

These bugs date to **v0.14.0**, so they are live in 0.18.0 today rather than being RC regressions.

Stacked on #108, which supplies the behavioral scenarios (`new with a leading flag cds`, `new does not cd to a flag value`) that prove this fix and fail without it.

Refs #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)