### PR TITLE
fix(st): announce the PR fetch before waiting on it

### DIFF
--- a/crates/wsp/src/cli/delete.rs
+++ b/crates/wsp/src/cli/delete.rs
@@ -138,6 +138,14 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
                             }
                             inputs.push((id.clone(), meta.branch.clone()));
                         }
+                        // Same reasoning as `wsp st`: announce the network wait
+                        // before taking it. Counted in repos, not `inputs`,
+                        // which holds up to two branch queries per repo.
+                        eprintln!(
+                            "Fetching pull requests for {} repo{}...",
+                            meta.repos.len(),
+                            if meta.repos.len() == 1 { "" } else { "s" }
+                        );
                         let pr_results = crate::pr::fetch_parallel(&inputs);
                         let mut seen = std::collections::HashSet::new();
                         pr_results

--- a/crates/wsp/src/cli/status.rs
+++ b/crates/wsp/src/cli/status.rs
@@ -145,6 +145,15 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
             .iter()
             .map(|r| (r.identity.clone(), meta.branch.clone()))
             .collect();
+        // Say what we are waiting on before waiting on it — this is N GitHub
+        // API calls and the only thing the user sees otherwise is a stalled
+        // terminal. Stderr, so `--json` output stays clean. See the Speed
+        // tenets in docs/design-tenets.md.
+        eprintln!(
+            "Fetching pull requests for {} repo{}...",
+            inputs.len(),
+            if inputs.len() == 1 { "" } else { "s" }
+        );
         let pr_results = crate::pr::fetch_parallel(&inputs);
         for ((identity, _branch), pr) in pr_results {
             if let Some(repo) = repos.iter_mut().find(|r| r.identity == identity) {


### PR DESCRIPTION
Closes #102.

`wsp st` with `pr.source = github` fired N GitHub API calls and printed nothing. A ten-repo workspace on a slow link was ten seconds of dead terminal. The only output on that path was a warning if a fetch thread panicked.

```rust
eprintln!(
    "Fetching pull requests for {} repo{}...",
    inputs.len(),
    if inputs.len() == 1 { "" } else { "s" }
);
let pr_results = crate::pr::fetch_parallel(&inputs);
```

## Which tenet

Speed #2 — *"Say what you are fetching, and how much, before waiting on it. Silence past a second is a bug."*

Speed #3 (*reads stay local*) is **not** violated: the fetch is gated on `pr.source` being configured, so the user opted in. The bug was only the silence.

## `wsp rm` had it too

`delete.rs:141` is a second silent caller of `pr::fetch_parallel`. The issue named only `st`, but this is the same defect — fixing one would apply the tenet to half the codebase and invite the same report again.

Its count comes from `meta.repos`, not `inputs`: that vec holds up to *two* branch queries per repo (the current branch and `meta.branch`), so `inputs.len()` would overstate the work.

## Two small judgement calls

**Pluralized**, unlike the neighbouring `"Fetching {} mirrors..."` and `"with {} repos..."` lines. A single-repo workspace is common and *"1 repos"* is the first thing you'd notice. `new.rs:248` already does this, so it's the existing precedent rather than a new one.

**Stderr**, so `--json` on stdout stays clean — matching `fetch.rs`. Not gated on `--json`: an agent reading stdout is unaffected, and gating would diverge from `fetch.rs` for no gain.

## Verification

Ran against a real workspace with a sandboxed `XDG_DATA_HOME`:

```
--- pr.source unset ---
  (silent, correct)

--- pr.source = github ---
Fetching pull requests for 1 repo...
```

The default path stays silent, which matters because most users never set `pr.source`. And the live run exercised the **singular** — the exact case the neighbouring pattern would have rendered as "1 repos".

- [x] 667 tests pass
- [x] `cargo fmt`, `cargo clippy --workspace --all-targets` clean
- [x] Runtime-verified in both states

No unit test: this is a log line whose only interesting property is *ordering* relative to the network call, which a test asserting on stderr wouldn't meaningfully pin down. Verified by running it instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
