### PR TITLE
refactor(completion): declare shell navigation on the command itself

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ homepage   = "https://github.com/jganoff/wsp"
 [workspace.dependencies]
 anyhow        = "1"
 chrono        = { version = "0.4", features = ["serde"] }
-clap          = { version = "4", features = ["derive"] }
+clap          = { version = "4", features = ["derive", "unstable-ext"] }  # unstable-ext needed for Command::add/get (ShellNav); may change in patch releases
 clap_complete = { version = "4", features = ["unstable-dynamic"] }  # unstable-dynamic needed for dynamic completion; may change in patch releases
 ctrlc         = "3"
 dirs          = "6"

--- a/crates/wsp/src/cli/cd.rs
+++ b/crates/wsp/src/cli/cd.rs
@@ -10,6 +10,8 @@ use super::completers;
 
 pub fn cmd() -> Command {
     Command::new("cd")
+        // Destination arrives on stdout, gated on WSP_SHELL.
+        .add(crate::shellnav::ShellNav::prints_path())
         .about("Change directory into a workspace")
         .long_about(
             "Change directory into a workspace.\n\n\

--- a/crates/wsp/src/cli/cfg.rs
+++ b/crates/wsp/src/cli/cfg.rs
@@ -16,6 +16,7 @@ use wsp_core::workspace;
 
 pub fn cmd() -> Command {
     Command::new("config")
+        .add(crate::shellnav::ShellNav::none())
         .about("Manage wsp settings")
         .long_about(
             "Manage wsp settings.\n\n\

--- a/crates/wsp/src/cli/completion.rs
+++ b/crates/wsp/src/cli/completion.rs
@@ -281,17 +281,15 @@ fn build_posix_cd_into(cmd_name: &str) -> String {
     )
 }
 
-/// Shell body for `wsp recover <name>`: run the command, then cd into the
-/// restored workspace. Only cds when the first argument is a plain workspace
-/// name (not a subcommand like `ls`/`show` or a flag).
+/// Shell body for `wsp recover`: cd to whatever the binary reports.
+///
+/// This used to derive the workspace name from `$1` and hardcode a skip list
+/// for the `ls`/`list`/`show` subcommands. It no longer needs either: only the
+/// restore path calls `cd_request`, so the read-only subcommands report nothing
+/// and the wrapper moves nowhere. That deletes the skip list, the argv scan, and
+/// the test that guarded both.
 fn build_posix_recover() -> String {
-    "shift\n\
-     \x20     command \"$wsp_bin\" recover \"$@\" || return\n\
-     \x20     local _wsp_name=\"$1\"\n\
-     \x20     if [[ -n \"$_wsp_name\" && \"$_wsp_name\" != ls && \"$_wsp_name\" != list && \"$_wsp_name\" != show && \"$_wsp_name\" != -* ]]; then\n\
-     \x20       cd \"$wsp_root/$_wsp_name\"\n\
-     \x20     fi"
-        .to_string()
+    build_posix_cd_into("recover")
 }
 
 /// Shell body for `wsp rename`: vacate, rename, then follow the workspace to
@@ -523,11 +521,14 @@ function wsp\n\
 \n\
         case recover\n\
             set -l args $argv[2..]\n\
-            command $wsp_bin recover $args; or return\n\
-            set -l _wsp_name $args[1]\n\
-            if test -n \"$_wsp_name\"; and not string match -qr '^(ls|list|show|-.*)$' -- \"$_wsp_name\"\n\
-                cd \"$wsp_root/$_wsp_name\"\n\
+            set -l cdfile (mktemp)\n\
+            WSP_CD_FILE=$cdfile command $wsp_bin recover $args\n\
+            set -l rc $status\n\
+            if test $rc -eq 0 -a -s $cdfile\n\
+                cd -- (cat $cdfile)\n\
             end\n\
+            rm -f $cdfile\n\
+            return $rc\n\
 \n\
         case '*'\n\
             command $wsp_bin $argv\n\
@@ -795,30 +796,43 @@ fn write_powershell(w: &mut dyn Write, bin_str: &str, wsp_root: &str) -> Result<
         "            if ($rc -ne 0) {{ $global:LASTEXITCODE = $rc }}"
     )?;
     writeln!(w, "        }}")?;
+    // Same WSP_CD_FILE form as `new`: only recover's restore path reports a
+    // destination, so `recover ls` / `recover show` move nothing and the wrapper
+    // needs no skip list.
     writeln!(w, "        'recover' {{")?;
     writeln!(
         w,
         "            $restArgs = @($args | Select-Object -Skip 1)"
     )?;
+    writeln!(
+        w,
+        "            $cdFile = [System.IO.Path]::GetTempFileName()"
+    )?;
+    writeln!(w, "            $env:WSP_CD_FILE = $cdFile")?;
     writeln!(w, "            & $wspBin recover @restArgs")?;
+    writeln!(w, "            $rc = $LASTEXITCODE")?;
     writeln!(
         w,
-        "            if ($LASTEXITCODE -eq 0 -and $restArgs.Count -gt 0) {{"
+        "            Remove-Item Env:\\WSP_CD_FILE -ErrorAction SilentlyContinue"
     )?;
-    writeln!(w, "                $wspName = $null")?;
-    writeln!(w, "                foreach ($a in $restArgs) {{")?;
     writeln!(
         w,
-        "                    if (-not $a.StartsWith('-') -and $a -notin 'ls', 'list', 'show') {{ $wspName = $a; break }}"
+        "            $dest = if (Test-Path -LiteralPath $cdFile) {{ (Get-Content -LiteralPath $cdFile -Raw) }} else {{ '' }}"
     )?;
-    writeln!(w, "                }}")?;
-    writeln!(w, "                if ($wspName) {{")?;
     writeln!(
         w,
-        "                    Set-Location (Join-Path $wspRoot $wspName)"
+        "            Remove-Item -LiteralPath $cdFile -ErrorAction SilentlyContinue"
     )?;
-    writeln!(w, "                }}")?;
+    writeln!(
+        w,
+        "            if ($rc -eq 0 -and -not [string]::IsNullOrWhiteSpace($dest)) {{"
+    )?;
+    writeln!(w, "                Set-Location -LiteralPath $dest.Trim()")?;
     writeln!(w, "            }}")?;
+    writeln!(
+        w,
+        "            if ($rc -ne 0) {{ $global:LASTEXITCODE = $rc }}"
+    )?;
     writeln!(w, "        }}")?;
     writeln!(w, "        default {{")?;
     writeln!(w, "            & $wspBin @args")?;
@@ -929,9 +943,11 @@ mod tests {
                 "case {}: wsp_root should be single-quoted",
                 tc.name
             );
-            // wsp_root should be referenced as $wsp_root, not interpolated
+            // wsp_root should be referenced as $wsp_root, not interpolated.
+            // No trailing slash: nothing builds "$wsp_root/<name>" any more, the
+            // wrapper only cds to the root itself.
             assert!(
-                out.contains("$wsp_root/"),
+                out.contains("$wsp_root"),
                 "case {}: wsp_root should be referenced as variable",
                 tc.name
             );
@@ -983,29 +999,6 @@ mod tests {
     }
 
     #[test]
-    fn test_posix_recover_cds_into_workspace() {
-        let out = output(|w| {
-            write_posix(
-                w,
-                "/usr/bin/wsp",
-                "/home/user/dev",
-                "zsh",
-                ShellHookOpts::default(),
-            )
-        });
-        assert!(out.contains("recover)"), "recover case must be present");
-        assert!(
-            out.contains("cd \"$wsp_root/$_wsp_name\""),
-            "recover must cd into restored workspace"
-        );
-        // Must guard against subcommands
-        assert!(
-            out.contains("ls") && out.contains("show"),
-            "recover must skip cd for ls/show subcommands"
-        );
-    }
-
-    #[test]
     fn test_fish_contains_all_cases() {
         let out = output(|w| {
             write_fish(
@@ -1024,27 +1017,6 @@ mod tests {
         ] {
             assert!(out.contains(pattern), "missing case pattern: {}", pattern);
         }
-    }
-
-    #[test]
-    fn test_fish_recover_cds_into_workspace() {
-        let out = output(|w| {
-            write_fish(
-                w,
-                "/usr/bin/wsp",
-                "/home/user/dev",
-                ShellHookOpts::default(),
-            )
-        });
-        assert!(out.contains("case recover"), "recover case must be present");
-        assert!(
-            out.contains("cd \"$wsp_root/$_wsp_name\""),
-            "recover must cd into restored workspace"
-        );
-        assert!(
-            out.contains("ls|list|show"),
-            "recover must skip cd for ls/list/show subcommands"
-        );
     }
 
     #[test]
@@ -1121,7 +1093,7 @@ mod tests {
             "wsp_root should be single-quoted"
         );
         assert!(
-            out.contains("$wsp_root/"),
+            out.contains("$wsp_root"),
             "wsp_root should be referenced as variable"
         );
         assert!(
@@ -1466,7 +1438,7 @@ mod tests {
     /// asserts the argv derivation is gone from every dialect, not merely that
     /// one spelling of it is absent.
     #[test]
-    fn test_new_takes_destination_from_binary() {
+    fn test_destination_comes_from_binary() {
         let posix = output(|w| {
             write_posix(
                 w,
@@ -1505,6 +1477,38 @@ mod tests {
         );
 
         let pwsh = output(|w| write_powershell(w, r"C:\wsp.exe", r"C:\dev"));
+        // recover now uses the same mechanism, so its old argv scan and
+        // ls/list/show skip list must be gone from every dialect.
+        let posix_recover = case_body(&posix, "    recover)", "    *)");
+        assert!(
+            posix_recover.contains("WSP_CD_FILE"),
+            "posix recover must pass WSP_CD_FILE"
+        );
+        assert!(
+            !posix_recover.contains("!= ls"),
+            "posix recover must not keep a subcommand skip list"
+        );
+
+        let fish_recover = case_body(&fish, "case recover", "case '*'");
+        assert!(
+            fish_recover.contains("WSP_CD_FILE"),
+            "fish recover must pass WSP_CD_FILE"
+        );
+        assert!(
+            !fish_recover.contains("ls|list|show"),
+            "fish recover must not keep a subcommand skip list"
+        );
+
+        let pwsh_recover = case_body(&pwsh, "'recover' {", "default {");
+        assert!(
+            pwsh_recover.contains("$env:WSP_CD_FILE"),
+            "powershell recover must pass WSP_CD_FILE"
+        );
+        assert!(
+            !pwsh_recover.contains("$wspName"),
+            "powershell recover must not scan argv"
+        );
+
         let pwsh_new = case_body(&pwsh, "$_ -in 'new', 'create'", "'cd' {");
         assert!(
             pwsh_new.contains("$env:WSP_CD_FILE"),
@@ -1552,28 +1556,6 @@ mod tests {
         assert!(
             out.contains("CompletionResult"),
             "scriptblock must return CompletionResult objects"
-        );
-    }
-
-    #[test]
-    fn test_ps_recover_cds_into_workspace() {
-        let out = output(|w| write_powershell(w, r"C:\wsp.exe", r"C:\dev"));
-        assert!(out.contains("'recover'"), "recover case must be present");
-        assert!(
-            out.contains("Set-Location (Join-Path $wspRoot $wspName)"),
-            "recover must cd into restored workspace"
-        );
-        assert!(
-            out.contains("ls") && out.contains("list") && out.contains("show"),
-            "recover must skip cd for ls/list/show subcommands"
-        );
-        assert!(
-            out.contains("$a.StartsWith('-')"),
-            "recover must skip cd for flag arguments"
-        );
-        assert!(
-            !out.contains("$wspName = $restArgs[0]"),
-            "recover must not use restArgs[0] directly (flags before workspace name would be used as workspace name)"
         );
     }
 
@@ -1672,67 +1654,6 @@ mod tests {
         assert!(
             ps_rm.contains("& $wspBin rm @restArgs"),
             "powershell: remove must normalize to rm"
-        );
-    }
-
-    /// The `recover` wrapper case reads `$1` as the workspace name, skipping the
-    /// subcommands it knows about. That is safe today, and this test fails if
-    /// either assumption behind it stops holding.
-    ///
-    /// `new` had exactly this shape and was silently wrong for years: posix read
-    /// `$1` positionally, PowerShell scanned for the first non-flag token, and
-    /// both mis-read `wsp new -w src new-ws`. `recover` escapes that only
-    /// because it has no flags that consume the following token, and because the
-    /// wrapper enumerates all of its subcommands. Neither is guaranteed by
-    /// anything but this test.
-    ///
-    /// If it fails, route `recover` through WSP_CD_FILE the way `new` does
-    /// rather than extending the scan — see #105.
-    #[test]
-    fn test_recover_wrapper_assumptions_hold() {
-        // build() populates the defaults clap computes lazily. Without it
-        // get_num_args() is None even for a flag that plainly takes a value,
-        // which made the first version of this assertion vacuous.
-        let mut cmd = crate::cli::recover::cmd();
-        cmd.build();
-
-        // 1. No flag may consume the token after it, or that value would be
-        //    mistaken for the workspace name. Positionals are exempt: the
-        //    positional *is* what the wrapper means to read.
-        //
-        //    Unknown arity counts as taking a value — fail closed, so a future
-        //    clap change cannot quietly turn this back into a no-op.
-        for arg in cmd.get_arguments() {
-            let takes_value = arg.get_num_args().map(|n| n.takes_values()).unwrap_or(true);
-            assert!(
-                arg.is_positional() || !takes_value,
-                "recover gained a value-taking flag (--{}), whose value the \
-                 wrapper will mistake for the workspace name",
-                arg.get_id()
-            );
-        }
-
-        // 2. The wrapper skips exactly ls/list/show. A new subcommand would be
-        //    treated as a workspace name and cd'd into.
-        // build() also injects clap's own `help` subcommand. It is excluded
-        // because it is not reachable as a subcommand here: recover's optional
-        // positional captures the token first, so `wsp recover help` errors with
-        // "no recoverable workspace named help" and the wrapper's `|| return`
-        // skips the cd. Verified by running it through the wrapper.
-        let mut subs: Vec<String> = Vec::new();
-        for sub in cmd.get_subcommands() {
-            if sub.get_name() == "help" {
-                continue;
-            }
-            subs.push(sub.get_name().to_string());
-            subs.extend(sub.get_visible_aliases().map(String::from));
-        }
-        subs.sort();
-        assert_eq!(
-            subs,
-            vec!["list".to_string(), "ls".to_string(), "show".to_string()],
-            "recover's subcommands changed — the wrapper's skip list \
-             (ls/list/show) must be updated to match"
         );
     }
 
@@ -1847,24 +1768,18 @@ mod tests {
     /// here, as does the reverse.
     #[test]
     fn test_shellnav_matches_wrapper_cases() {
-        let generated = output(|w| {
-            write_posix(
-                w,
-                "/usr/bin/wsp",
-                "/home/user/dev",
-                "zsh",
-                ShellHookOpts::default(),
-            )
-        });
-        let mut cases = posix_case_names(&generated);
-        cases.sort();
+        // posix_case_names already sorts.
+        let mut cases = posix_case_names(&generated_posix());
         cases.dedup();
 
         let mut declared: Vec<String> = Vec::new();
         for sub in crate::cli::build_cli().get_subcommands() {
+            // Declared gaps move the shell but have no wrapper case on
+            // purpose; they are excluded here rather than silently passing as
+            // safe.
             if sub
                 .get::<crate::shellnav::ShellNav>()
-                .is_some_and(|n| n.moves_shell())
+                .is_some_and(|n| n.moves_shell() && !n.is_unhandled_gap())
             {
                 declared.push(sub.get_name().to_string());
                 declared.extend(sub.get_visible_aliases().map(String::from));
@@ -1906,6 +1821,31 @@ mod tests {
              Add `.add(ShellNav::none())` if the command cannot move the shell's \
              directory, or the matching constructor if it can — and then give it a \
              wrapper case and a STRAND_CASES row in tests/shell_cd.rs."
+        );
+    }
+
+    /// `rename` must check the previous directory before the reported
+    /// destination.
+    ///
+    /// Both flags are set for `rename`, and the order is load-bearing: rendering
+    /// follow-first would teleport someone who ran `wsp rename w new` from
+    /// `$HOME` into a workspace they were never in, because `$HOME` survives and
+    /// a destination was reported. Nothing else pins this down, since `rename` is
+    /// the only command with both flags.
+    #[test]
+    fn test_rename_prefers_previous_over_destination() {
+        let generated = generated_posix();
+        let body = case_body(&generated, "    rename)", "    rm|remove)");
+        let prev_at = body
+            .find("-d \"$_wsp_prev\"")
+            .expect("rename must test the previous directory");
+        let dest_at = body
+            .find("-s \"$_wsp_cd\"")
+            .expect("rename must test the reported destination");
+        assert!(
+            prev_at < dest_at,
+            "rename must prefer the previous directory over the reported \
+             destination; found the destination check first:\n{body}"
         );
     }
 }

--- a/crates/wsp/src/cli/completion.rs
+++ b/crates/wsp/src/cli/completion.rs
@@ -37,6 +37,7 @@ impl ShellHookOpts {
 
 pub fn cmd() -> Command {
     Command::new("completion")
+        .add(crate::shellnav::ShellNav::none())
         .about("Output shell integration (completions + wrapper function) [read-only]")
         .long_about(
             "Output shell integration (completions + wrapper function) [read-only].\n\n\
@@ -1735,38 +1736,6 @@ mod tests {
         );
     }
 
-    /// Commands that cannot relocate or remove the directory the shell might be
-    /// standing in, and therefore need no wrapper case.
-    ///
-    /// This list exists so that adding a command forces a decision instead of a
-    /// default. See `test_every_command_is_classified`.
-    const NO_RELOCATION: &[&str] = &[
-        "completion",
-        "config",
-        "describe",
-        "diff",
-        "doctor",
-        "exec",
-        "help",
-        "init",
-        "log",
-        "ls",
-        "registry",
-        "setup",
-        "st",
-        "sync",
-        "template",
-        "whatsnew",
-    ];
-
-    /// Commands that *can* strand the shell but have no wrapper case yet.
-    /// Tracked, not forgotten.
-    const KNOWN_GAPS: &[&str] = &[
-        // `wsp repo rm` deletes a repo's directory. The wrapper dispatches on
-        // $1, so `repo` would need nested handling. See #115.
-        "repo",
-    ];
-
     /// Case labels present in the generated posix wrapper.
     fn posix_case_names(out: &str) -> Vec<String> {
         let mut v = Vec::new();
@@ -1869,47 +1838,6 @@ mod tests {
         );
     }
 
-    /// Every top-level command must be accounted for: it either has a wrapper
-    /// case, is declared unable to relocate the shell's directory, or is a
-    /// tracked gap.
-    ///
-    /// This is the structural guard for the class of bug that produced #103,
-    /// #110, #111 and the `rename` bug. Each of those was a command that moved
-    /// or removed the directory the shell was in while the wrapper did nothing
-    /// or moved somewhere wrong — and each was found by someone noticing, not by
-    /// a test. Adding a command now fails this test until it is classified, so
-    /// "nobody thought about the wrapper" stops being a possible outcome.
-    ///
-    /// It also catches a subtler mistake: a case body written but never wired
-    /// into `build_posix_cases`, which is exactly how the `rename` fix failed
-    /// the first time. Names are read from the generated script, so an unwired
-    /// body does not count as coverage.
-    #[test]
-    fn test_every_command_is_classified() {
-        let wrapper_cases = posix_case_names(&generated_posix());
-
-        for sub in crate::cli::build_cli().get_subcommands() {
-            let mut names = vec![sub.get_name().to_string()];
-            names.extend(sub.get_visible_aliases().map(String::from));
-
-            let classified = names.iter().any(|n| {
-                wrapper_cases.contains(n)
-                    || NO_RELOCATION.contains(&n.as_str())
-                    || KNOWN_GAPS.contains(&n.as_str())
-            });
-            assert!(
-                classified,
-                "command `wsp {}` is unclassified. If it can move or remove the \
-                 directory the shell is standing in, give it a wrapper case in \
-                 build_posix_cases / write_fish / write_powershell and add a row \
-                 to STRAND_CASES in tests/shell_cd.rs. If it cannot, add it to \
-                 NO_RELOCATION. Aliases checked: {:?}",
-                sub.get_name(),
-                names,
-            );
-        }
-    }
-
     /// The wrapper's cases and the commands' own declarations must agree.
     ///
     /// This is the payoff of declaring `ShellNav` on the command: there is no
@@ -1950,6 +1878,34 @@ mod tests {
             "commands declaring ShellNav and wrapper cases disagree.\n  \
              declared on commands: {declared:?}\n  \
              cases in the wrapper:  {cases:?}"
+        );
+    }
+
+    /// Every top-level command must declare how it affects the shell's cwd.
+    ///
+    /// Requiring an explicit declaration — including `ShellNav::none()` — is
+    /// what removes the hand-maintained exemption list this replaced. Absence
+    /// would be indistinguishable from "nobody thought about it", which is how
+    /// `wsp rename` shipped for five releases moving the workspace directory
+    /// with no wrapper case at all.
+    ///
+    /// Hidden commands are exempt: they are codegen helpers, not user surface.
+    #[test]
+    fn test_every_command_declares_shell_nav() {
+        let cli = crate::cli::build_cli();
+        let missing: Vec<&str> = cli
+            .get_subcommands()
+            .filter(|s| !s.is_hide_set())
+            .filter(|s| s.get::<crate::shellnav::ShellNav>().is_none())
+            .map(|s| s.get_name())
+            .collect();
+
+        assert!(
+            missing.is_empty(),
+            "these commands do not declare a ShellNav: {missing:?}\n  \
+             Add `.add(ShellNav::none())` if the command cannot move the shell's \
+             directory, or the matching constructor if it can — and then give it a \
+             wrapper case and a STRAND_CASES row in tests/shell_cd.rs."
         );
     }
 }

--- a/crates/wsp/src/cli/completion.rs
+++ b/crates/wsp/src/cli/completion.rs
@@ -1909,4 +1909,47 @@ mod tests {
             );
         }
     }
+
+    /// The wrapper's cases and the commands' own declarations must agree.
+    ///
+    /// This is the payoff of declaring `ShellNav` on the command: there is no
+    /// list to maintain here. A command that says it moves the shell must have a
+    /// wrapper case, and a wrapper case must correspond to a command that says
+    /// so. Adding a command with a `ShellNav` and forgetting the generator fails
+    /// here, as does the reverse.
+    #[test]
+    fn test_shellnav_matches_wrapper_cases() {
+        let generated = output(|w| {
+            write_posix(
+                w,
+                "/usr/bin/wsp",
+                "/home/user/dev",
+                "zsh",
+                ShellHookOpts::default(),
+            )
+        });
+        let mut cases = posix_case_names(&generated);
+        cases.sort();
+        cases.dedup();
+
+        let mut declared: Vec<String> = Vec::new();
+        for sub in crate::cli::build_cli().get_subcommands() {
+            if sub
+                .get::<crate::shellnav::ShellNav>()
+                .is_some_and(|n| n.moves_shell())
+            {
+                declared.push(sub.get_name().to_string());
+                declared.extend(sub.get_visible_aliases().map(String::from));
+            }
+        }
+        declared.sort();
+        declared.dedup();
+
+        assert_eq!(
+            declared, cases,
+            "commands declaring ShellNav and wrapper cases disagree.\n  \
+             declared on commands: {declared:?}\n  \
+             cases in the wrapper:  {cases:?}"
+        );
+    }
 }

--- a/crates/wsp/src/cli/delete.rs
+++ b/crates/wsp/src/cli/delete.rs
@@ -14,6 +14,9 @@ use super::completers;
 pub fn cmd() -> Command {
     Command::new("rm")
         .visible_alias("remove")
+        // Removes the workspace directory: step aside, then come back only if it
+        // survived (a blocked removal leaves it in place).
+        .add(crate::shellnav::ShellNav::vacates())
         .about("Remove a workspace")
         .long_about(
             "Remove a workspace.\n\n\

--- a/crates/wsp/src/cli/describe.rs
+++ b/crates/wsp/src/cli/describe.rs
@@ -11,6 +11,7 @@ use super::completers;
 
 pub fn cmd() -> Command {
     Command::new("describe")
+        .add(crate::shellnav::ShellNav::none())
         .about("Set or update a workspace description")
         .long_about(
             "Set or update a workspace description.\n\n\

--- a/crates/wsp/src/cli/diff.rs
+++ b/crates/wsp/src/cli/diff.rs
@@ -16,6 +16,7 @@ use super::completers;
 
 pub fn cmd() -> Command {
     Command::new("diff")
+        .add(crate::shellnav::ShellNav::none())
         .about("Show git diff across workspace repos [read-only]")
         .long_about(
             "Show git diff across workspace repos [read-only].\n\n\

--- a/crates/wsp/src/cli/doctor.rs
+++ b/crates/wsp/src/cli/doctor.rs
@@ -22,6 +22,7 @@ use wsp_core::workspace;
 
 pub fn cmd() -> Command {
     Command::new("doctor")
+        .add(crate::shellnav::ShellNav::none())
         .about("Check workspace and global state for problems")
         .long_about(
             "Check workspace and global state for problems.\n\n\

--- a/crates/wsp/src/cli/exec.rs
+++ b/crates/wsp/src/cli/exec.rs
@@ -13,6 +13,7 @@ use super::completers;
 
 pub fn cmd() -> Command {
     Command::new("exec")
+        .add(crate::shellnav::ShellNav::none())
         .about("Run a command in each repo of a workspace")
         .long_about(
             "Run a command in each repo of a workspace.\n\n\

--- a/crates/wsp/src/cli/help.rs
+++ b/crates/wsp/src/cli/help.rs
@@ -365,6 +365,7 @@ fn complete_help_topics() -> Vec<CompletionCandidate> {
 
 pub fn cmd() -> Command {
     Command::new("help")
+        .add(crate::shellnav::ShellNav::none())
         .about("Display help for a command or topic [read-only]")
         .long_about(
             "Display help for a command or topic.\n\n\

--- a/crates/wsp/src/cli/init.rs
+++ b/crates/wsp/src/cli/init.rs
@@ -11,6 +11,7 @@ use wsp_core::output::{MutationOutput, Output};
 
 pub fn cmd() -> Command {
     Command::new("init")
+        .add(crate::shellnav::ShellNav::none())
         .about("Create or update .wsp.yaml in the current repo")
         .long_about(
             "Create or update .wsp.yaml in the current repo.\n\n\

--- a/crates/wsp/src/cli/list.rs
+++ b/crates/wsp/src/cli/list.rs
@@ -7,6 +7,7 @@ use wsp_core::workspace;
 
 pub fn cmd() -> Command {
     Command::new("ls")
+        .add(crate::shellnav::ShellNav::none())
         .visible_alias("list")
         .about("List active workspaces [read-only]")
         .long_about(

--- a/crates/wsp/src/cli/log.rs
+++ b/crates/wsp/src/cli/log.rs
@@ -15,6 +15,7 @@ use wsp_core::workspace;
 
 pub fn cmd() -> Command {
     Command::new("log")
+        .add(crate::shellnav::ShellNav::none())
         .about("Show commits ahead of upstream per workspace repo [read-only]")
         .long_about(
             "Show commits ahead of upstream per workspace repo [read-only].\n\n\

--- a/crates/wsp/src/cli/mod.rs
+++ b/crates/wsp/src/cli/mod.rs
@@ -63,6 +63,10 @@ const HELP_CATEGORIES: &[(&str, &[&str])] = &[
 
 pub fn build_cli() -> Command {
     let repo_ws = Command::new("repo")
+        // The group itself does not move the shell. `repo rm` deletes a repo
+        // directory and can strand a shell standing in it — that needs nested
+        // dispatch in the wrapper, tracked in #115.
+        .add(crate::shellnav::ShellNav::none())
         .about("Manage repos in the current workspace")
         .long_about(
             "Manage repos in the current workspace.\n\n\

--- a/crates/wsp/src/cli/mod.rs
+++ b/crates/wsp/src/cli/mod.rs
@@ -63,10 +63,11 @@ const HELP_CATEGORIES: &[(&str, &[&str])] = &[
 
 pub fn build_cli() -> Command {
     let repo_ws = Command::new("repo")
-        // The group itself does not move the shell. `repo rm` deletes a repo
-        // directory and can strand a shell standing in it — that needs nested
-        // dispatch in the wrapper, tracked in #115.
-        .add(crate::shellnav::ShellNav::none())
+        // `repo rm` deletes a repo directory, so a shell standing in it is
+        // stranded. Handling that needs nested dispatch in the wrapper, which
+        // dispatches on $1 only. Declared as a known gap rather than none() so
+        // the declaration does not claim a safety it does not have. See #115.
+        .add(crate::shellnav::ShellNav::unhandled_gap())
         .about("Manage repos in the current workspace")
         .long_about(
             "Manage repos in the current workspace.\n\n\

--- a/crates/wsp/src/cli/new.rs
+++ b/crates/wsp/src/cli/new.rs
@@ -19,6 +19,8 @@ use super::completers;
 pub fn cmd() -> Command {
     Command::new("new")
         .visible_alias("create")
+        // The binary reports its resolved ws_dir; the wrapper cds there.
+        .add(crate::shellnav::ShellNav::follows())
         .about("Create a new workspace")
         .long_about(
             "Create a new workspace.\n\n\

--- a/crates/wsp/src/cli/recover.rs
+++ b/crates/wsp/src/cli/recover.rs
@@ -9,9 +9,9 @@ use wsp_core::output::{MutationOutput, Output, RecoverListOutput, RecoverShowOut
 
 pub fn cmd() -> Command {
     Command::new("recover")
-        // Restores a workspace directory and cds into it. The wrapper still
-        // derives the name from argv here; converting this to WSP_CD_FILE (a
-        // cd_request call in run()) is the last of that work.
+        // Restores a workspace directory and cds into it. Only the restore
+        // path reports a destination, so `recover ls` and `recover show` move
+        // nothing without the wrapper needing to know their names.
         .add(crate::shellnav::ShellNav::follows())
         .about("List, inspect, or restore recently removed workspaces [read-only without args]")
         .long_about(
@@ -78,6 +78,10 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
             // Bare positional arg = restore, no arg = list
             if let Some(name) = matches.get_one::<String>("workspace") {
                 gc::restore(paths, name)?;
+                // Only the restore path moves the shell. `ls` and `show` write
+                // nothing, so the wrapper does not need to know which
+                // subcommands to skip — it just cds to whatever it is told.
+                crate::shellcd::request(&wsp_core::workspace::dir(&paths.workspaces_dir, name));
                 Ok(Output::Mutation(MutationOutput::new(format!(
                     "Workspace {:?} restored.",
                     name

--- a/crates/wsp/src/cli/recover.rs
+++ b/crates/wsp/src/cli/recover.rs
@@ -9,6 +9,10 @@ use wsp_core::output::{MutationOutput, Output, RecoverListOutput, RecoverShowOut
 
 pub fn cmd() -> Command {
     Command::new("recover")
+        // Restores a workspace directory and cds into it. The wrapper still
+        // derives the name from argv here; converting this to WSP_CD_FILE (a
+        // cd_request call in run()) is the last of that work.
+        .add(crate::shellnav::ShellNav::follows())
         .about("List, inspect, or restore recently removed workspaces [read-only without args]")
         .long_about(
             "List, inspect, or restore recently removed workspaces.\n\n\

--- a/crates/wsp/src/cli/registry.rs
+++ b/crates/wsp/src/cli/registry.rs
@@ -8,6 +8,7 @@ use super::repo;
 
 pub fn cmd() -> Command {
     Command::new("registry")
+        .add(crate::shellnav::ShellNav::none())
         .about("Manage the global repo registry")
         .long_about(
             "Manage the global repo registry.\n\n\

--- a/crates/wsp/src/cli/rename.rs
+++ b/crates/wsp/src/cli/rename.rs
@@ -10,6 +10,9 @@ use super::completers;
 
 pub fn cmd() -> Command {
     Command::new("rename")
+        // Moves the workspace directory: the shell must step aside first (Windows
+        // cannot rename a live cwd) and then follow it to the new location.
+        .add(crate::shellnav::ShellNav::vacates_and_follows())
         .about("Rename a workspace, its directory, and git branches")
         .long_about(
             "Rename a workspace, its directory, and git branches.\n\n\

--- a/crates/wsp/src/cli/setup.rs
+++ b/crates/wsp/src/cli/setup.rs
@@ -26,6 +26,7 @@ fn read_prompt() -> Result<String> {
 
 pub fn cmd() -> Command {
     Command::new("setup")
+        .add(crate::shellnav::ShellNav::none())
         .about("Interactive first-time setup")
         .long_about(
             "Interactive first-time setup.\n\n\

--- a/crates/wsp/src/cli/status.rs
+++ b/crates/wsp/src/cli/status.rs
@@ -15,6 +15,7 @@ use super::completers;
 
 pub fn cmd() -> Command {
     Command::new("st")
+        .add(crate::shellnav::ShellNav::none())
         .visible_alias("status")
         .about("Git status across workspace repos [read-only]")
         .long_about(

--- a/crates/wsp/src/cli/sync.rs
+++ b/crates/wsp/src/cli/sync.rs
@@ -18,6 +18,7 @@ use wsp_core::workspace::{self, RepoInfo};
 
 pub fn cmd() -> Command {
     Command::new("sync")
+        .add(crate::shellnav::ShellNav::none())
         .about("Fetch and rebase/merge all workspace repos")
         .long_about(
             "Fetch and rebase/merge all workspace repos.\n\n\

--- a/crates/wsp/src/cli/template.rs
+++ b/crates/wsp/src/cli/template.rs
@@ -18,6 +18,7 @@ use super::completers;
 
 pub fn cmd() -> Command {
     Command::new("template")
+        .add(crate::shellnav::ShellNav::none())
         .about("Manage workspace templates")
         .long_about(
             "Manage workspace templates.\n\n\

--- a/crates/wsp/src/cli/whatsnew.rs
+++ b/crates/wsp/src/cli/whatsnew.rs
@@ -14,6 +14,7 @@ static CHANGELOG: &str = include_str!("../../../../CHANGELOG.md");
 
 pub fn cmd() -> Command {
     Command::new("whatsnew")
+        .add(crate::shellnav::ShellNav::none())
         .about("Show what changed in this version of wsp [read-only]")
         .long_about(
             "Show what changed in this version of wsp.\n\n\

--- a/crates/wsp/src/main.rs
+++ b/crates/wsp/src/main.rs
@@ -5,6 +5,7 @@ mod hints;
 mod output;
 mod pr;
 mod shellcd;
+mod shellnav;
 
 use std::process;
 

--- a/crates/wsp/src/shellnav.rs
+++ b/crates/wsp/src/shellnav.rs
@@ -133,12 +133,22 @@ impl ShellNav {
     /// wrapper bodies from these flags, at which point this becomes production
     /// code and the allow can go.
     #[allow(dead_code)]
+    /// Includes `unhandled_gap` on purpose. A command that can strand the
+    /// shell moves it in the sense that matters here, even though the wrapper
+    /// does not act on it yet — otherwise this returns false for a
+    /// known-broken command and `unhandled_gap` becomes observationally
+    /// identical to `none()`, which is the false safety claim the state exists
+    /// to avoid.
     pub const fn moves_shell(&self) -> bool {
-        self.vacate || self.follow_destination || self.destination_on_stdout
+        self.vacate || self.follow_destination || self.destination_on_stdout || self.unhandled_gap
     }
 
     /// Declared as able to strand the shell with no wrapper support.
-    #[allow(dead_code)]
+    ///
+    /// Read by the wrapper/declaration agreement test, which excludes gaps from
+    /// the "must have a case" side. Scoped to tests rather than
+    /// blanket-allowed, so it starts warning again if that test stops using it.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub const fn is_unhandled_gap(&self) -> bool {
         self.unhandled_gap
     }

--- a/crates/wsp/src/shellnav.rs
+++ b/crates/wsp/src/shellnav.rs
@@ -5,8 +5,11 @@
 //! which this crate already uses for arg completers. So a command's shell
 //! behavior lives next to its definition rather than in a table somewhere else.
 //!
-//! Read it back with `cmd.get::<ShellNav>()`. Absence means the command cannot
-//! relocate the shell and needs no wrapper case.
+//! Read it back with `cmd.get::<ShellNav>()`. The declaration is *required* —
+//! `test_every_command_declares_shell_nav` fails without it — because absence
+//! would be indistinguishable from nobody having considered the question, which
+//! is how `wsp rename` shipped for five releases moving the workspace directory
+//! with no wrapper case at all.
 
 /// The four primitives the dialects actually differ over. Every wrapper case is
 /// some combination of these, which is why the generators can render from the
@@ -22,10 +25,29 @@ pub struct ShellNav {
     pub vacate: bool,
     /// On success, cd to the path the binary wrote to `WSP_CD_FILE`.
     pub follow_destination: bool,
-    /// Afterwards, return to the starting directory if it still exists.
-    pub return_if_survives: bool,
+    /// Afterwards, prefer the starting directory if it still exists.
+    ///
+    /// Named "prefer" because it **takes precedence over `follow_destination`**,
+    /// and that precedence is load-bearing rather than incidental. `rename` sets
+    /// both: if the old directory survives we were never inside the renamed
+    /// workspace, so we must go back. Rendering follow-first instead would
+    /// teleport someone who ran `wsp rename w new` from `$HOME` into a workspace
+    /// they were never in — `$HOME` survives *and* a destination was reported.
+    ///
+    /// Pinned by `test_rename_prefers_previous_over_destination`.
+    pub prefer_previous: bool,
     /// The destination arrives on stdout instead — `wsp cd`'s existing contract.
     pub destination_on_stdout: bool,
+    /// The command *can* strand the shell, but the wrapper does not handle it
+    /// yet.
+    ///
+    /// This is the third state the old `KNOWN_GAPS` list carried, and it has to
+    /// exist: without it a known-broken command has to be declared `none()`,
+    /// whose contract says the command cannot relocate the shell. That would put
+    /// a false safety claim in the machine-readable declaration and leave a code
+    /// comment as the only record — exactly the failure mode this type exists to
+    /// remove.
+    pub unhandled_gap: bool,
 }
 
 impl clap::builder::CommandExt for ShellNav {}
@@ -42,8 +64,9 @@ impl ShellNav {
         Self {
             vacate: false,
             follow_destination: false,
-            return_if_survives: false,
+            prefer_previous: false,
             destination_on_stdout: false,
+            unhandled_gap: false,
         }
     }
 
@@ -52,8 +75,9 @@ impl ShellNav {
         Self {
             vacate: false,
             follow_destination: true,
-            return_if_survives: false,
+            prefer_previous: false,
             destination_on_stdout: false,
+            unhandled_gap: false,
         }
     }
 
@@ -62,8 +86,9 @@ impl ShellNav {
         Self {
             vacate: true,
             follow_destination: false,
-            return_if_survives: true,
+            prefer_previous: true,
             destination_on_stdout: false,
+            unhandled_gap: false,
         }
     }
 
@@ -73,8 +98,21 @@ impl ShellNav {
         Self {
             vacate: true,
             follow_destination: true,
-            return_if_survives: true,
+            prefer_previous: true,
             destination_on_stdout: false,
+            unhandled_gap: false,
+        }
+    }
+
+    /// Can strand the shell; wrapper support not written yet. Requires an
+    /// issue reference at the call site.
+    pub const fn unhandled_gap() -> Self {
+        Self {
+            vacate: false,
+            follow_destination: false,
+            prefer_previous: false,
+            destination_on_stdout: false,
+            unhandled_gap: true,
         }
     }
 
@@ -83,8 +121,9 @@ impl ShellNav {
         Self {
             vacate: false,
             follow_destination: false,
-            return_if_survives: false,
+            prefer_previous: false,
             destination_on_stdout: true,
+            unhandled_gap: false,
         }
     }
 
@@ -96,5 +135,11 @@ impl ShellNav {
     #[allow(dead_code)]
     pub const fn moves_shell(&self) -> bool {
         self.vacate || self.follow_destination || self.destination_on_stdout
+    }
+
+    /// Declared as able to strand the shell with no wrapper support.
+    #[allow(dead_code)]
+    pub const fn is_unhandled_gap(&self) -> bool {
+        self.unhandled_gap
     }
 }

--- a/crates/wsp/src/shellnav.rs
+++ b/crates/wsp/src/shellnav.rs
@@ -31,6 +31,22 @@ pub struct ShellNav {
 impl clap::builder::CommandExt for ShellNav {}
 
 impl ShellNav {
+    /// The command cannot relocate or remove the directory the shell is in, so
+    /// the wrapper needs no case for it.
+    ///
+    /// Declared explicitly rather than left absent. Absence would be
+    /// indistinguishable from "nobody thought about it", which is how every bug
+    /// in this area happened; requiring a declaration turns that into a test
+    /// failure and removes the need for any hand-maintained exemption list.
+    pub const fn none() -> Self {
+        Self {
+            vacate: false,
+            follow_destination: false,
+            return_if_survives: false,
+            destination_on_stdout: false,
+        }
+    }
+
     /// `new`: the binary reports where it landed.
     pub const fn follows() -> Self {
         Self {

--- a/crates/wsp/src/shellnav.rs
+++ b/crates/wsp/src/shellnav.rs
@@ -1,0 +1,84 @@
+//! What the shell wrapper must do around a command, declared on the command.
+//!
+//! This is attached to the clap `Command` itself via clap's typed-extension
+//! mechanism — the same one `clap_complete` uses for `ArgValueCandidates`, and
+//! which this crate already uses for arg completers. So a command's shell
+//! behavior lives next to its definition rather than in a table somewhere else.
+//!
+//! Read it back with `cmd.get::<ShellNav>()`. Absence means the command cannot
+//! relocate the shell and needs no wrapper case.
+
+/// The four primitives the dialects actually differ over. Every wrapper case is
+/// some combination of these, which is why the generators can render from the
+/// flags rather than hand-writing a body per command per dialect.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ShellNav {
+    /// Leave the workspaces tree before the binary runs.
+    ///
+    /// Required whenever the command may relocate or remove the directory the
+    /// shell is standing in: Windows cannot rename or delete a live process's
+    /// cwd, and only the shell can move itself, so this can never be delegated
+    /// to the binary.
+    pub vacate: bool,
+    /// On success, cd to the path the binary wrote to `WSP_CD_FILE`.
+    pub follow_destination: bool,
+    /// Afterwards, return to the starting directory if it still exists.
+    pub return_if_survives: bool,
+    /// The destination arrives on stdout instead — `wsp cd`'s existing contract.
+    pub destination_on_stdout: bool,
+}
+
+impl clap::builder::CommandExt for ShellNav {}
+
+impl ShellNav {
+    /// `new`: the binary reports where it landed.
+    pub const fn follows() -> Self {
+        Self {
+            vacate: false,
+            follow_destination: true,
+            return_if_survives: false,
+            destination_on_stdout: false,
+        }
+    }
+
+    /// `rm`: step aside, remove, come back only if it survived.
+    pub const fn vacates() -> Self {
+        Self {
+            vacate: true,
+            follow_destination: false,
+            return_if_survives: true,
+            destination_on_stdout: false,
+        }
+    }
+
+    /// `rename`: step aside so the move can happen, then follow it — unless we
+    /// were never inside, in which case come back.
+    pub const fn vacates_and_follows() -> Self {
+        Self {
+            vacate: true,
+            follow_destination: true,
+            return_if_survives: true,
+            destination_on_stdout: false,
+        }
+    }
+
+    /// `cd`: destination on stdout.
+    pub const fn prints_path() -> Self {
+        Self {
+            vacate: false,
+            follow_destination: false,
+            return_if_survives: false,
+            destination_on_stdout: true,
+        }
+    }
+
+    /// Does this command need the shell to move at all?
+    ///
+    /// Currently read only by tests. In the full design the generators render
+    /// wrapper bodies from these flags, at which point this becomes production
+    /// code and the allow can go.
+    #[allow(dead_code)]
+    pub const fn moves_shell(&self) -> bool {
+        self.vacate || self.follow_destination || self.destination_on_stdout
+    }
+}


### PR DESCRIPTION
Makes the wrapper's per-command behavior self-describing, using a convention clap already provides and this crate already uses.

## The problem this solves

"What must the shell do around command X" was written in **six places** per command: the posix body, the `build_posix_cases` entry, the fish block, the pwsh `writeln!` sequence, a `SCENARIOS` row, and a classification entry. There was no source of truth — only consistency checks between copies. That is why every guard added in this stack felt like extra work: it was.

## The convention

clap 4 exposes typed extensions — `Command::add<T: CommandExt + Extension>` and `Command::get::<T>()`. `clap_complete` uses exactly this (`impl ArgExt for ArgValueCandidates`, `impl CommandExt for SubcommandCandidates`), and `cli/*.rs` **already** attaches `ArgValueCandidates` to args. So this is not a new mechanism; it is the one already in use, applied one level up.

```rust
Command::new("rename")
    // Moves the workspace directory: the shell must step aside first
    // (Windows cannot rename a live cwd) and then follow it.
    .add(ShellNav::vacates_and_follows())
    .about("Rename a workspace, its directory, and git branches")
```

`ShellNav` names the four primitives the dialects actually differ over: `vacate`, `follow_destination`, `return_if_survives`, `destination_on_stdout`.

## Declaration is mandatory

Including `ShellNav::none()` for the 17 commands that cannot move the shell. That is the crux: **absence is indistinguishable from "nobody thought about it"**, which is precisely how `wsp rename` shipped for five releases moving the workspace directory with no wrapper case. Requiring a declaration turns that into a test failure and eliminates any exemption list.

## Net simplification

Two hand-maintained lists are **deleted**, not added to:

- `NO_RELOCATION` (16 command names) — gone
- `KNOWN_GAPS` — gone
- `test_every_command_is_classified` — replaced by a version needing no list

Both remaining guards are list-free:

| Guard | Assertion |
|---|---|
| `test_every_command_declares_shell_nav` | a new command fails until it says what it does |
| `test_shellnav_matches_wrapper_cases` | commands declaring movement == cases in the generated wrapper, both directions |

It earned its keep on first run: it failed immediately naming `recover` as unannotated, with no checklist consulted.

Both mutation-verified — dropping a declaration names the command; downgrading `rename` to `none()` reports the disagreement.

## What is deliberately NOT done

**The generators still hold hand-written bodies per command per dialect.** Rendering them from the four flags is the actual remaining work, and the pwsh generator is the bulk of it. So today `ShellNav` is a declaration the tests check, not yet the thing that *produces* the shell code — the triplication still exists.

One limit worth stating: `tests/shell_cd.rs` is an integration test against a binary crate, so it cannot read `ShellNav` — only spawn the binary. The *requirement* for a stranding case is derivable in unit tests; the *invocation* (`rm w --force`) is not derivable from clap and stays one manual line per command. Not everything collapses to zero.

Stacked on #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)