### PR TITLE
docs(src): state the constraint, not the incident

### DIFF
--- a/crates/wsp/src/cli/doctor.rs
+++ b/crates/wsp/src/cli/doctor.rs
@@ -205,8 +205,8 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
         // origin-url-match check below compares each clone against
         // `cfg.upstream_url()`, so on a stale snapshot it warns about the entry
         // this run just created — and declines to fix it, because the stale
-        // registered URL is empty. That is why the warning used to survive the
-        // run that resolved it and clear only on a second `wsp doctor --fix`.
+        // registered URL is empty. Without this reload the warning survives the
+        // run that resolved it and clears only on a second `wsp doctor --fix`.
         let cfg = config::Config::load_from(&paths.config_path).unwrap_or(cfg);
 
         // W9. AGENTS.md / CLAUDE.md validity

--- a/crates/wsp/src/hints.rs
+++ b/crates/wsp/src/hints.rs
@@ -138,9 +138,9 @@ mod tests {
         paths: Paths,
     }
 
-    // Built from explicit directories rather than Paths::resolve(), which reads
-    // XDG_DATA_HOME and falls back to $HOME for workspaces_dir -- so these tests
-    // used to point at the developer's real ~/dev/workspaces.
+    // Explicit directories, not Paths::resolve(): that reads XDG_DATA_HOME but
+    // falls back to $HOME for workspaces_dir, which would aim these tests at the
+    // developer's real ~/dev/workspaces.
     fn make_paths() -> TestPaths {
         let tmp = tempfile::tempdir().unwrap();
         let paths = wsp_core::testutil::make_test_paths(&tmp);


### PR DESCRIPTION
```whatsnew
NONE
```

## What

Two source comments described a bug in the past tense rather than what the code prevents. Present tense says what breaks if you delete the line, which is the part worth reading.

**`hints.rs`**

```diff
-// ... -- so these tests used to point at the developer's real ~/dev/workspaces.
+// ... which would aim these tests at the developer's real ~/dev/workspaces.
```

**`doctor.rs`**

```diff
-// That is why the warning used to survive the run that resolved it and
-// clear only on a second `wsp doctor --fix`.
+// Without this reload the warning survives the run that resolved it and
+// clears only on a second `wsp doctor --fix`.
```

Both now read as "here is what this line is holding back" rather than "here is what happened once."

## Not swept

Regression tests that name what regressed — `shell_cd.rs`, `workspace.rs:6908`, `mirror_propagation_warning.rs`. A test comment saying *"this used to leave staged diffs"* tells you what broke when the test goes red, which is exactly what a regression test is for.

Second of three. #117 covers CI/build config; docs follow.

## Verification

- [x] `cargo fmt --check` clean, builds
- [x] comments only — no behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
