### PR TITLE
docs(completers): the unsafe_code guard is narrower than claimed

### DIFF
--- a/crates/wsp/src/cli/completers.rs
+++ b/crates/wsp/src/cli/completers.rs
@@ -5,8 +5,10 @@
 // clap calls. The `_in` function below each wrapper takes those values as
 // parameters, so tests drive them directly instead of mutating the process
 // environment. Keep it that way: `std::env::set_var` is unsafe in edition 2024
-// and both crate roots deny unsafe_code, so a test that reaches for the
-// environment will not compile.
+// and both crate roots deny unsafe_code, so no unit test can mutate the
+// environment. That guard stops at the crate root -- `crates/wsp/tests/*.rs`
+// are separate crates without the deny -- and it bars mutation, not access:
+// reading `$HOME` through `Paths::resolve()` needs no unsafe at all.
 use std::path::Path;
 
 use clap_complete::engine::CompletionCandidate;


### PR DESCRIPTION
```whatsnew
NONE
```

## What

A comment I shipped in #104 is wrong:

> `std::env::set_var` is unsafe in edition 2024 and both crate roots deny unsafe_code, so **a test that reaches for the environment will not compile**.

Wrong in two directions.

**The guard stops at the crate root.** `#![deny(unsafe_code)]` is on `crates/wsp/src/main.rs:1` and `crates/wsp-core/src/lib.rs:62`. The four files under `crates/wsp/tests/` are their own crate roots and carry no such attribute — an integration test can call `unsafe { set_var }` today and compile. They currently set `XDG_DATA_HOME` on a child `Command`, which is safe and correct, but the lint isn't what's keeping them honest.

**It bars mutation, not access.** `Paths::resolve()` reads `XDG_DATA_HOME` and falls back to `dirs::home_dir()` for `workspaces_dir` — no `unsafe` anywhere. That's the live hazard, and the reason `hints.rs` builds its paths explicitly instead. `set_current_dir` is safe in edition 2024 too; unused today, equally uncovered.

## Why it matters more than vagueness

Someone debugging a flaky parallel test run lands here and concludes *"can't be shared process state, it wouldn't compile"* — and stops looking in the one place the bug actually lives. An overclaim in a guard comment is worse than no comment.

The corrected version names where the guard doesn't reach, which is the part worth grepping.

## How it was found

Three independent reviews of the comment sweep in #117, none shown the PR description or my reasoning, each given a different lens (new maintainer, on-call debugger, accuracy reviewer). All three flagged this independently. The same sentence had been copied into `ci.yml`, corrected there in #117.

I wrote the original claim, so I was the wrong person to check it.

## Verification

- [x] `grep -rn "deny(unsafe_code)" crates` — two hits, both `src/` crate roots
- [x] no file in `crates/wsp/tests/` contains the attribute
- [x] `cargo fmt --check` clean, builds
- [x] comment only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
