### PR TITLE
test(completion): guard the assumptions behind recover's argv scan

### DIFF
--- a/crates/wsp/src/cli/completion.rs
+++ b/crates/wsp/src/cli/completion.rs
@@ -1569,4 +1569,65 @@ mod tests {
             "powershell: remove must normalize to rm"
         );
     }
+
+    /// The `recover` wrapper case reads `$1` as the workspace name, skipping the
+    /// subcommands it knows about. That is safe today, and this test fails if
+    /// either assumption behind it stops holding.
+    ///
+    /// `new` had exactly this shape and was silently wrong for years: posix read
+    /// `$1` positionally, PowerShell scanned for the first non-flag token, and
+    /// both mis-read `wsp new -w src new-ws`. `recover` escapes that only
+    /// because it has no flags that consume the following token, and because the
+    /// wrapper enumerates all of its subcommands. Neither is guaranteed by
+    /// anything but this test.
+    ///
+    /// If it fails, route `recover` through WSP_CD_FILE the way `new` does
+    /// rather than extending the scan — see #105.
+    #[test]
+    fn test_recover_wrapper_assumptions_hold() {
+        // build() populates the defaults clap computes lazily. Without it
+        // get_num_args() is None even for a flag that plainly takes a value,
+        // which made the first version of this assertion vacuous.
+        let mut cmd = crate::cli::recover::cmd();
+        cmd.build();
+
+        // 1. No flag may consume the token after it, or that value would be
+        //    mistaken for the workspace name. Positionals are exempt: the
+        //    positional *is* what the wrapper means to read.
+        //
+        //    Unknown arity counts as taking a value — fail closed, so a future
+        //    clap change cannot quietly turn this back into a no-op.
+        for arg in cmd.get_arguments() {
+            let takes_value = arg.get_num_args().map(|n| n.takes_values()).unwrap_or(true);
+            assert!(
+                arg.is_positional() || !takes_value,
+                "recover gained a value-taking flag (--{}), whose value the \
+                 wrapper will mistake for the workspace name",
+                arg.get_id()
+            );
+        }
+
+        // 2. The wrapper skips exactly ls/list/show. A new subcommand would be
+        //    treated as a workspace name and cd'd into.
+        // build() also injects clap's own `help` subcommand. It is excluded
+        // because it is not reachable as a subcommand here: recover's optional
+        // positional captures the token first, so `wsp recover help` errors with
+        // "no recoverable workspace named help" and the wrapper's `|| return`
+        // skips the cd. Verified by running it through the wrapper.
+        let mut subs: Vec<String> = Vec::new();
+        for sub in cmd.get_subcommands() {
+            if sub.get_name() == "help" {
+                continue;
+            }
+            subs.push(sub.get_name().to_string());
+            subs.extend(sub.get_visible_aliases().map(String::from));
+        }
+        subs.sort();
+        assert_eq!(
+            subs,
+            vec!["list".to_string(), "ls".to_string(), "show".to_string()],
+            "recover's subcommands changed — the wrapper's skip list \
+             (ls/list/show) must be updated to match"
+        );
+    }
 }

