### PR TITLE
chore(release): v0.19.0-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,48 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.19.0-rc.2] - 2026-08-22
+## [0.19.0-rc.3] - 2026-08-24
+
+### Bug Fixes
+
+- *(completion)* Cd into the workspace for `wsp create` (#103)
+- *(release)* Run release-notes on workflow_run, not a dist hook (#109)
+- *(completion)* Take `new`'s cd destination from the binary (#110)
+- *(st)* Announce the PR fetch before waiting on it (#112)
+- *(completion)* Make `rm` vacate unconditionally instead of comparing paths (#111)
+- *(completion)* Follow the workspace on rename, and guard the class (#121)
+- *(completion)* Stop the wrapper cd'ing into `--json` output (#127)
+- *(completion)* Keep `cd -` working after rm and rename (#124)
+
+### Refactor
+
+- *(completers)* Read ambient state only in the clap wrapper (#104)
+- *(config)* One constructor for Paths (#107)
+- *(completion)* Declare shell navigation on the command itself (#122)
+
+### Documentation
+
+- *(tenets)* Add a Speed section (#101)
+- Fix two stale claims in RELEASING.md and ci.yml (#123)
+- *(src)* State the constraint, not the incident (#118)
+- *(removal-safety)* Drop a note about a parameter that no longer exists (#119)
+- *(completers)* The unsafe_code guard is narrower than claimed (#120)
+- *(ci)* State the constraint, not the incident (#117)
+
+### Performance
+
+- *(ci)* Run tests in parallel (#106)
+
+### Testing
+
+- *(completion)* Assert wrapper cd behavior in real shells (#108)
+- *(completion)* Guard the assumptions behind recover's argv scan (#114)
+
+### Ci
+
+- Require a whatsnew block in every PR description (#116)
+
+## [0.19.0-rc.2] - 2026-08-23
 
 ### Features
 
@@ -23,6 +64,7 @@ All notable changes to this project will be documented in this file.
 - Smoke-test built binaries before tagging a release (#93)
 - Move audit-check past v2.0.0 for the Node 24 runtime (#97)
 - Lead the release body with the WHATSNEW prose (#98)
+- Hand pwsh a native path for the Windows smoke binary (#100)
 
 ## [0.19.0-rc.1] - 2026-08-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,7 +1540,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wsp"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "wsp-core"
-version = "0.19.0-rc.2"
+version = "0.19.0-rc.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version    = "0.19.0-rc.2"
+version    = "0.19.0-rc.3"
 edition    = "2024"
 license    = "MIT"
 repository = "https://github.com/jganoff/wsp"

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -1,5 +1,22 @@
 # What's New
 
+## [0.19.0-rc.3] - 2026-08-24
+
+### Fixes
+
+Shell integration only — these need `eval "$(wsp completion <shell>)"` in
+your shell startup, and all of them go back to v0.14.0.
+
+- `wsp new` and `wsp create` now always change into the new workspace. Before,
+  that only worked when you put the name first: `wsp new --empty my-ws` left
+  you where you were, and on PowerShell `wsp new -w other my-ws` could drop
+  you into the wrong workspace entirely.
+- `wsp rm` and `wsp rename` now work from inside the workspace you are acting
+  on. On Windows they failed outright.
+- `wsp rm` and `wsp rename` no longer break `cd -`. It takes you back where
+  you came from, not to your workspaces directory.
+- `wsp cd <workspace> --json` no longer fails.
+
 ## [0.19.0-rc.2] - 2026-08-22
 
 ### `wsp create`


### PR DESCRIPTION
Third release candidate for 0.19.0. Entirely shell-integration fixes.

## What's in it

Eight user-facing fixes, **all present since v0.14.0** and all affecting anyone using `eval "$(wsp completion <shell>)"`:

| Fix | PR |
|---|---|
| `wsp create` didn't cd into the new workspace | #103 |
| `wsp new --empty <name>` (flag first) cd'd nowhere | #110 |
| `wsp new -b feat/x` cd'd nowhere — name derived from the branch | #110 |
| `wsp new -w src <name>` cd'd into `src` on PowerShell | #110 |
| `wsp rm` from inside the workspace failed outright on Windows | #111 |
| `wsp rename` stranded the shell; failed outright on Windows | #121 |
| `cd -` broke after `wsp rm` / `wsp rename` | #124 |
| `wsp cd <ws> --json` cd'd into the JSON document | #127 |

Plus internal work with no user-visible effect: the behavioural test harness (#108), guards against the recurrence class (#114), and `ShellNav` declaring each command's shell behaviour on the command itself (#122).

## One thing to know about the notes

`scripts/whatsnew-draft.sh` collected only **2** of these. The `whatsnew` CI job (#116) landed partway through the day, so six of the eight fixes merged before any PR was required to carry a block. Those six are written by hand in this commit.

This is a one-off: every PR from #116 onward carries a block, so the script is the right mechanism going forward — it just could not see backwards. Worth knowing so the thin automated output is not read as "rc.3 was a quiet release".

## Verification

- `just ci` green locally: fmt, clippy `-D warnings` (both feature configs), full test suite, SKILL.md freshness
- `wsp whatsnew` resolves the new `## [0.19.0-rc.3]` section against the bumped version
- Every fix above is covered by behavioural tests that spawn real shells — zsh, bash, fish on unix, PowerShell on Windows — rather than asserting on generated text

## Not included

#128 (documenting the wrapper's contract in `completion.rs` and `AGENTS.md`) is still open. Docs-only, no effect on the release.

## After merge

`just release-dispatch 0.19.0-rc.3` — CI tags the merged commit. Per RELEASING.md the prerelease suffix means the Homebrew tap is deliberately untouched, so `brew install` users are unaffected and testers opt in explicitly.

When 0.19.0 final ships, the three `-rc.N` sections in `WHATSNEW.md` should be consolidated into one `## [0.19.0]`.

```whatsnew
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)