### PR TITLE
fix(completion): stop the wrapper cd'ing into `--json` output

### DIFF
--- a/crates/wsp/src/cli/completion.rs
+++ b/crates/wsp/src/cli/completion.rs
@@ -238,10 +238,18 @@ fn build_posix_cases() -> Vec<ShellCase> {
         },
         ShellCase {
             pattern: "cd".to_string(),
+            // Pass the output through when it is not a directory. `cd`'s
+            // stdout is the structured-output channel, so with --json it
+            // carries a document rather than a path; capturing it and cd'ing
+            // blind turned `wsp cd <ws> --json` into an error. See #125.
             body: "shift\n\
-                 \x20     local dir\n\
-                 \x20     dir=$(WSP_SHELL=1 command \"$wsp_bin\" cd \"$@\") || return\n\
-                 \x20     cd \"$dir\""
+                 \x20     local _wsp_out\n\
+                 \x20     _wsp_out=$(WSP_SHELL=1 command \"$wsp_bin\" cd \"$@\") || return\n\
+                 \x20     if [[ -d \"$_wsp_out\" ]]; then\n\
+                 \x20       cd -- \"$_wsp_out\"\n\
+                 \x20     else\n\
+                 \x20       printf '%s\\n' \"$_wsp_out\"\n\
+                 \x20     fi"
                 .to_string(),
         },
         ShellCase {
@@ -490,8 +498,12 @@ function wsp\n\
 \n\
         case cd\n\
             set -l args $argv[2..]\n\
-            set -l dir (WSP_SHELL=1 command $wsp_bin cd $args); or return\n\
-            cd $dir\n\
+            set -l out (WSP_SHELL=1 command $wsp_bin cd $args); or return\n\
+            if test -d \"$out\"\n\
+                cd -- \"$out\"\n\
+            else\n\
+                printf '%s\\n' $out\n\
+            end\n\
 \n\
         case rename\n\
             set -l args $argv[2..]\n\
@@ -693,13 +705,24 @@ fn write_powershell(w: &mut dyn Write, bin_str: &str, wsp_root: &str) -> Result<
         "            $restArgs = @($args | Select-Object -Skip 1)"
     )?;
     writeln!(w, "            $env:WSP_SHELL = '1'")?;
-    writeln!(w, "            $dir = & $wspBin cd @restArgs")?;
+    writeln!(w, "            $out = & $wspBin cd @restArgs")?;
     writeln!(
         w,
         "            Remove-Item Env:\\WSP_SHELL -ErrorAction SilentlyContinue"
     )?;
-    writeln!(w, "            if ($LASTEXITCODE -eq 0 -and $dir) {{")?;
-    writeln!(w, "                Set-Location $dir")?;
+    // -Raw so a multi-line document (--json) survives as one string rather
+    // than an array of lines.
+    writeln!(w, "            $rc = $LASTEXITCODE")?;
+    writeln!(w, "            $text = ($out -join \"`n\")")?;
+    writeln!(w, "            if ($rc -eq 0 -and $text) {{")?;
+    writeln!(
+        w,
+        "                if (Test-Path -LiteralPath $text -PathType Container) {{"
+    )?;
+    writeln!(w, "                    Set-Location -LiteralPath $text")?;
+    writeln!(w, "                }} else {{")?;
+    writeln!(w, "                    Write-Output $text")?;
+    writeln!(w, "                }}")?;
     writeln!(w, "            }}")?;
     writeln!(w, "        }}")?;
     writeln!(w, "        {{ $_ -in 'rm', 'remove' }} {{")?;

--- a/crates/wsp/tests/shell_cd.rs
+++ b/crates/wsp/tests/shell_cd.rs
@@ -885,3 +885,85 @@ fn wrapper_does_not_change_command_outcomes() {
     }
     assert!(ran > 0, "no shell available for the differential test");
 }
