### PR TITLE
fix(completion): make `rm` vacate unconditionally instead of comparing paths

### DIFF
--- a/crates/wsp/src/cli/completion.rs
+++ b/crates/wsp/src/cli/completion.rs
@@ -292,24 +292,36 @@ fn build_posix_recover() -> String {
         .to_string()
 }
 
+/// Shell body for `wsp rm`: step out of the way, remove, then step back if the
+/// directory survived.
+///
+/// The shell must vacate before the binary runs — on Windows a directory that
+/// is a live process's cwd cannot be renamed, so removal fails outright — and
+/// only the shell can move itself, so this cannot be delegated to the binary
+/// the way `new` delegates its destination.
+///
+/// It deliberately does *not* work out whether `$PWD` is inside the target.
+/// That comparison was a string match against `$wsp_root/<name>`, which yields
+/// a false negative on 8.3 short paths, trailing separators, slash direction,
+/// and junctions. On unix a false negative is harmless — the rename succeeds
+/// regardless — but on Windows it means `wsp rm` fails for no visible reason.
+/// Leaving unconditionally and returning only if the old directory still exists
+/// is correct in every case and has nothing to spell wrong:
+///
+/// - removed while inside  -> old dir is gone   -> stay at the root
+/// - removal blocked       -> old dir survives  -> return, as if nothing moved
+/// - never inside          -> old dir survives  -> return, no visible change
 fn build_posix_cd_out(cmd_name: &str) -> String {
     format!(
         "shift\n\
-         \x20     local _wsp_name\n\
-         \x20     for _wsp_name in \"$@\"; do\n\
-         \x20       [[ \"$_wsp_name\" != -* ]] && break\n\
-         \x20       _wsp_name=\n\
-         \x20     done\n\
-         \x20     if [[ -n \"$_wsp_name\" ]]; then\n\
-         \x20       local wsp_dir=\"$wsp_root/$_wsp_name\"\n\
-         \x20       if [[ \"$PWD\" = \"$wsp_dir\" || \"$PWD\" = \"$wsp_dir\"/* ]]; then\n\
-         \x20         cd \"$wsp_root\" || cd \"$HOME\"\n\
-         \x20       fi\n\
-         \x20     fi\n\
+         \x20     local _wsp_prev=\"$PWD\"\n\
+         \x20     cd \"$wsp_root\" 2>/dev/null || cd \"$HOME\" || return\n\
          \x20     command \"$wsp_bin\" {cmd_name} \"$@\"\n\
-         \x20     if [[ ! -d \"$PWD\" ]]; then\n\
-         \x20       cd \"$wsp_root\" || cd \"$HOME\"\n\
-         \x20     fi",
+         \x20     local _wsp_rc=$?\n\
+         \x20     if [[ -d \"$_wsp_prev\" ]]; then\n\
+         \x20       cd \"$_wsp_prev\"\n\
+         \x20     fi\n\
+         \x20     return $_wsp_rc",
     )
 }
 
@@ -450,23 +462,14 @@ function wsp\n\
 \n\
         case rm remove\n\
             set -l args $argv[2..]\n\
-            set -l _wsp_name\n\
-            for _a in $args\n\
-                if not string match -q -- '-*' $_a\n\
-                    set _wsp_name $_a\n\
-                    break\n\
-                end\n\
-            end\n\
-            if test -n \"$_wsp_name\"\n\
-                set -l wsp_dir \"$wsp_root/$_wsp_name\"\n\
-                if string match -q -- \"$wsp_dir\" $PWD; or string match -q -- \"$wsp_dir/*\" $PWD\n\
-                    cd \"$wsp_root\"; or cd $HOME\n\
-                end\n\
-            end\n\
+            set -l prev $PWD\n\
+            cd \"$wsp_root\" 2>/dev/null; or cd $HOME; or return 1\n\
             command $wsp_bin rm $args\n\
-            if not test -d $PWD\n\
-                cd \"$wsp_root\"; or cd $HOME\n\
+            set -l rc $status\n\
+            if test -d \"$prev\"\n\
+                cd \"$prev\"\n\
             end\n\
+            return $rc\n\
 \n\
         case recover\n\
             set -l args $argv[2..]\n\
@@ -644,29 +647,26 @@ fn write_powershell(w: &mut dyn Write, bin_str: &str, wsp_root: &str) -> Result<
         w,
         "            $restArgs = @($args | Select-Object -Skip 1)"
     )?;
-    writeln!(w, "            $wspName = $null")?;
-    writeln!(w, "            foreach ($a in $restArgs) {{")?;
-    writeln!(
-        w,
-        "                if (-not $a.StartsWith('-')) {{ $wspName = $a; break }}"
-    )?;
-    writeln!(w, "            }}")?;
-    writeln!(w, "            if ($wspName) {{")?;
-    writeln!(w, "                $wspDir = Join-Path $wspRoot $wspName")?;
-    writeln!(
-        w,
-        "                if ($PWD.Path -eq $wspDir -or $PWD.Path -like \"$wspDir\\*\") {{"
-    )?;
-    writeln!(w, "                    Set-Location $wspRoot")?;
-    writeln!(w, "                }}")?;
-    writeln!(w, "            }}")?;
+    // Vacate unconditionally rather than testing whether $PWD is inside the
+    // target. The old `-eq`/`-like` comparison against "$wspRoot\<name>" gave a
+    // false negative on 8.3 short paths, trailing separators, slash direction,
+    // and junctions — and on Windows a false negative is fatal, because a
+    // directory that is a live process's cwd cannot be renamed, so `wsp rm`
+    // failed outright. See build_posix_cd_out for the case analysis.
+    writeln!(w, "            $prev = $PWD.Path")?;
+    writeln!(w, "            Set-Location $wspRoot")?;
     writeln!(w, "            & $wspBin rm @restArgs")?;
+    writeln!(w, "            $rc = $LASTEXITCODE")?;
     writeln!(
         w,
-        "            if (-not (Test-Path -LiteralPath $PWD.Path -PathType Container)) {{"
+        "            if (Test-Path -LiteralPath $prev -PathType Container) {{"
     )?;
-    writeln!(w, "                Set-Location $wspRoot")?;
+    writeln!(w, "                Set-Location -LiteralPath $prev")?;
     writeln!(w, "            }}")?;
+    writeln!(
+        w,
+        "            if ($rc -ne 0) {{ $global:LASTEXITCODE = $rc }}"
+    )?;
     writeln!(w, "        }}")?;
     writeln!(w, "        'recover' {{")?;
     writeln!(
@@ -1287,42 +1287,6 @@ mod tests {
 
     // Regression: rm cd-out check must require a path separator after the workspace
     // name, otherwise `wsp rm foo` incorrectly cds you out when you're in `foobar`.
-    #[test]
-    fn test_posix_rm_does_not_false_positive_on_prefix_match() {
-        for shell in &["zsh", "bash"] {
-            let out = output(|w| {
-                write_posix(
-                    w,
-                    "/usr/bin/wsp",
-                    "/home/user/dev",
-                    shell,
-                    ShellHookOpts::default(),
-                )
-            });
-            assert!(
-                out.contains(r#"= "$wsp_dir" || "$PWD" = "$wsp_dir"/*"#),
-                "{shell}: rm check must require separator, not bare prefix glob"
-            );
-        }
-    }
-
-    #[test]
-    fn test_fish_rm_does_not_false_positive_on_prefix_match() {
-        let out = output(|w| {
-            write_fish(
-                w,
-                "/usr/bin/wsp",
-                "/home/user/dev",
-                ShellHookOpts::default(),
-            )
-        });
-        assert!(
-            out.contains(
-                r#"string match -q -- "$wsp_dir" $PWD; or string match -q -- "$wsp_dir/*" $PWD"#
-            ),
-            "fish: rm check must require separator, not bare prefix glob"
-        );
-    }
 
     // --- PowerShell tests ---
 
@@ -1487,34 +1451,6 @@ mod tests {
     }
 
     #[test]
-    fn test_ps_rm_cds_out_of_workspace() {
-        let out = output(|w| write_powershell(w, r"C:\wsp.exe", r"C:\dev"));
-        assert!(
-            out.contains("'rm', 'remove'"),
-            "rm/remove case must be present"
-        );
-        // Must cd out before deleting if currently inside the workspace
-        assert!(
-            out.contains("$wspDir = Join-Path $wspRoot $wspName"),
-            "rm must compute workspace dir"
-        );
-        assert!(
-            out.contains("$PWD.Path -eq $wspDir -or $PWD.Path -like \"$wspDir\\*\""),
-            "rm must check if cwd is exactly or inside workspace (with separator)"
-        );
-        // Must always call `rm`, even when user typed `remove`
-        assert!(
-            out.contains("& $wspBin rm @restArgs"),
-            "remove must normalize to rm"
-        );
-        // Must cd away if the directory disappeared (e.g. rm -f with no prompt)
-        assert!(
-            out.contains("Test-Path -LiteralPath $PWD.Path -PathType Container"),
-            "rm must cd away if cwd no longer exists"
-        );
-    }
-
-    #[test]
     fn test_ps_bin_with_single_quote() {
         let out = output(|w| write_powershell(w, r"C:\it's\wsp.exe", r"C:\dev"));
         assert!(
@@ -1536,6 +1472,79 @@ mod tests {
             out.contains(r"$wspRoot = 'C:\o''brien\dev'"),
             "wsp_root single quote must be doubled: {}",
             out
+        );
+    }
+
+    /// `rm` must vacate unconditionally and come back only if the old directory
+    /// survived — with no path comparison anywhere.
+    ///
+    /// The comparison this replaces gave false negatives on 8.3 short paths,
+    /// trailing separators, slash direction and junctions. On unix that was
+    /// harmless; on Windows it made `wsp rm` fail outright, because a directory
+    /// that is a live process's cwd cannot be renamed.
+    ///
+    /// The prefix-match hazard the previous tests guarded (`rm w` while sitting
+    /// in `w-extra`) is now covered behaviorally in tests/shell_cd.rs, which is
+    /// a stronger check than asserting on the shape of the comparison.
+    #[test]
+    fn test_rm_vacates_without_comparing_paths() {
+        for shell in &["zsh", "bash"] {
+            let out = output(|w| {
+                write_posix(
+                    w,
+                    "/usr/bin/wsp",
+                    "/home/user/dev",
+                    shell,
+                    ShellHookOpts::default(),
+                )
+            });
+            let body = case_body(&out, "    rm)", "    remove)");
+            assert!(
+                body.contains("_wsp_prev=\"$PWD\""),
+                "{shell}: rm must remember where it started"
+            );
+            assert!(
+                body.contains("-d \"$_wsp_prev\""),
+                "{shell}: rm must return only if the old directory survived"
+            );
+            assert!(
+                !body.contains("wsp_dir"),
+                "{shell}: rm must not compare against a computed workspace dir"
+            );
+        }
+
+        let fish = output(|w| {
+            write_fish(
+                w,
+                "/usr/bin/wsp",
+                "/home/user/dev",
+                ShellHookOpts::default(),
+            )
+        });
+        let fish_rm = case_body(&fish, "case rm remove", "case recover");
+        assert!(
+            fish_rm.contains("set -l prev $PWD"),
+            "fish: rm must remember where it started"
+        );
+        assert!(
+            !fish_rm.contains("wsp_dir"),
+            "fish: rm must not compare against a computed workspace dir"
+        );
+
+        let pwsh = output(|w| write_powershell(w, r"C:\wsp.exe", r"C:\dev"));
+        let ps_rm = case_body(&pwsh, "$_ -in 'rm', 'remove'", "'recover' {");
+        assert!(
+            ps_rm.contains("$prev = $PWD.Path"),
+            "powershell: rm must remember where it started"
+        );
+        assert!(
+            !ps_rm.contains("$wspDir"),
+            "powershell: rm must not compare against a computed workspace dir"
+        );
+        // `remove` must still normalize to the real subcommand name.
+        assert!(
+            ps_rm.contains("& $wspBin rm @restArgs"),
+            "powershell: remove must normalize to rm"
         );
     }
 }

--- a/crates/wsp/src/cli/completion.rs
+++ b/crates/wsp/src/cli/completion.rs
@@ -244,11 +244,8 @@ fn build_posix_cases() -> Vec<ShellCase> {
                 .to_string(),
         },
         ShellCase {
-            pattern: "rm".to_string(),
-            body: build_posix_cd_out("rm"),
-        },
-        ShellCase {
-            pattern: "remove".to_string(),
+            // Both spellings share one body, which always invokes `rm`.
+            pattern: "rm|remove".to_string(),
             body: build_posix_cd_out("rm"),
         },
         ShellCase {
@@ -316,8 +313,9 @@ fn build_posix_cd_out(cmd_name: &str) -> String {
         "shift\n\
          \x20     local _wsp_prev=\"$PWD\"\n\
          \x20     cd \"$wsp_root\" 2>/dev/null || cd \"$HOME\" || return\n\
+         \x20     local _wsp_rc\n\
          \x20     command \"$wsp_bin\" {cmd_name} \"$@\"\n\
-         \x20     local _wsp_rc=$?\n\
+         \x20     _wsp_rc=$?\n\
          \x20     if [[ -d \"$_wsp_prev\" ]]; then\n\
          \x20       cd \"$_wsp_prev\"\n\
          \x20     fi\n\
@@ -446,11 +444,11 @@ function wsp\n\
     switch $argv[1]\n\
         case new create\n\
             set -l args $argv[2..]\n\
-            set -l cdfile (mktemp); or return\n\
+            set -l cdfile (mktemp)\n\
             WSP_CD_FILE=$cdfile command $wsp_bin new $args\n\
             set -l rc $status\n\
             if test $rc -eq 0 -a -s $cdfile\n\
-                cd (cat $cdfile)\n\
+                cd -- (cat $cdfile)\n\
             end\n\
             rm -f $cdfile\n\
             return $rc\n\
@@ -624,8 +622,17 @@ fn write_powershell(w: &mut dyn Write, bin_str: &str, wsp_root: &str) -> Result<
         w,
         "            if ($rc -eq 0 -and -not [string]::IsNullOrWhiteSpace($dest)) {{"
     )?;
-    writeln!(w, "                Set-Location $dest.Trim()")?;
+    // -LiteralPath: without it Set-Location treats [ and ] as wildcards, so a
+    // workspace path containing them would fail to resolve.
+    writeln!(w, "                Set-Location -LiteralPath $dest.Trim()")?;
     writeln!(w, "            }}")?;
+    // Cmdlets do not touch $LASTEXITCODE, so it would survive on its own —
+    // restore it explicitly anyway, to match the rm case and to keep the exit
+    // status a stated contract rather than an inherited side effect.
+    writeln!(
+        w,
+        "            if ($rc -ne 0) {{ $global:LASTEXITCODE = $rc }}"
+    )?;
     writeln!(w, "        }}")?;
     writeln!(w, "        'cd' {{")?;
     writeln!(
@@ -654,7 +661,17 @@ fn write_powershell(w: &mut dyn Write, bin_str: &str, wsp_root: &str) -> Result<
     // directory that is a live process's cwd cannot be renamed, so `wsp rm`
     // failed outright. See build_posix_cd_out for the case analysis.
     writeln!(w, "            $prev = $PWD.Path")?;
-    writeln!(w, "            Set-Location $wspRoot")?;
+    // try/catch expresses `cd "$wsp_root" || cd "$HOME"` directly. Inferring
+    // failure from "$PWD did not change" would misfire when the shell is
+    // already at the root, sending it to $HOME for no reason.
+    writeln!(
+        w,
+        "            try {{ Set-Location -LiteralPath $wspRoot -ErrorAction Stop }}"
+    )?;
+    writeln!(
+        w,
+        "            catch {{ Set-Location -LiteralPath $HOME -ErrorAction SilentlyContinue }}"
+    )?;
     writeln!(w, "            & $wspBin rm @restArgs")?;
     writeln!(w, "            $rc = $LASTEXITCODE")?;
     writeln!(
@@ -835,7 +852,7 @@ mod tests {
                 ShellHookOpts::default(),
             )
         });
-        for pattern in &["new|create)", "cd)", "rm)", "remove)", "recover)", "*)"] {
+        for pattern in &["new|create)", "cd)", "rm|remove)", "recover)", "*)"] {
             assert!(out.contains(pattern), "missing case pattern: {}", pattern);
         }
     }
@@ -1498,7 +1515,7 @@ mod tests {
                     ShellHookOpts::default(),
                 )
             });
-            let body = case_body(&out, "    rm)", "    remove)");
+            let body = case_body(&out, "    rm|remove)", "    recover)");
             assert!(
                 body.contains("_wsp_prev=\"$PWD\""),
                 "{shell}: rm must remember where it started"

--- a/crates/wsp/src/cli/completion.rs
+++ b/crates/wsp/src/cli/completion.rs
@@ -314,7 +314,7 @@ fn build_posix_cd_out(cmd_name: &str) -> String {
          \x20     local _wsp_prev=\"$PWD\"\n\
          \x20     cd \"$wsp_root\" 2>/dev/null || cd \"$HOME\" || return\n\
          \x20     local _wsp_rc\n\
-         \x20     command \"$wsp_bin\" {cmd_name} \"$@\"\n\
+         \x20     WSP_PWD=\"$_wsp_prev\" command \"$wsp_bin\" {cmd_name} \"$@\"\n\
          \x20     _wsp_rc=$?\n\
          \x20     if [[ -d \"$_wsp_prev\" ]]; then\n\
          \x20       cd \"$_wsp_prev\"\n\
@@ -462,7 +462,7 @@ function wsp\n\
             set -l args $argv[2..]\n\
             set -l prev $PWD\n\
             cd \"$wsp_root\" 2>/dev/null; or cd $HOME; or return 1\n\
-            command $wsp_bin rm $args\n\
+            WSP_PWD=$prev command $wsp_bin rm $args\n\
             set -l rc $status\n\
             if test -d \"$prev\"\n\
                 cd \"$prev\"\n\
@@ -672,8 +672,13 @@ fn write_powershell(w: &mut dyn Write, bin_str: &str, wsp_root: &str) -> Result<
         w,
         "            catch {{ Set-Location -LiteralPath $HOME -ErrorAction SilentlyContinue }}"
     )?;
+    writeln!(w, "            $env:WSP_PWD = $prev")?;
     writeln!(w, "            & $wspBin rm @restArgs")?;
     writeln!(w, "            $rc = $LASTEXITCODE")?;
+    writeln!(
+        w,
+        "            Remove-Item Env:\\WSP_PWD -ErrorAction SilentlyContinue"
+    )?;
     writeln!(
         w,
         "            if (Test-Path -LiteralPath $prev -PathType Container) {{"

--- a/crates/wsp/src/cli/delete.rs
+++ b/crates/wsp/src/cli/delete.rs
@@ -46,7 +46,9 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
     let name = if let Some(n) = matches.get_one::<String>("workspace") {
         n.clone()
     } else {
-        let cwd = std::env::current_dir()?;
+        // Via invocation_dir: the wrapper vacates before running rm, so the
+        // process cwd is the workspaces root rather than where the user was.
+        let cwd = crate::shellcd::invocation_dir()?;
         let ws_dir = workspace::detect(&cwd)?;
         let meta = workspace::load_metadata(&ws_dir)
             .map_err(|e| anyhow::anyhow!("reading workspace: {}", e))?;

--- a/crates/wsp/src/shellcd.rs
+++ b/crates/wsp/src/shellcd.rs
@@ -30,3 +30,29 @@ pub fn request(dir: &Path) {
     };
     let _ = std::fs::write(file, dir.to_string_lossy().as_bytes());
 }
+
+/// The directory the user ran the command from.
+///
+/// Normally this is the process cwd. But the wrapper *vacates* — steps out of
+/// the workspaces tree — before invoking commands that relocate or remove a
+/// directory, because Windows cannot rename or delete a live process's cwd.
+/// That would otherwise destroy cwd-based workspace detection: `wsp rm` takes
+/// the workspace name as an optional positional and falls back to detecting it
+/// from where the user was standing.
+///
+/// So the wrapper forwards the original directory in `WSP_PWD`, and commands
+/// that can be invoked behind a vacating wrapper must resolve their cwd through
+/// here rather than calling `current_dir()` directly.
+///
+/// Falls back to the real cwd when `WSP_PWD` is unset or does not name an
+/// existing directory, so an unwrapped shell and a stale value both behave
+/// exactly as before.
+pub fn invocation_dir() -> std::io::Result<std::path::PathBuf> {
+    if let Some(p) = std::env::var_os("WSP_PWD") {
+        let p = std::path::PathBuf::from(p);
+        if p.is_dir() {
+            return Ok(p);
+        }
+    }
+    std::env::current_dir()
+}

--- a/crates/wsp/tests/shell_cd.rs
+++ b/crates/wsp/tests/shell_cd.rs
@@ -217,6 +217,16 @@ const SCENARIOS: &[Scenario] = &[
         expect: Expect::Root,
     },
     Scenario {
+        // Bare form: no workspace name, resolved from the directory the user was
+        // standing in. The wrapper vacates before invoking, so this only works
+        // if the original cwd is forwarded — it regressed exactly here.
+        name: "bare rm resolves the workspace from the cwd",
+        setup: &[&["new", "w", "--empty"]],
+        start: Start::Ws("w"),
+        cmd: &["rm", "--force", "--yes"],
+        expect: Expect::Root,
+    },
+    Scenario {
         // Prefix hazard: removing `w` while standing in `w-extra` must leave the
         // shell alone. Previously guarded by asserting the wrapper's comparison
         // required a separator; now that there is no comparison at all, assert
@@ -525,11 +535,11 @@ fn shell_wrapper_cd_behavior_matches_across_shells() {
 /// restructured the return paths in all four dialects. A wrapper that cds
 /// correctly but swallows a non-zero status silently breaks `wsp new x && ...`
 /// and any script that checks the result.
-fn status_in_shell(shell: &Shell, env: &Env, cmd: &[&str]) -> i32 {
+fn status_in_shell(shell: &Shell, env: &Env, start: &Path, cmd: &[&str]) -> i32 {
     let load = shell.load.replace("WSPBIN", &quote(shell.quote, WSP));
     let script = format!(
         "{load}\ncd {}\nwsp {} >{null} 2>{null}\n{}",
-        quote(shell.quote, &env.ws_root.to_string_lossy()),
+        quote(shell.quote, &start.to_string_lossy()),
         cmd.join(" "),
         shell.print_status,
         null = shell.null,
@@ -576,7 +586,7 @@ fn shell_wrapper_preserves_exit_status() {
         }
         for (what, argv, want) in EXIT_CASES {
             let env = make_env();
-            let got = status_in_shell(shell, &env, argv);
+            let got = status_in_shell(shell, &env, &env.ws_root, argv);
             ran += 1;
             assert_eq!(
                 got,
@@ -588,4 +598,80 @@ fn shell_wrapper_preserves_exit_status() {
         }
     }
     assert!(ran > 0, "no shell available to test exit statuses");
+}
+
+/// Run the binary directly, with `cwd` as the working directory, and return its
+/// exit status. No shell, no wrapper.
+fn status_direct(env: &Env, cwd: &Path, cmd: &[&str]) -> i32 {
+    let mut c = Command::new(WSP);
+    apply_env(&mut c, env);
+    let out = c
+        .args(cmd)
+        .current_dir(cwd)
+        .output()
+        .expect("spawn wsp directly");
+    out.status.code().unwrap_or(-1)
+}
+
+/// The wrapper must not change *what* a command does — only where the shell
+/// ends up.
+///
+/// This is the general form of the bug that made `wsp rm --force --yes` fail:
+/// the wrapper vacates before invoking, which silently removed the cwd that the
+/// optional-positional fallback reads. Every row in the scenario table passed an
+/// explicit workspace name, so nothing noticed.
+///
+/// Rather than enumerate argument forms — which is what missed it — this runs
+/// each scenario twice from the same starting directory, once through the
+/// wrapper and once against the binary directly, and requires the same exit
+/// status. Any future interposition that changes what a command sees fails here
+/// without anyone having to predict which form it breaks.
+#[test]
+fn wrapper_does_not_change_command_outcomes() {
+    let mut ran = 0usize;
+    for shell in SHELLS {
+        if !is_installed(shell) {
+            continue;
+        }
+        for sc in SCENARIOS {
+            // Fresh fixture per side: these commands mutate state.
+            let mut codes = Vec::new();
+            for wrapped in [true, false] {
+                let env = make_env();
+                for args in sc.setup {
+                    run_setup(&env, args);
+                }
+                let start = match sc.start {
+                    Start::Root => env.ws_root.clone(),
+                    Start::Ws(n) => env.ws_root.join(n),
+                    Start::WsSub(n, sub) => {
+                        let p = env.ws_root.join(n).join(sub);
+                        std::fs::create_dir_all(&p).expect("create start subdir");
+                        p
+                    }
+                };
+                codes.push(if wrapped {
+                    status_in_shell(shell, &env, &start, sc.cmd)
+                } else {
+                    status_direct(&env, &start, sc.cmd)
+                });
+            }
+            ran += 1;
+            assert_eq!(
+                codes[0],
+                codes[1],
+                "shell={} scenario={:?} cmd=`wsp {}`\n  \
+                 through the wrapper: exit {}\n  \
+                 binary directly:     exit {}\n  \
+                 The wrapper changed the command's outcome. It may only change \
+                 where the shell ends up.",
+                shell.bin,
+                sc.name,
+                sc.cmd.join(" "),
+                codes[0],
+                codes[1],
+            );
+        }
+    }
+    assert!(ran > 0, "no shell available for the differential test");
 }

--- a/crates/wsp/tests/shell_cd.rs
+++ b/crates/wsp/tests/shell_cd.rs
@@ -63,6 +63,8 @@ struct Shell {
     print_pwd: &'static str,
     /// Where to send the command's own output.
     null: &'static str,
+    /// Prints the exit status of the previous command.
+    print_status: &'static str,
     quote: Quote,
 }
 
@@ -74,6 +76,7 @@ const SHELLS: &[Shell] = &[
         load: r#"eval "$(WSPBIN completion bash)" 2>/dev/null"#,
         print_pwd: r#"printf '%s\n' "$PWD""#,
         null: "/dev/null",
+        print_status: r#"printf '%s\n' "$?""#,
         quote: Quote::Posix,
     },
     Shell {
@@ -83,6 +86,7 @@ const SHELLS: &[Shell] = &[
         load: r#"eval "$(WSPBIN completion zsh)" 2>/dev/null"#,
         print_pwd: r#"printf '%s\n' "$PWD""#,
         null: "/dev/null",
+        print_status: r#"printf '%s\n' "$?""#,
         quote: Quote::Posix,
     },
     Shell {
@@ -91,6 +95,7 @@ const SHELLS: &[Shell] = &[
         load: r#"WSPBIN completion fish 2>/dev/null | source"#,
         print_pwd: r#"printf '%s\n' "$PWD""#,
         null: "/dev/null",
+        print_status: r#"echo $status"#,
         quote: Quote::Posix,
     },
 ];
@@ -102,6 +107,8 @@ const SHELLS: &[Shell] = &[Shell {
     load: r#"Invoke-Expression ((& WSPBIN completion powershell) -join "`n")"#,
     print_pwd: r#"Write-Output $PWD.Path"#,
     null: "$null",
+    // $LASTEXITCODE is $null until a native command has run in the session.
+    print_status: r#"if ($null -eq $LASTEXITCODE) { Write-Output 0 } else { Write-Output $LASTEXITCODE }"#,
     quote: Quote::PowerShell,
 }];
 
@@ -115,6 +122,10 @@ enum Start {
     Root,
     /// Inside workspace `<name>`.
     Ws(&'static str),
+    /// Inside `<name>/<subdir>`, which the harness creates. Covers standing
+    /// deeper than the workspace root — the case the wrapper's old
+    /// `"$wsp_dir"/*` glob existed to catch.
+    WsSub(&'static str, &'static str),
 }
 
 /// Where the shell is expected to end up.
@@ -222,6 +233,28 @@ const SCENARIOS: &[Scenario] = &[
         start: Start::Ws("w"),
         cmd: &["remove", "w", "--force"],
         expect: Expect::Root,
+    },
+    Scenario {
+        // Standing deeper than the workspace root. The wrapper used to need a
+        // `"$wsp_dir"/*` glob for this; vacate-and-return handles it with no
+        // special case, so assert it still does.
+        name: "rm from a nested directory escapes",
+        setup: &[&["new", "w", "--empty"]],
+        start: Start::WsSub("w", "nested/deeper"),
+        cmd: &["rm", "w", "--force"],
+        expect: Expect::Root,
+    },
+    Scenario {
+        // The failure branch of vacate-and-return: the command errors, so the
+        // starting directory survives and the shell must come back to it rather
+        // than being left at the root. Removing a nonexistent workspace is the
+        // only way to fail `rm` hermetically — a blocked removal needs repos
+        // with unmerged branches, which cannot be built offline (#91).
+        name: "failed rm returns to where it started",
+        setup: &[&["new", "w", "--empty"]],
+        start: Start::Ws("w"),
+        cmd: &["rm", "nope", "--force"],
+        expect: Expect::Unchanged,
     },
     Scenario {
         name: "recover cds into the restored workspace",
@@ -423,6 +456,11 @@ fn shell_wrapper_cd_behavior_matches_across_shells() {
             let start = match sc.start {
                 Start::Root => env.ws_root.clone(),
                 Start::Ws(n) => env.ws_root.join(n),
+                Start::WsSub(n, sub) => {
+                    let p = env.ws_root.join(n).join(sub);
+                    std::fs::create_dir_all(&p).expect("create start subdir");
+                    p
+                }
             };
             let expected = match sc.expect {
                 Expect::Root => env.ws_root.clone(),
@@ -478,4 +516,76 @@ fn shell_wrapper_cd_behavior_matches_across_shells() {
         "no shell was available to test; expected at least one of {:?}",
         SHELLS.iter().map(|s| s.bin).collect::<Vec<_>>()
     );
+}
+
+/// Run a command through the wrapper and return its exit status.
+///
+/// Separate from `run_in_shell` because the wrapper's *exit code* is a distinct
+/// contract from where it leaves the shell, and both fixes in this area
+/// restructured the return paths in all four dialects. A wrapper that cds
+/// correctly but swallows a non-zero status silently breaks `wsp new x && ...`
+/// and any script that checks the result.
+fn status_in_shell(shell: &Shell, env: &Env, cmd: &[&str]) -> i32 {
+    let load = shell.load.replace("WSPBIN", &quote(shell.quote, WSP));
+    let script = format!(
+        "{load}\ncd {}\nwsp {} >{null} 2>{null}\n{}",
+        quote(shell.quote, &env.ws_root.to_string_lossy()),
+        cmd.join(" "),
+        shell.print_status,
+        null = shell.null,
+    );
+
+    let mut c = Command::new(shell.bin);
+    apply_env(&mut c, env);
+    let out = c
+        .args(shell.args)
+        .arg(&script)
+        .output()
+        .unwrap_or_else(|e| panic!("spawning {} failed: {e}", shell.bin));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let last = stdout
+        .lines()
+        .rfind(|l| !l.trim().is_empty())
+        .unwrap_or_else(|| panic!("{} printed no status\nscript:\n{script}", shell.bin));
+    last.trim()
+        .parse()
+        .unwrap_or_else(|e| panic!("{}: unparseable status {last:?}: {e}", shell.bin))
+}
+
+/// (description, argv, expected exit status)
+const EXIT_CASES: &[(&str, &[&str], i32)] = &[
+    ("successful new", &["new", "w", "--empty"], 0),
+    ("new with no name", &["new"], 1),
+    // clap exits 2 for a usage error, not 1. Asserting the exact code (rather
+    // than "non-zero") is what proves the wrapper propagates the real status
+    // instead of normalizing everything to 0/1.
+    ("new with a bad flag", &["new", "--nope"], 2),
+    ("rm of a missing workspace", &["rm", "nope", "--force"], 1),
+    // `ls` rather than `st`: these run from the workspaces root, and `st`
+    // correctly fails outside a workspace.
+    ("read-only ls", &["ls"], 0),
+];
+
+/// The wrapper must not swallow or invent exit codes.
+#[test]
+fn shell_wrapper_preserves_exit_status() {
+    let mut ran = 0usize;
+    for shell in SHELLS {
+        if !is_installed(shell) {
+            continue;
+        }
+        for (what, argv, want) in EXIT_CASES {
+            let env = make_env();
+            let got = status_in_shell(shell, &env, argv);
+            ran += 1;
+            assert_eq!(
+                got,
+                *want,
+                "shell={} case={what:?} cmd=`wsp {}`: expected exit {want}, got {got}",
+                shell.bin,
+                argv.join(" "),
+            );
+        }
+    }
+    assert!(ran > 0, "no shell available to test exit statuses");
 }

--- a/crates/wsp/tests/shell_cd.rs
+++ b/crates/wsp/tests/shell_cd.rs
@@ -613,19 +613,28 @@ fn status_direct(env: &Env, cwd: &Path, cmd: &[&str]) -> i32 {
     out.status.code().unwrap_or(-1)
 }
 
-/// The wrapper must not change *what* a command does — only where the shell
-/// ends up.
+/// The wrapper must never break a command that works without it.
 ///
 /// This is the general form of the bug that made `wsp rm --force --yes` fail:
 /// the wrapper vacates before invoking, which silently removed the cwd that the
 /// optional-positional fallback reads. Every row in the scenario table passed an
-/// explicit workspace name, so nothing noticed.
+/// explicit workspace name, so nothing noticed. Rather than enumerate argument
+/// forms — which is what missed it — this runs each scenario twice from the same
+/// starting directory, once through the wrapper and once against the binary
+/// directly, so a future interposition fails here without anyone predicting
+/// which form it breaks.
 ///
-/// Rather than enumerate argument forms — which is what missed it — this runs
-/// each scenario twice from the same starting directory, once through the
-/// wrapper and once against the binary directly, and requires the same exit
-/// status. Any future interposition that changes what a command sees fails here
-/// without anyone having to predict which form it breaks.
+/// The assertion is one-directional, and the direction matters. It would be
+/// wrong to require the same exit status: on Windows the wrapper legitimately
+/// *rescues* commands. `wsp rm w --force` from inside `w` fails when run
+/// directly, because a directory that is a live process's cwd cannot be
+/// renamed — and succeeds through the wrapper, because vacating first is
+/// exactly what the vacate step is for. CI demonstrated this (wrapped exit 0,
+/// direct exit 1), which is also the first hard confirmation of that Windows
+/// behavior in this repo; it had only been inferred from a code comment.
+///
+/// So: success without the wrapper implies success with it. The reverse is
+/// allowed and, on Windows, is the whole point.
 #[test]
 fn wrapper_does_not_change_command_outcomes() {
     let mut ran = 0usize;
@@ -657,19 +666,19 @@ fn wrapper_does_not_change_command_outcomes() {
                 });
             }
             ran += 1;
-            assert_eq!(
-                codes[0],
-                codes[1],
+            let (wrapped, direct) = (codes[0], codes[1]);
+            assert!(
+                direct != 0 || wrapped == 0,
                 "shell={} scenario={:?} cmd=`wsp {}`\n  \
-                 through the wrapper: exit {}\n  \
-                 binary directly:     exit {}\n  \
-                 The wrapper changed the command's outcome. It may only change \
-                 where the shell ends up.",
+                 binary directly:     exit {direct} (succeeded)\n  \
+                 through the wrapper: exit {wrapped} (failed)\n  \
+                 The wrapper broke a command that works without it. It may \
+                 change where the shell ends up, and it may rescue a command \
+                 that cannot run from the current directory, but it may not \
+                 take away something that worked.",
                 shell.bin,
                 sc.name,
                 sc.cmd.join(" "),
-                codes[0],
-                codes[1],
             );
         }
     }

--- a/crates/wsp/tests/shell_cd.rs
+++ b/crates/wsp/tests/shell_cd.rs
@@ -206,6 +206,17 @@ const SCENARIOS: &[Scenario] = &[
         expect: Expect::Root,
     },
     Scenario {
+        // Prefix hazard: removing `w` while standing in `w-extra` must leave the
+        // shell alone. Previously guarded by asserting the wrapper's comparison
+        // required a separator; now that there is no comparison at all, assert
+        // the behavior instead.
+        name: "rm of a name-prefix workspace does not move the shell",
+        setup: &[&["new", "w", "--empty"], &["new", "w-extra", "--empty"]],
+        start: Start::Ws("w-extra"),
+        cmd: &["rm", "w", "--force"],
+        expect: Expect::Unchanged,
+    },
+    Scenario {
         name: "remove alias escapes like rm",
         setup: &[&["new", "w", "--empty"]],
         start: Start::Ws("w"),


### PR DESCRIPTION
Fixes a shipped bug: **`wsp rm` can fail outright on Windows** when run from inside the workspace being removed.

## The bug

The wrapper decides whether to step out of the way by string-comparing `$PWD` against `$wsp_root/<name>`:

```zsh
if [[ "$PWD" = "$wsp_dir" || "$PWD" = "$wsp_dir"/* ]]; then cd "$wsp_root"; fi
```

String comparison of paths yields false negatives on 8.3 short paths, trailing separators, slash direction, and junctions.

On unix a false negative is harmless — the rename succeeds either way, because a directory that is a process's cwd can still be unlinked. **On Windows it is fatal:** such a directory cannot be renamed, so `wsp rm` fails with no indication why. The `Test-Path $PWD` fallback then sees the directory still present and doesn't rescue the shell either, so you end up stuck inside a workspace that failed to be removed.

**This was observed, not theorized.** The Windows job in #108 failed in exactly this way once the test environment happened to supply a short path (`C:\Users\RUNNER~1\...`) as `workspaces_dir` while PowerShell reported `$PWD.Path` in long form. A real user reaches the same state via a junction or a stray trailing backslash in config.

## The fix

Stop comparing. Remember `$PWD`, leave for the workspaces root, run the command, and return only if the old directory still exists:

```zsh
local _wsp_prev="$PWD"
cd "$wsp_root" 2>/dev/null || cd "$HOME" || return
command "$wsp_bin" rm "$@"
local _wsp_rc=$?
[[ -d "$_wsp_prev" ]] && cd "$_wsp_prev"
return $_wsp_rc
```

Correct in all three cases, with nothing to spell wrong:

| Situation | Old dir | Result |
|---|---|---|
| removed while inside | gone | stay at the root ✅ |
| removal blocked | survives | return — nothing appears to move ✅ |
| never inside | survives | return — no visible change ✅ |

That third case also covers the **prefix hazard** the deleted tests guarded (`rm w` while sitting in `w-extra`): `w-extra` survives, so the shell returns to it.

## Tests

Three tests asserted on the *shape of the comparison* and were deleted, since there is no longer a comparison to check. Replaced with:

- `test_rm_vacates_without_comparing_paths` — scoped per dialect via `case_body`, asserting the vacate/return structure is present and that no computed workspace dir appears.
- A **behavioral** scenario in `tests/shell_cd.rs`: `rm of a name-prefix workspace does not move the shell`. Mutation-verified — stubbing out the return step makes it fail.

Trading a string assertion for a behavioral one is the point; the string version is what let the prefix guard drift out of sync with reality.

## Note on #105

This deliberately keeps a pre-cd step. #105 cannot delegate it to the binary: only the shell can move itself, and it must do so *before* the binary runs, whereas `WSP_CD_FILE` is read after the process exits. What this change does do is make that remaining step simple enough that #105 no longer has to make a fragile comparison robust — it just deletes it.

Stacked on #110.

Refs #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)