### PR TITLE
ci: require a whatsnew block in every PR description

### DIFF
--- a/.claude/skills/wsp-release/SKILL.md
+++ b/.claude/skills/wsp-release/SKILL.md
@@ -15,8 +15,11 @@ version.
 1. Stop if the tree is dirty. Run `just build` so later checks use current code.
 2. `just changelog`, show the user the unreleased entries, and confirm the bump
    level matches them.
-3. Draft the `WHATSNEW.md` notes per the rules in `RELEASING.md`. **Show the
-   draft and wait for approval** before continuing; the user may rewrite it.
+3. Run `scripts/whatsnew-draft.sh` to collect the notes each PR wrote for
+   itself, then shape them into the `WHATSNEW.md` section per the rules in
+   `RELEASING.md`. Prefer those notes over re-deriving prose from the
+   changelog — the author had the context. **Show the draft and wait for
+   approval** before continuing; the user may rewrite it.
 4. Work through the flow in `RELEASING.md`. Do not merge the release PR
    yourself.
 5. After it merges, run `just release-dispatch <version>` and report each job.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+<!--
+The whatsnew block below is required and is checked by CI.
+
+It becomes the user-facing release notes in WHATSNEW.md. Write it for someone
+who runs wsp, not someone who maintains it: what changed for them, in their
+words. Behaviour, not mechanism.
+
+Put NONE in the block if a user cannot observe this change by running wsp —
+refactors, tests, CI, docs, dependency bumps. That is a normal answer.
+
+Style rules live in RELEASING.md under "Writing release notes".
+-->
+
+```whatsnew
+NONE
+```
+
+## What
+
+## Why

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,54 @@ jobs:
           fi
           echo "release notes present for $new"
 