--- a/crates/wsp/tests/shell_cd.rs
+++ b/crates/wsp/tests/shell_cd.rs
@@ -198,6 +198,15 @@ const SCENARIOS: &[Scenario] = &[
         expect: Expect::Ws("w"),
     },
     Scenario {
+        // `cd` reads its destination from the command's stdout, so a failing
+        // command must not be allowed to move the shell to an empty path.
+        name: "cd to a missing workspace does not move the shell",
+        setup: &[],
+        start: Start::Root,
+        cmd: &["cd", "nope"],
+        expect: Expect::Unchanged,
+    },
+    Scenario {
         // Guards the "does this cd for every command?" worry: read-only
         // commands must leave the shell where it is.
         name: "st does not move the shell",

--- a/crates/wsp/tests/shell_cd.rs
+++ b/crates/wsp/tests/shell_cd.rs
@@ -537,8 +537,11 @@ fn shell_wrapper_cd_behavior_matches_across_shells() {
 /// and any script that checks the result.
 fn status_in_shell(shell: &Shell, env: &Env, start: &Path, cmd: &[&str]) -> i32 {
     let load = shell.load.replace("WSPBIN", &quote(shell.quote, WSP));
+    // Only stdout is discarded, matching run_in_shell: stderr is kept so a
+    // failure on a platform that cannot be reproduced locally still explains
+    // itself.
     let script = format!(
-        "{load}\ncd {}\nwsp {} >{null} 2>{null}\n{}",
+        "{load}\ncd {}\nwsp {} >{null}\n{}",
         quote(shell.quote, &start.to_string_lossy()),
         cmd.join(" "),
         shell.print_status,
@@ -553,27 +556,84 @@ fn status_in_shell(shell: &Shell, env: &Env, start: &Path, cmd: &[&str]) -> i32 
         .output()
         .unwrap_or_else(|e| panic!("spawning {} failed: {e}", shell.bin));
     let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
     let last = stdout
         .lines()
         .rfind(|l| !l.trim().is_empty())
-        .unwrap_or_else(|| panic!("{} printed no status\nscript:\n{script}", shell.bin));
-    last.trim()
-        .parse()
-        .unwrap_or_else(|e| panic!("{}: unparseable status {last:?}: {e}", shell.bin))
+        .unwrap_or_else(|| {
+            panic!(
+                "{} printed no status\nscript:\n{script}\nstderr: {stderr}",
+                shell.bin
+            )
+        });
+    last.trim().parse().unwrap_or_else(|e| {
+        panic!(
+            "{}: unparseable status {last:?}: {e}\nstderr: {stderr}",
+            shell.bin
+        )
+    })
 }
 
-/// (description, argv, expected exit status)
-const EXIT_CASES: &[(&str, &[&str], i32)] = &[
-    ("successful new", &["new", "w", "--empty"], 0),
-    ("new with no name", &["new"], 1),
+/// One exit-status expectation. A struct rather than a tuple so the fields are
+/// named at the use site, matching `Scenario` above.
+struct ExitCase {
+    what: &'static str,
+    /// Run with the binary directly to build the fixture.
+    setup: &'static [&'static [&'static str]],
+    argv: &'static [&'static str],
+    want: i32,
+}
+
+const EXIT_CASES: &[ExitCase] = &[
+    ExitCase {
+        what: "successful new",
+        setup: &[],
+        argv: &["new", "w", "--empty"],
+        want: 0,
+    },
+    // rm's success path needs its own coverage: every other rm case here
+    // fails, so a wrapper that returned nonsense on success would slip by.
+    ExitCase {
+        what: "successful rm",
+        setup: &[&["new", "w", "--empty"]],
+        argv: &["rm", "w", "--force"],
+        want: 0,
+    },
+    ExitCase {
+        what: "successful recover",
+        setup: &[&["new", "w", "--empty"], &["rm", "w", "--force"]],
+        argv: &["recover", "w"],
+        want: 0,
+    },
+    ExitCase {
+        what: "new with no name",
+        setup: &[],
+        argv: &["new"],
+        want: 1,
+    },
     // clap exits 2 for a usage error, not 1. Asserting the exact code (rather
     // than "non-zero") is what proves the wrapper propagates the real status
     // instead of normalizing everything to 0/1.
-    ("new with a bad flag", &["new", "--nope"], 2),
-    ("rm of a missing workspace", &["rm", "nope", "--force"], 1),
+    ExitCase {
+        what: "new with a bad flag",
+        setup: &[],
+        argv: &["new", "--nope"],
+        want: 2,
+    },
+    ExitCase {
+        what: "rm of a missing workspace",
+        setup: &[],
+        argv: &["rm", "nope", "--force"],
+        want: 1,
+    },
     // `ls` rather than `st`: these run from the workspaces root, and `st`
     // correctly fails outside a workspace.
-    ("read-only ls", &["ls"], 0),
+    ExitCase {
+        what: "read-only ls",
+        setup: &[],
+        argv: &["ls"],
+        want: 0,
+    },
 ];
 
 /// The wrapper must not swallow or invent exit codes.
@@ -584,16 +644,21 @@ fn shell_wrapper_preserves_exit_status() {
         if !is_installed(shell) {
             continue;
         }
-        for (what, argv, want) in EXIT_CASES {
+        for case in EXIT_CASES {
             let env = make_env();
-            let got = status_in_shell(shell, &env, &env.ws_root, argv);
+            for args in case.setup {
+                run_setup(&env, args);
+            }
+            let got = status_in_shell(shell, &env, &env.ws_root, case.argv);
             ran += 1;
             assert_eq!(
                 got,
-                *want,
-                "shell={} case={what:?} cmd=`wsp {}`: expected exit {want}, got {got}",
+                case.want,
+                "shell={} case={:?} cmd=`wsp {}`: expected exit {}, got {got}",
                 shell.bin,
-                argv.join(" "),
+                case.what,
+                case.argv.join(" "),
+                case.want,
             );
         }
     }


### PR DESCRIPTION
Closes #105.

## Why this closes #105 rather than implementing it

#105 proposed replacing all per-command argv parsing in the wrapper with a single `WSP_CD_FILE` mechanism. Most of it is done, and what remains has no defect behind it:

| Case | State |
|---|---|
| `new` / `create` | takes its destination from the binary (#110) |
| `rm` / `remove` | no longer reads the workspace name at all (#111) |
| `cd` | single required positional; reads its path from stdout |
| `recover` | still reads `$1` — **and that is safe, for two reasons nothing was checking** |

`recover` has no flags at all: two subcommands (`ls`/`list`, `show <ws>`) and one bare optional positional. So there is no flag value to mistake for the workspace name, and the wrapper's `ls|list|show` skip list is complete. The remaining scope in #105 was architectural uniformity, not a bug — and by "compose, don't accumulate," an open refactor issue with no defect behind it mostly invites churn.

What it *did* leave behind was an unguarded assumption. `new` had exactly recover's shape and was silently wrong since v0.14.0. recover escapes it by accident of its current argument surface, not by design.

## What this adds

One test asserting the two properties the wrapper depends on:

1. **No value-taking flag on `recover`** — adding `--to <dir>` would make the scan pick up `<dir>` as the workspace name.
2. **The subcommand set is exactly `ls`/`list`/`show`** — adding `recover prune` would make the wrapper try to cd into `<root>/prune`.

Either failure points at the fix: route `recover` through `WSP_CD_FILE` like `new`, rather than extending the scan.

## The first version of this test was vacuous

Worth stating plainly, because it is the same failure mode as the tests this stack has spent its time replacing — `test_ps_new_skips_flag_args_when_cding` matching the `rm` branch, `test_ps_contains_all_cases` matching `'new'` inside `'new', 'create'`.

`get_num_args()` returns `None` until clap builds the command, so `.unwrap_or(false)` classified a plainly value-taking flag as harmless and **mutation A passed against the broken guard.** Found only because I mutation-tested it. Fixed by calling `cmd.build()` first and treating unknown arity as value-taking, so a future clap change cannot silently turn it back into a no-op.

Both assertions are now mutation-verified:

```
MUTATION A (add --to <dir>)      -> "recover gained a value-taking flag (--to)"  FAILED ✓
MUTATION B (add `recover prune`) -> "recover's subcommands changed"              FAILED ✓
restored                         -> ok ✓
```

## One thing checked rather than assumed

`cmd.build()` injects clap's own `help` subcommand, which the test excludes. That is not a hole: recover's optional positional captures the token first, so `wsp recover help` errors with `no recoverable workspace named "help"` and the wrapper's `|| return` skips the cd. Confirmed by running it through a real wrapper, not by reading the code.

Stacked on #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)