### PR TITLE
docs(removal-safety): drop a note about a parameter that no longer exists

### DIFF
--- a/docs/features/removal-safety.md
+++ b/docs/features/removal-safety.md
@@ -53,4 +53,4 @@ If a squash merge resolved conflicts by changing file contents, `is_content_merg
 
 The gc dir lives alongside mirrors in the XDG data directory (`~/.local/share/wsp/gc/`). `gc::move_dir` uses `fs::rename` when possible, falling back to recursive copy + delete for cross-filesystem moves (EXDEV). GC metadata (`.wsp-gc.yaml`) is written inside the workspace dir before the move.
 
-`workspace::remove(paths, name, force)` — always moves to gc. There is no bypass; tests that need to inspect gc internals use the gc path directly.
+`workspace::remove(paths, name, force)` — always moves to gc. There is no bypass.

--- a/docs/features/removal-safety.md
+++ b/docs/features/removal-safety.md
@@ -53,4 +53,4 @@ If a squash merge resolved conflicts by changing file contents, `is_content_merg
 
 The gc dir lives alongside mirrors in the XDG data directory (`~/.local/share/wsp/gc/`). `gc::move_dir` uses `fs::rename` when possible, falling back to recursive copy + delete for cross-filesystem moves (EXDEV). GC metadata (`.wsp-gc.yaml`) is written inside the workspace dir before the move.
 
-`workspace::remove(paths, name, force)` — always moves to gc. Tests that previously passed `permanent: true` to bypass gc internals now use the gc path directly.
+`workspace::remove(paths, name, force)` — always moves to gc. There is no bypass; tests that need to inspect gc internals use the gc path directly.


### PR DESCRIPTION
```whatsnew
NONE
```

## What

```diff
-`workspace::remove(paths, name, force)` — always moves to gc. Tests that
-previously passed `permanent: true` to bypass gc internals now use the gc
-path directly.
+`workspace::remove(paths, name, force)` — always moves to gc. There is no
+bypass; tests that need to inspect gc internals use the gc path directly.
```

`permanent: true` does not exist anywhere in the codebase — verified by grep. The sentence documented a migration away from a parameter a reader will never encounter. The fact worth stating is that there is no bypass at all.

## Scope

Third and last of the sweep. I scanned every file under `docs/` for the same pattern and this was the only real hit. Two look-alikes are correctly worded present-tense behaviour and were left alone:

- `removal-safety.md:6` — "their checkout **no longer exists**" describes what makes a worktree prunable
- `setup-commands/definition.md:141` — "re-prompt even if **previously approved**" is the spec

#117 covers CI/build config, #118 covers source comments.

## Verification

- [x] `grep -rn "permanent" crates` confirms the parameter is gone
- [x] docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