+      # Every PR declares its user-facing impact while the author still has the
+      # context. Squash is the only merge method here and the squash body is the
+      # PR description verbatim, so this block lands in main's commit body and
+      # `just whatsnew-draft` can collect it at release time without network.
+      #
+      # Dependabot cannot be taught to write one, so it is exempt; its bumps are
+      # not user-facing anyway.
+      - name: require a whatsnew block in the PR description
+        if: github.actor != 'dependabot[bot]'
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          body=$(printf '%s' "$BODY" | tr -d '\r')
+
+          if ! printf '%s\n' "$body" | grep -q '^```whatsnew[[:space:]]*$'; then
+            echo "Add a whatsnew block to the PR description:"
+            echo ''
+            echo '    ```whatsnew'
+            echo '    - `wsp foo` no longer does the wrong thing.'
+            echo '    ```'
+            echo ''
+            echo "Use NONE if a user cannot observe this change by running wsp"
+            echo "(refactors, tests, CI, docs). Style: RELEASING.md."
+            echo "::error::PR description has no \`\`\`whatsnew block"
+            exit 1
+          fi
+
+          block=$(printf '%s\n' "$body" | awk '
+            /^```whatsnew[[:space:]]*$/ { inblock = 1; next }
+            inblock && /^```/           { exit }
+            inblock                     { print }
+          ')
+
+          compact=$(printf '%s' "$block" | tr -d '[:space:]')
+          if [ -z "$compact" ]; then
+            echo "::error::the whatsnew block is empty — write a note or put NONE in it"
+            exit 1
+          fi
+
+          if [ "$(printf '%s' "$compact" | tr '[:lower:]' '[:upper:]')" = "NONE" ]; then
+            echo "declared not user-facing"
+            exit 0
+          fi
+
+          echo "whatsnew note:"
+          printf '%s\n' "$block"
+
   # Linux runs first. If logic is broken it shows up here cheaply before we
   # spin up macOS and Windows runners.
   #

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Use `filelock::with_config()` / `with_metadata()` / `with_template()` for all re
 
 Product: binary `wsp`, metadata `.wsp.yaml`, env `WSP_SHELL`, shell vars `wsp_bin`/`wsp_root`/`wsp_dir`, data dir `~/.local/share/wsp/`. Internal Rust names (`ws_dir`, `ws_bin`) are shorthand, not product identifiers.
 
-**CLAUDE.md is a symlink to AGENTS.md** — do not replace the symlink with a regular file.
+**`AGENTS.md` is the source of truth**; `CLAUDE.md` is a real file that imports it with `@AGENTS.md`. Put content here, not there. Do not make `CLAUDE.md` a symlink: git on Windows without symlink support checks one out as a text file containing the literal string `AGENTS.md`.
 
 **Before proposing a new command name**, check the open GitHub issues (labels P1--P4) — planned command names are reserved there. A name collision means either the existing issue needs to be closed/updated first, or a different name is needed.
 
@@ -105,6 +105,18 @@ Product: binary `wsp`, metadata `.wsp.yaml`, env `WSP_SHELL`, shell vars `wsp_bi
 ## Releasing
 
 See [`RELEASING.md`](RELEASING.md) for the process, or `/wsp-release` to be walked through it. In short: releases go through a reviewed PR and nobody pushes tags from a laptop. The rules below are the ones that bite during ordinary work, not at release time.
+
+**Every PR needs a `whatsnew` block in its description**, enforced by the `whatsnew` CI job. It is the user-facing note for this change, written while you still have the context:
+
+````
+```whatsnew
+- `wsp new` no longer leaves you outside the workspace it created.
+```
+````
+
+Put `NONE` in the block when a user cannot observe the change by running `wsp` — refactors, tests, CI, docs. That is the common answer, not a cop-out. Style rules are in `RELEASING.md`; write behaviour, not mechanism.
+
+This works because squash is the only merge method here and the squash body is the PR description verbatim, so the block lands in `main`'s commit body. `scripts/whatsnew-draft.sh` collects them at release time from `git log` alone — no network, no bot, no fragment files. **If merge commits or rebase merging are ever enabled, notes silently stop reaching `main`** and that script goes quiet.
 
 **Do not manually edit `release.yml`.** It is fully owned by `cargo-dist` — any hand-edits (e.g. SHA-pinning actions) will be overwritten the next time `dist generate` runs, and the `dist plan` freshness check in CI will fail on every PR until they are reverted.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,6 @@
-AGENTS.md
+# CLAUDE.md
+
+Claude Code reads this file; other agents read `AGENTS.md`. Rather than keep two
+that drift, this imports the one source of truth.
+
+@AGENTS.md

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -65,6 +65,21 @@ near-identical entries makes the file read as though three things shipped.
 `WHATSNEW.md` is compiled into the binary and shown by `wsp whatsnew`. Prepend
 a section under `# What's New` using the post-bump version and today's date.
 
+Start from the notes each PR wrote for itself:
+
+```bash
+scripts/whatsnew-draft.sh          # since the most recent tag
+```
+
+Every PR carries a ```whatsnew block in its description (CI enforces it), and
+squash-merging puts that description in the commit body, so this collects them
+from `git log` with no network. `NONE` blocks are dropped.
+
+Treat the output as raw material. It arrives newest-first and one bullet per
+PR, so you still order by impact, fold several symptoms of one cause into a
+single line, and decide what deserves prose — judgements that need all of them
+in view at once.
+
 Written for people who **use** wsp: technical, impatient, want to know what to
 try and what got fixed. Second person, active voice, no hype, no emoji.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,8 +1,10 @@
 # scripts
 
-These run in CI before every release is tagged (`global-artifacts-jobs` in
-`dist-workspace.toml` makes `host` wait on them), and locally via `just smoke`.
-A failure means no tag and no release.
+## Smoke tests
+
+`smoke.sh` and `smoke.ps1` run in CI before every release is tagged
+(`global-artifacts-jobs` in `dist-workspace.toml` makes `host` wait on them),
+and locally via `just smoke`. A failure means no tag and no release.
 
 They are deliberately shallow — "does the published binary work at all". Deep
 behavioural coverage belongs in the e2e suite (#69); as that grows, these
@@ -16,9 +18,8 @@ Two scripts, same checks: `smoke.sh` (macOS/Linux) and `smoke.ps1` (Windows).
     ./scripts/smoke.sh  --wsp ./wsp     --expect-version 0.19.0-rc.1
     ./scripts/smoke.ps1 -Wsp .\wsp.exe -ExpectVersion 0.19.0-rc.1
 
-`smoke.sh` has been run and passes. `smoke.ps1` has not — it was written
-without a PowerShell to check it against, so expect the possibility of a typo
-on first use.
+Both have run and passed on their target platforms, `smoke.ps1` on the Windows
+runner during a real release.
 
 ## What they do
 
@@ -88,3 +89,19 @@ inserts upstream, giving `host: needs [..., custom-smoke]`.
 
 Only three of the five build targets have runners, so `aarch64-unknown-linux-gnu`
 and `aarch64-pc-windows-msvc` are built but never smoke-tested.
+
+## Release notes
+
+`whatsnew-draft.sh` collects the ```whatsnew blocks from every PR merged since
+a tag, so the release author starts from notes the change authors wrote rather
+than re-deriving prose from commit subjects.
+
+    scripts/whatsnew-draft.sh            # since the most recent tag
+    scripts/whatsnew-draft.sh v0.19.0    # since a specific tag
+
+It reads `git log` only — no network. Squash is the only merge method here and
+the squash body is the PR description verbatim, so the blocks are already in
+`main`'s history. Blocks containing `NONE` are dropped.
+
+Output is raw material: newest-first, one bullet per PR. Ordering and merging
+related entries stays with whoever writes the release. See `RELEASING.md`.

--- a/scripts/whatsnew-draft.sh
+++ b/scripts/whatsnew-draft.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Collect the whatsnew blocks merged since a tag into a draft release note.
+#
+#   scripts/whatsnew-draft.sh            # since the most recent tag
+#   scripts/whatsnew-draft.sh v0.19.0    # since a specific tag
+#
+# Squash is the only merge method in this repo and the squash body is the PR
+# description verbatim, so every merged PR's whatsnew block is already in the
+# commit body on main. No network, no bot, no fragment files to clean up.
+#
+# The output is raw material, not the finished section. Ordering by impact,
+# merging several symptoms of one cause into a single line, and deciding what
+# deserves prose are judgements you can only make with all of them in view.
+set -euo pipefail
+
+since="${1:-}"
+if [ -z "$since" ]; then
+  since=$(git describe --tags --abbrev=0 2>/dev/null || true)
+fi
+if [ -z "$since" ]; then
+  echo "no tag found; pass one explicitly: scripts/whatsnew-draft.sh v0.19.0" >&2
+  exit 1
+fi
+
+range="$since..HEAD"
+count=$(git rev-list --count "$range")
+echo "# collected from $count commit(s) in $range" >&2
+echo >&2
+
+# %B is the raw body; the record separator keeps multi-line notes together.
+notes=$(git log "$range" --format='%B%x00' | awk '
+  BEGIN { RS = "\0" }
+  {
+    inblock = 0
+    n = split($0, lines, "\n")
+    for (i = 1; i <= n; i++) {
+      line = lines[i]
+      sub(/\r$/, "", line)
+      if (line ~ /^```whatsnew[[:space:]]*$/) { inblock = 1; continue }
+      if (inblock && line ~ /^```/)           { inblock = 0; continue }
+      if (inblock)                            { print line }
+    }
+  }
+')
+
+# Drop NONE markers and blank lines left behind by them.
+cleaned=$(printf '%s\n' "$notes" \
+  | grep -v -i -x '[[:space:]]*none[[:space:]]*' \
+  | sed '/^[[:space:]]*$/d')
+
+if [ -z "$cleaned" ]; then
+  echo "no user-facing notes in $range" >&2
+  exit 0
+fi
+
+printf '%s\n' "$cleaned"


### PR DESCRIPTION
```whatsnew
NONE
```

## What

Every PR now carries a `whatsnew` block in its description. This PR is the first one — the block above is the opt-out, since none of this is visible to someone running `wsp`.

````
```whatsnew
- `wsp new` no longer leaves you outside the workspace it created.
```
````

`NONE` declares no user-visible change. That's the common answer for refactors, tests, CI and docs, not a cop-out.

## Why

The release notes for rc.2 were written by reading eight merged PR bodies and reconstructing prose from them. Every author already knew what to say at the time and had nowhere to put it. The best moment to write a note is in the PR that causes it.

## Why blocks in the description, not fragments or trailers

Two repo settings decide this:

```
squash=true  merge=false  rebase=false
squash_merge_commit_message=PR_BODY
```

Squash is the **only** permitted merge, and the commit body is always the PR description. So the block lands in `main`'s history automatically, and `scripts/whatsnew-draft.sh` collects it from `git log` alone — no network, no bot, no fragment directory to create and prune.

- **Commit trailers are ruled out**: a `RELNOTE:` line in a branch commit is discarded by the squash. Only the description survives.
- **Fragment files** (towncrier, HashiCorp's `.changelog/`) work, and win on one axis — the note appears in the file diff and is reviewed as code. They cost a directory, a cleanup step, and a convention. Given the settings above, `git log` already carries the data.
- **Editing `WHATSNEW.md` per PR** is why towncrier exists: every PR touches the same lines. The #108/#110/#111 stack would have conflicted three times.

Recorded in `AGENTS.md` that enabling merge commits or rebase merging would silently stop notes reaching `main` and quietly empty the collector.

## Enforcement

A step on the existing `whatsnew` job — already a required check, so no ruleset change and it blocks immediately. A new job would have needed adding to the ruleset to have any effect.

The PR template ships the block pre-filled with `NONE` so it's filled in rather than remembered. Dependabot is exempt; it can't be taught, and its bumps aren't user-facing.

## What it doesn't do

The draft is raw material. It arrives newest-first, one bullet per PR. Ordering by impact, folding several symptoms of one cause into one line, and deciding what deserves prose still happen at release time — those need every note in view at once.

## Also in here

- **`CLAUDE.md` becomes a real file importing `@AGENTS.md`.** As a symlink, git on Windows without symlink support checks it out as a text file containing the literal string `AGENTS.md`. The `agentmd.rs` symlink test is unaffected — it asserts on the symlink wsp creates *in a workspace*, not this repo's own file.
- **`scripts/README.md` said `smoke.ps1` had never been run.** It has, on the Windows runner during the rc.2 release.

## Verification

The gate, against nine PR-body shapes:

```
note present       -> PASS      empty block  -> FAIL (blank template)
NONE               -> PASS      no block     -> FAIL
lowercase none     -> PASS      empty body   -> FAIL
CRLF line endings  -> PASS      multi-line   -> PASS
block mid-body     -> PASS
```

CRLF matters — GitHub sends bodies with `\r\n`, which would otherwise defeat the fence match.

The collector, against a throwaway repo with five squash-shaped commits: extracted both real notes, dropped `NONE` and lowercase `none`, ignored a pre-convention commit with no block, and preserved a multi-line note's continuation line.

- [x] `ci.yml` parses; `whatsnew` job now has three steps
- [x] 667 tests pass, `cargo fmt --check` clean
- [x] `git` records `mode change 120000 => 100644` for `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
