### PR TITLE
docs: fix two stale claims in RELEASING.md and ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,18 @@ jobs:
   #
   # Tests run in parallel. They needed --test-threads=1 only because completer
   # tests mutated XDG_DATA_HOME to steer Paths::resolve(). Completers now take
-  # their inputs as parameters, and env mutation can no longer compile at all:
-  # set_var is unsafe in edition 2024 and both crate roots deny unsafe_code.
+  # their inputs as parameters, so no test needs the environment.
+  #
+  # The compiler enforces that only for unit tests inside src/: set_var is
+  # unsafe in edition 2024 and both crate roots deny unsafe_code, so a test
+  # module there cannot mutate the environment without an explicit
+  # #[allow(unsafe_code)]. It is not enforced under crates/wsp/tests/ — each
+  # file there is its own crate root and inherits no lint attributes from
+  # main.rs, so an integration test can write `unsafe { set_var(..) }` and
+  # build cleanly. Nothing does today; reject new ones in review, because a
+  # single one reintroduces the cross-thread race that parallel tests here
+  # assume is impossible.
+  #
   # If this flag ever looks necessary again, something reintroduced shared
   # process state — fix that instead of serializing the suite.
   test-linux:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -101,10 +101,13 @@ full-structure example.
 
 ## After the release
 
-Nothing to do by hand. `release-notes.yml` runs as a publish job and prepends the
-`WHATSNEW.md` section for the version to the release body, above the generated
-commit log and install table. It fails loudly if the section is missing, which
-the `whatsnew` CI gate should already have prevented.
+Nothing to do by hand. `release-notes.yml` triggers on `workflow_run` when the
+Release workflow completes, and prepends the `WHATSNEW.md` section for the
+version to the release body, above the generated commit log and install table.
+It fails loudly if the section is missing, which the `whatsnew` CI gate should
+already have prevented. It is deliberately not a dist job hook — none of them,
+publish jobs included, can express "after the release exists, including on
+prereleases"; the header comment in that workflow has the per-hook detail.
 
 Verify with `gh run list --limit 5` and `gh release list --limit 3`.
 


### PR DESCRIPTION
Two comment/doc defects from review, both already on `main` and unrelated to any
open PR. Comments and prose only — no code or CI behavior changes.

## RELEASING.md — "runs as a publish job"

"After the release" said `release-notes.yml` "runs as a publish job".

Verified against `.github/workflows/release-notes.yml`: its trigger is
`on: workflow_run: workflows: ["Release"], types: [completed]`. There is no dist
job hook anywhere in it, and its own header comment rules publish jobs out by
name — dist stamps every publish job with a `!announcement_is_prerelease` guard,
so one would skip on exactly the prereleases these notes matter for. Living
outside `release.yml` is also what keeps `dist generate` from clobbering it. So
the doc contradicted both the code and the rationale comment.

Corrected to name the `workflow_run` trigger and to record that the dist hooks
were rejected deliberately, pointing at the workflow header for the per-hook
detail.

## ci.yml — the `--test-threads=1` justification overclaimed

The comment claimed env mutation "can no longer compile at all: set_var is
unsafe in edition 2024 and both crate roots deny unsafe_code."

Verified: `#![deny(unsafe_code)]` exists at exactly two places,
`crates/wsp/src/main.rs:1` and `crates/wsp-core/src/lib.rs:62`
(`grep -rn unsafe_code crates/`), and the edition is `2024` in the workspace
`Cargo.toml`. But each file under `crates/wsp/tests/` is its own crate root and
inherits no lint attributes from `main.rs`. Checked all four
(`gc_warning.rs`, `mirror_propagation_warning.rs`, `shell_cd.rs`,
`shell_completion.rs`) — none carries its own `deny(unsafe_code)`. So a future
integration test could write `unsafe { set_var(..) }`, build cleanly, and
silently reintroduce the cross-thread race the comment said was impossible. The
deny is also bypassable in-crate with an explicit `#[allow(unsafe_code)]` —
`main.rs:177` already does that for `SetConsoleOutputCP`.

Rewritten to state the guarantee that actually holds (compiler-enforced for unit
tests in `src/`, absent an explicit allow) and its limit (`tests/` is
review-enforced only). No `set_var` call exists anywhere in the tree today, so
this is a documentation fix, not a live bug.

## Verification

- `just ci` passes on this branch (fmt, clippy with and without `codegen`,
  `check-cross`, `cargo audit`, build, 392 tests + doctests, SKILL.md freshness).
- Confirmed the `ci.yml` change is comment-only by diffing the non-comment lines
  of the file against `HEAD` — identical.
- `.github/workflows/release.yml` was not touched (cargo-dist owns it).

## Noted, not changed

`crates/wsp/src/cli/completers.rs:6-9` carries the same overclaim in a narrower
form: "a test that reaches for the environment will not compile." Same gap — true
for the unit tests in that file, not for `crates/wsp/tests/`. Left alone as it
was out of scope for this review; happy to fold it in.

If the `tests/` gap is worth a real guard rather than an honest comment, the
cheap options are adding `#![deny(unsafe_code)]` to each integration test file
(does not prevent a *new* file from omitting it) or a CI grep for `unsafe` under
`crates/wsp/tests/`. Not implemented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)