+
+/// `--json` must survive the wrapper untouched, on every command.
+///
+/// `cd` is the only cd-ing command whose destination arrives on stdout, which
+/// is also the structured-output channel. Capturing it and cd'ing blind meant
+/// `wsp cd <ws> --json` tried to change directory into the JSON document and
+/// exited 1 — so `--json` worked for that command only without the wrapper
+/// installed, which is the opposite of who wants it. See #125.
+///
+/// The wrapper now cds only when the output names a directory and passes
+/// anything else through. This checks both halves: the shell must not move, and
+/// the document must reach stdout byte-for-byte, or a consumer piping it into a
+/// JSON parser breaks.
+#[test]
+fn wrapper_passes_json_through_untouched() {
+    let mut ran = 0usize;
+    for shell in SHELLS {
+        if !is_installed(shell) {
+            continue;
+        }
+        let env = make_env();
+        run_setup(&env, &["new", "w", "--empty"]);
+
+        // What the binary emits with no wrapper in the way.
+        let mut direct = Command::new(WSP);
+        apply_env(&mut direct, &env);
+        let expected = direct
+            .args(["cd", "w", "--json"])
+            .current_dir(&env.ws_root)
+            .env("WSP_SHELL", "1")
+            .output()
+            .expect("spawn wsp directly");
+        let expected_out = String::from_utf8_lossy(&expected.stdout).trim().to_string();
+        assert!(
+            expected_out.starts_with('{'),
+            "precondition: `wsp cd --json` should emit a JSON document, got {expected_out:?}"
+        );
+
+        // The same thing through the wrapper. PWD is printed last so we can
+        // check the shell stayed put.
+        let load = shell.load.replace("WSPBIN", &quote(shell.quote, WSP));
+        let script = format!(
+            "{load}\ncd {}\nwsp cd w --json\n{}",
+            quote(shell.quote, &env.ws_root.to_string_lossy()),
+            shell.print_pwd,
+        );
+        let mut c = Command::new(shell.bin);
+        apply_env(&mut c, &env);
+        let out = c
+            .args(shell.args)
+            .arg(&script)
+            .output()
+            .unwrap_or_else(|e| panic!("spawning {} failed: {e}", shell.bin));
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let mut lines: Vec<&str> = stdout.lines().collect();
+
+        let landed = PathBuf::from(
+            lines
+                .pop()
+                .unwrap_or_else(|| panic!("{} printed nothing", shell.bin))
+                .trim(),
+        );
+        let passed_through = lines.join("\n").trim().to_string();
+        ran += 1;
+
+        assert_eq!(
+            canon(&landed),
+            canon(&env.ws_root),
+            "shell={}: `wsp cd w --json` must not move the shell, but it landed in {}",
+            shell.bin,
+            landed.display(),
+        );
+        assert_eq!(
+            passed_through, expected_out,
+            "shell={}: the JSON document was altered by the wrapper.\n  \
+             expected: {expected_out}\n  \
+             got:      {passed_through}",
+            shell.bin,
+        );
+    }
+    assert!(ran > 0, "no shell available to test --json pass-through");
+}

--- a/crates/wsp/tests/shell_cd.rs
+++ b/crates/wsp/tests/shell_cd.rs
@@ -198,6 +198,17 @@ const SCENARIOS: &[Scenario] = &[
         expect: Expect::Ws("w"),
     },
     Scenario {
+        // With --json the output is a document, not a path. The shell must stay
+        // put — and routing this through the scenario table also gets it
+        // exit-code parity from wrapper_does_not_change_command_outcomes, which
+        // the dedicated content test does not cover.
+        name: "cd --json does not move the shell",
+        setup: &[&["new", "w", "--empty"]],
+        start: Start::Root,
+        cmd: &["cd", "w", "--json"],
+        expect: Expect::Unchanged,
+    },
+    Scenario {
         // `cd` reads its destination from the command's stdout, so a failing
         // command must not be allowed to move the shell to an empty path.
         name: "cd to a missing workspace does not move the shell",


### PR DESCRIPTION
Closes #125.

## The bug

```
$ wsp cd w --json
wsp:cd:21: no such file or directory: {\n  "path": "/…/ws/w"\n}
$ echo $?
1
```

Unwrapped it works fine. So `--json` worked for `wsp cd` **only for people without shell integration installed** — the opposite of who is likely to want it. Pre-existing since v0.14.0; the `cd` case has always captured stdout.

## Why it happens

Not a parsing slip — a tenet conflict. *"Structured output is the contract. Every command supports `--json`."* makes stdout the structured-output channel. The wrapper was also using stdout as its private channel for the destination. It cannot be both; whichever meaning wins, the other caller breaks.

Every other cd-ing command already avoids this: `new`, `rename` and `recover` report out-of-band via `WSP_CD_FILE` and leave stdout alone, so `--json` works through the wrapper for all three. `cd` was the only one overloading stdout, and the only one where `--json` was broken.

## The fix

Only treat the output as a destination when it *is* one; pass anything else through untouched.

**All three dialects had it** — fish captures with `set -l dir (...)`, PowerShell with `$dir = & $wspBin cd`. My first pass only fixed posix, which is worth saying because it is the same per-dialect omission that has bitten twice in this area already.

`cd` deliberately keeps the stdout channel rather than moving to `WSP_CD_FILE` like the others: it is much the most-used cd-ing command, and a `mktemp` per invocation on the hot path is not worth paying to buy symmetry. A `[[ -d ]]` test costs nothing.

## Test

`wrapper_passes_json_through_untouched` asserts **both** halves, because either alone would pass a broken wrapper:

1. the shell must not move, and
2. the document must arrive byte-for-byte — otherwise a consumer piping it into a parser breaks

Verified the pass-through is byte-identical (85 bytes both ways), parses as JSON, and pipes into a consumer. Mutation-verified by restoring the blind `cd`.

## Deliberately not changed

**`--json` stays on `cd`.** The path is also reachable via `wsp ls --json` (`.workspaces[].path`) and `wsp st --json` (`.workspace_dir`), so the envelope is a convenience rather than the only route. But *"an agent dropped into a workspace can discover and operate wsp without human guidance"* is worth more than removing a redundant flag — an agent that must learn "every command supports `--json` except `cd`" is worse off than one that gets an envelope it did not need.

Also worth noting `cd` cannot ever truly "always cd": a child process cannot change its parent's cwd, which is the constraint the whole wrapper exists to work around. The unwrapped "print the path instead" behaviour is a degraded mode, not a second identity to design away.

```whatsnew
- `wsp cd <workspace> --json` now works when shell integration is installed.
  It used to try to change directory into the JSON document and fail.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)