### PR TITLE
fix(completion): follow the workspace on rename, and guard the class

### DIFF
--- a/crates/wsp/src/cli/completion.rs
+++ b/crates/wsp/src/cli/completion.rs
@@ -244,6 +244,10 @@ fn build_posix_cases() -> Vec<ShellCase> {
                 .to_string(),
         },
         ShellCase {
+            pattern: "rename".to_string(),
+            body: build_posix_rename(),
+        },
+        ShellCase {
             // Both spellings share one body, which always invokes `rm`.
             pattern: "rm|remove".to_string(),
             body: build_posix_cd_out("rm"),
@@ -286,6 +290,38 @@ fn build_posix_recover() -> String {
      \x20     if [[ -n \"$_wsp_name\" && \"$_wsp_name\" != ls && \"$_wsp_name\" != list && \"$_wsp_name\" != show && \"$_wsp_name\" != -* ]]; then\n\
      \x20       cd \"$wsp_root/$_wsp_name\"\n\
      \x20     fi"
+        .to_string()
+}
+
+/// Shell body for `wsp rename`: vacate, rename, then follow the workspace to
+/// its new location — but only if we were standing in it.
+///
+/// Composes both mechanisms already in use here. The vacate step is `rm`'s: on
+/// Windows a directory that is a live process's cwd cannot be renamed, so the
+/// shell must step out before the binary runs, and only the shell can move
+/// itself. The destination comes from the binary like `new`'s, because `rename`
+/// takes the workspace name as an *optional* positional (falling back to CWD
+/// detection), so there is no reliable way to derive the new path from argv.
+///
+/// `$_wsp_prev` surviving means the rename did not affect us — either it failed,
+/// or we were somewhere else entirely — so return there and nothing appears to
+/// move. Landing at the new workspace root loses a subdirectory position
+/// (`<ws>/sub` becomes `<ws-new>`); reconstructing the relative subpath is
+/// possible but not worth the shell complexity.
+fn build_posix_rename() -> String {
+    "shift\n\
+     \x20     local _wsp_prev=\"$PWD\" _wsp_cd _wsp_rc\n\
+     \x20     _wsp_cd=$(mktemp) || return\n\
+     \x20     cd \"$wsp_root\" 2>/dev/null || cd \"$HOME\" || return\n\
+     \x20     WSP_CD_FILE=\"$_wsp_cd\" command \"$wsp_bin\" rename \"$@\"\n\
+     \x20     _wsp_rc=$?\n\
+     \x20     if [[ -d \"$_wsp_prev\" ]]; then\n\
+     \x20       cd \"$_wsp_prev\"\n\
+     \x20     elif [[ $_wsp_rc -eq 0 && -s \"$_wsp_cd\" ]]; then\n\
+     \x20       cd -- \"$(<\"$_wsp_cd\")\"\n\
+     \x20     fi\n\
+     \x20     rm -f \"$_wsp_cd\"\n\
+     \x20     return $_wsp_rc"
         .to_string()
 }
 
@@ -457,6 +493,21 @@ function wsp\n\
             set -l args $argv[2..]\n\
             set -l dir (WSP_SHELL=1 command $wsp_bin cd $args); or return\n\
             cd $dir\n\
+\n\
+        case rename\n\
+            set -l args $argv[2..]\n\
+            set -l prev $PWD\n\
+            set -l cdfile (mktemp)\n\
+            cd \"$wsp_root\" 2>/dev/null; or cd $HOME; or return 1\n\
+            WSP_CD_FILE=$cdfile command $wsp_bin rename $args\n\
+            set -l rc $status\n\
+            if test -d \"$prev\"\n\
+                cd \"$prev\"\n\
+            else if test $rc -eq 0 -a -s $cdfile\n\
+                cd -- (cat $cdfile)\n\
+            end\n\
+            rm -f $cdfile\n\
+            return $rc\n\
 \n\
         case rm remove\n\
             set -l args $argv[2..]\n\
@@ -684,6 +735,58 @@ fn write_powershell(w: &mut dyn Write, bin_str: &str, wsp_root: &str) -> Result<
         "            if (Test-Path -LiteralPath $prev -PathType Container) {{"
     )?;
     writeln!(w, "                Set-Location -LiteralPath $prev")?;
+    writeln!(w, "            }}")?;
+    writeln!(
+        w,
+        "            if ($rc -ne 0) {{ $global:LASTEXITCODE = $rc }}"
+    )?;
+    writeln!(w, "        }}")?;
+    // See build_posix_rename: vacate so Windows can rename at all, then follow
+    // the workspace to wherever the binary says it went, but only if we were
+    // standing in it.
+    writeln!(w, "        'rename' {{")?;
+    writeln!(
+        w,
+        "            $restArgs = @($args | Select-Object -Skip 1)"
+    )?;
+    writeln!(w, "            $prev = $PWD.Path")?;
+    writeln!(
+        w,
+        "            $cdFile = [System.IO.Path]::GetTempFileName()"
+    )?;
+    writeln!(w, "            $env:WSP_CD_FILE = $cdFile")?;
+    writeln!(
+        w,
+        "            try {{ Set-Location -LiteralPath $wspRoot -ErrorAction Stop }}"
+    )?;
+    writeln!(
+        w,
+        "            catch {{ Set-Location -LiteralPath $HOME -ErrorAction SilentlyContinue }}"
+    )?;
+    writeln!(w, "            & $wspBin rename @restArgs")?;
+    writeln!(w, "            $rc = $LASTEXITCODE")?;
+    writeln!(
+        w,
+        "            Remove-Item Env:\\\\WSP_CD_FILE -ErrorAction SilentlyContinue"
+    )?;
+    writeln!(
+        w,
+        "            $dest = if (Test-Path -LiteralPath $cdFile) {{ (Get-Content -LiteralPath $cdFile -Raw) }} else {{ '' }}"
+    )?;
+    writeln!(
+        w,
+        "            Remove-Item -LiteralPath $cdFile -ErrorAction SilentlyContinue"
+    )?;
+    writeln!(
+        w,
+        "            if (Test-Path -LiteralPath $prev -PathType Container) {{"
+    )?;
+    writeln!(w, "                Set-Location -LiteralPath $prev")?;
+    writeln!(
+        w,
+        "            }} elseif ($rc -eq 0 -and -not [string]::IsNullOrWhiteSpace($dest)) {{"
+    )?;
+    writeln!(w, "                Set-Location -LiteralPath $dest.Trim()")?;
     writeln!(w, "            }}")?;
     writeln!(
         w,
@@ -1629,5 +1732,180 @@ mod tests {
             "recover's subcommands changed — the wrapper's skip list \
              (ls/list/show) must be updated to match"
         );
+    }
+
+    /// Commands that cannot relocate or remove the directory the shell might be
+    /// standing in, and therefore need no wrapper case.
+    ///
+    /// This list exists so that adding a command forces a decision instead of a
+    /// default. See `test_every_command_is_classified`.
+    const NO_RELOCATION: &[&str] = &[
+        "completion",
+        "config",
+        "describe",
+        "diff",
+        "doctor",
+        "exec",
+        "help",
+        "init",
+        "log",
+        "ls",
+        "registry",
+        "setup",
+        "st",
+        "sync",
+        "template",
+        "whatsnew",
+    ];
+
+    /// Commands that *can* strand the shell but have no wrapper case yet.
+    /// Tracked, not forgotten.
+    const KNOWN_GAPS: &[&str] = &[
+        // `wsp repo rm` deletes a repo's directory. The wrapper dispatches on
+        // $1, so `repo` would need nested handling. See #115.
+        "repo",
+    ];
+
+    /// Case labels present in the generated posix wrapper.
+    fn posix_case_names(out: &str) -> Vec<String> {
+        let mut v = Vec::new();
+        for line in out.lines() {
+            let t = line.trim();
+            if let Some(pat) = t.strip_suffix(')')
+                && !pat.is_empty()
+                && pat != "*"
+                && !pat.contains(' ')
+            {
+                v.extend(pat.split('|').map(String::from));
+            }
+        }
+        v.sort();
+        v
+    }
+
+    /// Case labels present in the generated fish wrapper.
+    fn fish_case_names(out: &str) -> Vec<String> {
+        let mut v = Vec::new();
+        for line in out.lines() {
+            if let Some(rest) = line.trim().strip_prefix("case ") {
+                v.extend(
+                    rest.split_whitespace()
+                        .filter(|t| *t != "'*'")
+                        .map(String::from),
+                );
+            }
+        }
+        v.sort();
+        v
+    }
+
+    /// Case labels present in the generated PowerShell wrapper. Handles both
+    /// `'cd' {` and `{ $_ -in 'rm', 'remove' } {`.
+    fn ps_case_names(out: &str) -> Vec<String> {
+        let mut v = Vec::new();
+        for line in out.lines() {
+            let t = line.trim();
+            if !t.ends_with('{') {
+                continue;
+            }
+            if !(t.starts_with('\'') || t.starts_with("{ $_ -in")) {
+                continue;
+            }
+            let mut rest = t;
+            while let Some(i) = rest.find('\'') {
+                rest = &rest[i + 1..];
+                match rest.find('\'') {
+                    Some(j) => {
+                        v.push(rest[..j].to_string());
+                        rest = &rest[j + 1..];
+                    }
+                    None => break,
+                }
+            }
+        }
+        v.sort();
+        v
+    }
+
+    fn generated_posix() -> String {
+        output(|w| {
+            write_posix(
+                w,
+                "/usr/bin/wsp",
+                "/home/user/dev",
+                "zsh",
+                ShellHookOpts::default(),
+            )
+        })
+    }
+
+    /// The dialects must handle exactly the same set of commands.
+    ///
+    /// This is the #103 shape as a test: `create` was added to the posix wrapper
+    /// but the alias was missing everywhere, and nothing compared the dialects
+    /// to each other. A case added to one generator and forgotten in another is
+    /// now a failure rather than a platform-specific bug found by a user.
+    #[test]
+    fn test_dialects_cover_the_same_commands() {
+        let posix = posix_case_names(&generated_posix());
+        let fish = fish_case_names(&output(|w| {
+            write_fish(
+                w,
+                "/usr/bin/wsp",
+                "/home/user/dev",
+                ShellHookOpts::default(),
+            )
+        }));
+        let ps = ps_case_names(&output(|w| write_powershell(w, r"C:\wsp.exe", r"C:\dev")));
+
+        assert_eq!(
+            posix, fish,
+            "posix and fish wrappers handle different commands"
+        );
+        assert_eq!(
+            posix, ps,
+            "posix and powershell wrappers handle different commands"
+        );
+    }
+
+    /// Every top-level command must be accounted for: it either has a wrapper
+    /// case, is declared unable to relocate the shell's directory, or is a
+    /// tracked gap.
+    ///
+    /// This is the structural guard for the class of bug that produced #103,
+    /// #110, #111 and the `rename` bug. Each of those was a command that moved
+    /// or removed the directory the shell was in while the wrapper did nothing
+    /// or moved somewhere wrong — and each was found by someone noticing, not by
+    /// a test. Adding a command now fails this test until it is classified, so
+    /// "nobody thought about the wrapper" stops being a possible outcome.
+    ///
+    /// It also catches a subtler mistake: a case body written but never wired
+    /// into `build_posix_cases`, which is exactly how the `rename` fix failed
+    /// the first time. Names are read from the generated script, so an unwired
+    /// body does not count as coverage.
+    #[test]
+    fn test_every_command_is_classified() {
+        let wrapper_cases = posix_case_names(&generated_posix());
+
+        for sub in crate::cli::build_cli().get_subcommands() {
+            let mut names = vec![sub.get_name().to_string()];
+            names.extend(sub.get_visible_aliases().map(String::from));
+
+            let classified = names.iter().any(|n| {
+                wrapper_cases.contains(n)
+                    || NO_RELOCATION.contains(&n.as_str())
+                    || KNOWN_GAPS.contains(&n.as_str())
+            });
+            assert!(
+                classified,
+                "command `wsp {}` is unclassified. If it can move or remove the \
+                 directory the shell is standing in, give it a wrapper case in \
+                 build_posix_cases / write_fish / write_powershell and add a row \
+                 to STRAND_CASES in tests/shell_cd.rs. If it cannot, add it to \
+                 NO_RELOCATION. Aliases checked: {:?}",
+                sub.get_name(),
+                names,
+            );
+        }
     }
 }

--- a/crates/wsp/src/cli/completion.rs
+++ b/crates/wsp/src/cli/completion.rs
@@ -313,7 +313,7 @@ fn build_posix_rename() -> String {
      \x20     local _wsp_prev=\"$PWD\" _wsp_cd _wsp_rc\n\
      \x20     _wsp_cd=$(mktemp) || return\n\
      \x20     cd \"$wsp_root\" 2>/dev/null || cd \"$HOME\" || return\n\
-     \x20     WSP_CD_FILE=\"$_wsp_cd\" command \"$wsp_bin\" rename \"$@\"\n\
+     \x20     WSP_PWD=\"$_wsp_prev\" WSP_CD_FILE=\"$_wsp_cd\" command \"$wsp_bin\" rename \"$@\"\n\
      \x20     _wsp_rc=$?\n\
      \x20     if [[ -d \"$_wsp_prev\" ]]; then\n\
      \x20       cd \"$_wsp_prev\"\n\
@@ -499,7 +499,7 @@ function wsp\n\
             set -l prev $PWD\n\
             set -l cdfile (mktemp)\n\
             cd \"$wsp_root\" 2>/dev/null; or cd $HOME; or return 1\n\
-            WSP_CD_FILE=$cdfile command $wsp_bin rename $args\n\
+            WSP_PWD=$prev WSP_CD_FILE=$cdfile command $wsp_bin rename $args\n\
             set -l rc $status\n\
             if test -d \"$prev\"\n\
                 cd \"$prev\"\n\
@@ -763,11 +763,12 @@ fn write_powershell(w: &mut dyn Write, bin_str: &str, wsp_root: &str) -> Result<
         w,
         "            catch {{ Set-Location -LiteralPath $HOME -ErrorAction SilentlyContinue }}"
     )?;
+    writeln!(w, "            $env:WSP_PWD = $prev")?;
     writeln!(w, "            & $wspBin rename @restArgs")?;
     writeln!(w, "            $rc = $LASTEXITCODE")?;
     writeln!(
         w,
-        "            Remove-Item Env:\\\\WSP_CD_FILE -ErrorAction SilentlyContinue"
+        "            Remove-Item Env:\\WSP_CD_FILE -ErrorAction SilentlyContinue"
     )?;
     writeln!(
         w,

--- a/crates/wsp/src/cli/rename.rs
+++ b/crates/wsp/src/cli/rename.rs
@@ -83,6 +83,12 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
     }
 
     let new_dir = workspace::dir(&paths.workspaces_dir, &new_name);
+
+    // Tell the shell wrapper where the workspace went. Without this a shell
+    // standing inside the renamed workspace is left with a $PWD naming a path
+    // that no longer exists.
+    crate::shellcd::request(&new_dir);
+
     let new_branch = results
         .first()
         .map(|r| r.new_branch.as_str())

--- a/crates/wsp/src/cli/rename.rs
+++ b/crates/wsp/src/cli/rename.rs
@@ -52,7 +52,10 @@ fn detect_workspace_name(cwd: &std::path::Path) -> Result<String> {
 fn resolve_names(matches: &ArgMatches) -> Result<(String, String)> {
     let first = matches.get_one::<String>("old").unwrap();
     let second = matches.get_one::<String>("new");
-    let cwd = std::env::current_dir()?;
+    // Via invocation_dir: the wrapper vacates before running rename, so the
+    // process cwd is the workspaces root rather than where the user was. Both
+    // the bare form and `.` resolve the old name from here.
+    let cwd = crate::shellcd::invocation_dir()?;
 
     match second {
         Some(new_name) => {

--- a/crates/wsp/tests/shell_cd.rs
+++ b/crates/wsp/tests/shell_cd.rs
@@ -236,6 +236,39 @@ const SCENARIOS: &[Scenario] = &[
         expect: Expect::Root,
     },
     Scenario {
+        name: "rename follows the workspace we are in",
+        setup: &[&["new", "w", "--empty"]],
+        start: Start::Ws("w"),
+        cmd: &["rename", "w", "renamed"],
+        expect: Expect::Ws("renamed"),
+    },
+    Scenario {
+        // Renaming a workspace we are NOT in must not move us — guards a
+        // wrapper that follows the destination unconditionally.
+        name: "rename of another workspace does not move the shell",
+        setup: &[&["new", "w", "--empty"]],
+        start: Start::Root,
+        cmd: &["rename", "w", "renamed"],
+        expect: Expect::Unchanged,
+    },
+    Scenario {
+        // Bare form, documented in rename's long_about: old name omitted and
+        // resolved from the cwd the wrapper vacated from.
+        name: "bare rename resolves the old name from the cwd",
+        setup: &[&["new", "w", "--empty"]],
+        start: Start::Ws("w"),
+        cmd: &["rename", "renamed"],
+        expect: Expect::Ws("renamed"),
+    },
+    Scenario {
+        // `.` as the old name, also documented, also cwd-resolved.
+        name: "rename dot resolves the current workspace",
+        setup: &[&["new", "w", "--empty"]],
+        start: Start::Ws("w"),
+        cmd: &["rename", ".", "renamed"],
+        expect: Expect::Ws("renamed"),
+    },
+    Scenario {
         // Prefix hazard: removing `w` while standing in `w-extra` must leave the
         // shell alone. Previously guarded by asserting the wrapper's comparison
         // required a separator; now that there is no comparison at all, assert
@@ -366,6 +399,20 @@ fn apply_env(cmd: &mut Command, env: &Env) {
     // under the redirected data dir, so no suppression is needed.
 }
 
+/// Resolve a `Start` to a real directory, creating the subdirectory when the
+/// case asks to begin deeper than the workspace root.
+fn resolve_start(env: &Env, start: &Start) -> PathBuf {
+    match start {
+        Start::Root => env.ws_root.clone(),
+        Start::Ws(n) => env.ws_root.join(n),
+        Start::WsSub(n, sub) => {
+            let p = env.ws_root.join(n).join(sub);
+            std::fs::create_dir_all(&p).expect("create start subdir");
+            p
+        }
+    }
+}
+
 /// Run the binary directly, no shell. Used for fixture setup.
 fn run_setup(env: &Env, args: &[&str]) {
     let mut cmd = Command::new(WSP);
@@ -472,15 +519,7 @@ fn shell_wrapper_cd_behavior_matches_across_shells() {
                 run_setup(&env, args);
             }
 
-            let start = match sc.start {
-                Start::Root => env.ws_root.clone(),
-                Start::Ws(n) => env.ws_root.join(n),
-                Start::WsSub(n, sub) => {
-                    let p = env.ws_root.join(n).join(sub);
-                    std::fs::create_dir_all(&p).expect("create start subdir");
-                    p
-                }
-            };
+            let start = resolve_start(&env, &sc.start);
             let expected = match sc.expect {
                 Expect::Root => env.ws_root.clone(),
                 Expect::Ws(n) => env.ws_root.join(n),
@@ -609,6 +648,12 @@ const EXIT_CASES: &[ExitCase] = &[
         want: 0,
     },
     ExitCase {
+        what: "successful rename",
+        setup: &[&["new", "w", "--empty"]],
+        argv: &["rename", "w", "renamed"],
+        want: 0,
+    },
+    ExitCase {
         what: "successful recover",
         setup: &[&["new", "w", "--empty"], &["rm", "w", "--force"]],
         argv: &["recover", "w"],
@@ -718,14 +763,13 @@ const STRAND_CASES: &[StrandCase] = &[
 
 /// The shell must never be left in a directory that no longer exists.
 ///
-/// This is deliberately weaker than the scenario table: it does not care *where*
-/// the shell lands, only that the destination is real. That weakness is the
-/// point. Every bug in this area — #103, #110, #111, and `rename` — was a
-/// command that relocated the directory the shell was standing in while the
-/// wrapper either did nothing or moved somewhere wrong. Enumerating the correct
-/// destination per command is how those were missed; this asserts the one
-/// property all of them share, so a command nobody thought to add a scenario for
-/// still cannot strand the shell.
+/// Deliberately weaker than the scenario table: it does not care *where* the
+/// shell lands, only that the destination is real. That weakness is the point.
+/// Every bug in this area was a command that relocated the directory the shell
+/// was standing in while the wrapper either did nothing or moved somewhere
+/// wrong. Enumerating the correct destination per command is how those were
+/// missed; this asserts the one property all of them share, so a command nobody
+/// thought to add a scenario for still cannot strand the shell.
 ///
 /// A stranded shell is not cosmetic. `$PWD` names a path that is gone, so
 /// anything resolving it fails, and on Windows the relocation itself fails
@@ -780,15 +824,7 @@ fn wrapper_does_not_change_command_outcomes() {
             for args in case.setup {
                 run_setup(&env, args);
             }
-            let start = match case.start {
-                Start::Root => env.ws_root.clone(),
-                Start::Ws(n) => env.ws_root.join(n),
-                Start::WsSub(n, sub) => {
-                    let p = env.ws_root.join(n).join(sub);
-                    std::fs::create_dir_all(&p).expect("create start subdir");
-                    p
-                }
-            };
+            let start = resolve_start(&env, &case.start);
 
             let (pwd, stderr) = run_in_shell(shell, &env, &start, case.cmd);
             ran += 1;
@@ -809,7 +845,41 @@ fn wrapper_does_not_change_command_outcomes() {
         ran > 0,
         "no shell available to test the stranding invariant"
     );
+}
 
+/// Run the binary directly, with `cwd` as the working directory, and return its
+/// exit status. No shell, no wrapper.
+fn status_direct(env: &Env, cwd: &Path, cmd: &[&str]) -> i32 {
+    let mut c = Command::new(WSP);
+    apply_env(&mut c, env);
+    let out = c
+        .args(cmd)
+        .current_dir(cwd)
+        .output()
+        .expect("spawn wsp directly");
+    out.status.code().unwrap_or(-1)
+}
+
+/// The wrapper must not change *what* a command does — only where the shell
+/// ends up.
+///
+/// This is the general form of the bug that made `wsp rm --force --yes` and
+/// `wsp rename <new>` fail: the wrapper vacates before invoking, which silently
+/// removed the cwd both commands' optional-positional fallback reads. Every row
+/// in the scenario table passed an explicit workspace name, so nothing noticed.
+///
+/// Rather than enumerate argument forms — which is what missed it — this runs
+/// each scenario twice from the same starting directory, once through the
+/// wrapper and once against the binary directly, and requires the same exit
+/// status. Any future interposition that changes what a command sees fails here
+/// without anyone having to predict which form it breaks.
+#[test]
+fn wrapper_does_not_change_command_outcomes() {
+    let mut ran = 0usize;
+    for shell in SHELLS {
+        if !is_installed(shell) {
+            continue;
+        }
         for sc in SCENARIOS {
             // Fresh fixture per side: these commands mutate state.
             let mut codes = Vec::new();
@@ -818,15 +888,7 @@ fn wrapper_does_not_change_command_outcomes() {
                 for args in sc.setup {
                     run_setup(&env, args);
                 }
-                let start = match sc.start {
-                    Start::Root => env.ws_root.clone(),
-                    Start::Ws(n) => env.ws_root.join(n),
-                    Start::WsSub(n, sub) => {
-                        let p = env.ws_root.join(n).join(sub);
-                        std::fs::create_dir_all(&p).expect("create start subdir");
-                        p
-                    }
-                };
+                let start = resolve_start(&env, &sc.start);
                 codes.push(if wrapped {
                     status_in_shell(shell, &env, &start, sc.cmd)
                 } else {

--- a/crates/wsp/tests/shell_cd.rs
+++ b/crates/wsp/tests/shell_cd.rs
@@ -674,6 +674,65 @@ fn shell_wrapper_preserves_exit_status() {
     assert!(ran > 0, "no shell available to test exit statuses");
 }
 
+// ---------------------------------------------------------------------------
+// The invariant
+// ---------------------------------------------------------------------------
+
+/// A command that moves or deletes a workspace directory, run from inside it.
+struct StrandCase {
+    what: &'static str,
+    setup: &'static [&'static [&'static str]],
+    start: Start,
+    cmd: &'static [&'static str],
+}
+
+/// Every command that relocates or removes the directory the shell is standing
+/// in. Add a row here when a new one appears — that is the whole maintenance
+/// burden, and it is what the scenario table above cannot enforce.
+const STRAND_CASES: &[StrandCase] = &[
+    StrandCase {
+        what: "rm removes the workspace we are in",
+        setup: &[&["new", "w", "--empty"]],
+        start: Start::Ws("w"),
+        cmd: &["rm", "w", "--force"],
+    },
+    StrandCase {
+        what: "rm removes it while we are deeper inside",
+        setup: &[&["new", "w", "--empty"]],
+        start: Start::WsSub("w", "nested/deeper"),
+        cmd: &["rm", "w", "--force"],
+    },
+    StrandCase {
+        what: "rename moves the workspace we are in",
+        setup: &[&["new", "w", "--empty"]],
+        start: Start::Ws("w"),
+        cmd: &["rename", "w", "renamed"],
+    },
+    StrandCase {
+        what: "rename moves it while we are deeper inside",
+        setup: &[&["new", "w", "--empty"]],
+        start: Start::WsSub("w", "nested"),
+        cmd: &["rename", "w", "renamed"],
+    },
+];
+
+/// The shell must never be left in a directory that no longer exists.
+///
+/// This is deliberately weaker than the scenario table: it does not care *where*
+/// the shell lands, only that the destination is real. That weakness is the
+/// point. Every bug in this area — #103, #110, #111, and `rename` — was a
+/// command that relocated the directory the shell was standing in while the
+/// wrapper either did nothing or moved somewhere wrong. Enumerating the correct
+/// destination per command is how those were missed; this asserts the one
+/// property all of them share, so a command nobody thought to add a scenario for
+/// still cannot strand the shell.
+///
+/// A stranded shell is not cosmetic. `$PWD` names a path that is gone, so
+/// anything resolving it fails, and on Windows the relocation itself fails
+/// because a live process's cwd cannot be renamed or deleted.
+#[test]
+fn shell_wrapper_never_strands_the_shell() {
+
 /// Run the binary directly, with `cwd` as the working directory, and return its
 /// exit status. No shell, no wrapper.
 fn status_direct(env: &Env, cwd: &Path, cmd: &[&str]) -> i32 {
@@ -716,6 +775,41 @@ fn wrapper_does_not_change_command_outcomes() {
         if !is_installed(shell) {
             continue;
         }
+        for case in STRAND_CASES {
+            let env = make_env();
+            for args in case.setup {
+                run_setup(&env, args);
+            }
+            let start = match case.start {
+                Start::Root => env.ws_root.clone(),
+                Start::Ws(n) => env.ws_root.join(n),
+                Start::WsSub(n, sub) => {
+                    let p = env.ws_root.join(n).join(sub);
+                    std::fs::create_dir_all(&p).expect("create start subdir");
+                    p
+                }
+            };
+
+            let (pwd, stderr) = run_in_shell(shell, &env, &start, case.cmd);
+            ran += 1;
+            assert!(
+                pwd.is_dir(),
+                "shell={} case={:?} cmd=`wsp {}`\n  \
+                 the shell was left in a directory that does not exist: {}\n  \
+                 command stderr: {}",
+                shell.bin,
+                case.what,
+                case.cmd.join(" "),
+                pwd.display(),
+                if stderr.is_empty() { "<none>" } else { &stderr },
+            );
+        }
+    }
+    assert!(
+        ran > 0,
+        "no shell available to test the stranding invariant"
+    );
+
         for sc in SCENARIOS {
             // Fresh fixture per side: these commands mutate state.
             let mut codes = Vec::new();

--- a/crates/wsp/tests/shell_cd.rs
+++ b/crates/wsp/tests/shell_cd.rs
@@ -776,44 +776,6 @@ const STRAND_CASES: &[StrandCase] = &[
 /// because a live process's cwd cannot be renamed or deleted.
 #[test]
 fn shell_wrapper_never_strands_the_shell() {
-
-/// Run the binary directly, with `cwd` as the working directory, and return its
-/// exit status. No shell, no wrapper.
-fn status_direct(env: &Env, cwd: &Path, cmd: &[&str]) -> i32 {
-    let mut c = Command::new(WSP);
-    apply_env(&mut c, env);
-    let out = c
-        .args(cmd)
-        .current_dir(cwd)
-        .output()
-        .expect("spawn wsp directly");
-    out.status.code().unwrap_or(-1)
-}
-
-/// The wrapper must never break a command that works without it.
-///
-/// This is the general form of the bug that made `wsp rm --force --yes` fail:
-/// the wrapper vacates before invoking, which silently removed the cwd that the
-/// optional-positional fallback reads. Every row in the scenario table passed an
-/// explicit workspace name, so nothing noticed. Rather than enumerate argument
-/// forms — which is what missed it — this runs each scenario twice from the same
-/// starting directory, once through the wrapper and once against the binary
-/// directly, so a future interposition fails here without anyone predicting
-/// which form it breaks.
-///
-/// The assertion is one-directional, and the direction matters. It would be
-/// wrong to require the same exit status: on Windows the wrapper legitimately
-/// *rescues* commands. `wsp rm w --force` from inside `w` fails when run
-/// directly, because a directory that is a live process's cwd cannot be
-/// renamed — and succeeds through the wrapper, because vacating first is
-/// exactly what the vacate step is for. CI demonstrated this (wrapped exit 0,
-/// direct exit 1), which is also the first hard confirmation of that Windows
-/// behavior in this repo; it had only been inferred from a code comment.
-///
-/// So: success without the wrapper implies success with it. The reverse is
-/// allowed and, on Windows, is the whole point.
-#[test]
-fn wrapper_does_not_change_command_outcomes() {
     let mut ran = 0usize;
     for shell in SHELLS {
         if !is_installed(shell) {
@@ -860,19 +822,28 @@ fn status_direct(env: &Env, cwd: &Path, cmd: &[&str]) -> i32 {
     out.status.code().unwrap_or(-1)
 }
 
-/// The wrapper must not change *what* a command does — only where the shell
-/// ends up.
+/// The wrapper must never break a command that works without it.
 ///
 /// This is the general form of the bug that made `wsp rm --force --yes` and
 /// `wsp rename <new>` fail: the wrapper vacates before invoking, which silently
 /// removed the cwd both commands' optional-positional fallback reads. Every row
 /// in the scenario table passed an explicit workspace name, so nothing noticed.
-///
 /// Rather than enumerate argument forms — which is what missed it — this runs
 /// each scenario twice from the same starting directory, once through the
-/// wrapper and once against the binary directly, and requires the same exit
-/// status. Any future interposition that changes what a command sees fails here
-/// without anyone having to predict which form it breaks.
+/// wrapper and once against the binary directly, so a future interposition
+/// fails here without anyone predicting which form it breaks.
+///
+/// The assertion is one-directional, and the direction matters. It would be
+/// wrong to require the same exit status: on Windows the wrapper legitimately
+/// *rescues* commands. `wsp rm w --force` from inside `w` fails when run
+/// directly, because a directory that is a live process's cwd cannot be
+/// renamed — and succeeds through the wrapper, because vacating first is
+/// exactly what the vacate step is for. CI demonstrated this (wrapped exit 0,
+/// direct exit 1), which is also the first hard confirmation of that Windows
+/// behavior in this repo; it had only been inferred from a code comment.
+///
+/// So: success without the wrapper implies success with it. The reverse is
+/// allowed and, on Windows, is the whole point.
 #[test]
 fn wrapper_does_not_change_command_outcomes() {
     let mut ran = 0usize;


### PR DESCRIPTION
Fixes a shipped bug, and adds the structural guards that would have caught it.

## The bug

`wsp rename` moves the workspace directory, and the wrapper had **no case for it at all** — every occurrence of "rename" in `completion.rs` was tmux `rename-window`.

```
$ cd ~/dev/workspaces/old && wsp rename old new
Renamed workspace "old" -> "new"
$ [[ -d $PWD ]] || echo stranded
stranded
```

`ls` still appears to work because the shell holds a descriptor on the moved inode, but `$PWD` names a path that is gone.

**On Windows it is worse than a stale `$PWD`**: a directory that is a live process's cwd cannot be renamed, so `wsp rename` from inside the workspace fails outright — the same failure #111 fixed for `rm`. Shipped since **v0.14.0**.

## The fix

Composes both mechanisms already here:

- **Vacate first** (`rm`'s step), because only the shell can move itself and it must do so before the binary runs.
- **Then follow the destination** via `WSP_CD_FILE` (`new`'s mechanism), because `rename`'s workspace argument is an *optional* positional with CWD-detection fallback — there is no reliable way to derive the new path from argv.
- If the old directory survives, we were never inside it (or it failed), so return and nothing appears to move.

Landing at the new workspace root loses a subdirectory position (`<ws>/sub` → `<ws-new>`). Reconstructing the relative subpath is possible; it did not seem worth the shell complexity.

## Three structural guards

Every instance of this bug class so far was caught by a person, not a test:

| Guard | Catches |
|---|---|
| `shell_wrapper_never_strands_the_shell` | the one property all of them violated — the shell is left in a directory that does not exist |
| `test_every_command_is_classified` | a command with no wrapper case, **read from the generated script** so an unwired body does not count |
| `test_dialects_cover_the_same_commands` | a case present in one dialect and missing in another — this is #103 as a test |

The stranding invariant is deliberately weaker than the scenario table: it does not check *where* the shell lands. That weakness is the point — enumerating the correct destination per command is exactly how these were missed.

The second guard earned its keep immediately: **my first attempt at this fix defined `build_posix_rename` and never wired it into `build_posix_cases`**, and nothing noticed until the guard read case names out of the generated output.

All four mutations fail as intended: unwiring the rename case, dropping it from fish alone, dropping it from powershell alone, and adding an unclassified command.

## Known gap

`wsp repo rm` deletes a repo directory and can strand a shell the same way. The wrapper dispatches on `$1`, so `repo` needs nested handling — recorded in `KNOWN_GAPS` and tracked in #115 rather than fixed here.

Stacked on #114.

Refs #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)