### PR TITLE
feat(hints): warn when a workspace name collides with a recover subcommand

### DIFF
--- a/crates/wsp/src/cli/help.rs
+++ b/crates/wsp/src/cli/help.rs
@@ -208,7 +208,7 @@ HINTS
 
   advice.<key>          Boolean. Suppress a specific hint by key.
                         Keys: branchPrefix, setupCommands, registrySetupCommands,
-                              whatsnew
+                              reservedName, whatsnew
                         Example: `wsp config set advice.branchPrefix false`
                         Default: true (hint enabled)
 

--- a/crates/wsp/src/cli/recover.rs
+++ b/crates/wsp/src/cli/recover.rs
@@ -20,7 +20,9 @@ pub fn cmd() -> Command {
              (configurable via gc.retention-days). Set gc.retention-days to 0 to keep \
              deleted workspaces indefinitely.\n\n\
              Without arguments, lists recoverable workspaces. Use `show` to inspect \
-             a specific entry, or pass a name directly to restore it.",
+             a specific entry, or pass a name directly to restore it.\n\n\
+             A workspace named after a subcommand (`ls`, `list`, `show`) is resolved \
+             as that subcommand. Use `--` to restore one: `wsp recover -- ls`.",
         )
         .subcommand(
             Command::new("ls")

--- a/crates/wsp/src/hints.rs
+++ b/crates/wsp/src/hints.rs
@@ -18,6 +18,7 @@ pub const KNOWN_ADVICE_KEYS: &[&str] = &[
     "branchPrefix",
     "setupCommands",
     "registrySetupCommands",
+    "reservedName",
     "whatsnew",
 ];
 
@@ -25,7 +26,23 @@ pub const KNOWN_ADVICE_KEYS: &[&str] = &[
 ///
 /// `command` is the effective subcommand path: `"new"`, `"repo/add"`, etc.
 /// Returns hint strings to print to stderr. Empty when all hints are suppressed.
-pub fn evaluate(command: &str, cfg: &Config, paths: &Paths) -> Vec<&'static str> {
+/// Names `wsp recover` resolves as subcommands, derived from clap rather than
+/// hardcoded so the set cannot drift if a subcommand is added or renamed.
+fn recover_subcommand_names() -> Vec<String> {
+    let mut names = Vec::new();
+    for sub in crate::cli::recover::cmd().get_subcommands() {
+        names.push(sub.get_name().to_string());
+        names.extend(sub.get_visible_aliases().map(String::from));
+    }
+    names
+}
+
+pub fn evaluate(
+    command: &str,
+    workspace: Option<&str>,
+    cfg: &Config,
+    paths: &Paths,
+) -> Vec<&'static str> {
     if !cfg.hints.unwrap_or(true) {
         return vec![];
     }
@@ -90,6 +107,25 @@ pub fn evaluate(command: &str, cfg: &Config, paths: &Paths) -> Vec<&'static str>
              (suppress: wsp config set advice.registrySetupCommands false)",
         );
         touch_hint(&hints_dir, "registrySetupCommands");
+    }
+
+    // reservedName: clap resolves `recover`'s subcommands before its positional,
+    // so a workspace named after one of them cannot be restored by name. `ls`
+    // silently lists instead; `show` errors about a missing argument. `--` is the
+    // escape, and nothing else tells the user they will need it.
+    if command == "new"
+        && let Some(name) = workspace
+        && recover_subcommand_names().iter().any(|n| n == name)
+        && hint_enabled(cfg, "reservedName")
+        && hint_ready(&hints_dir, "reservedName", cooldown_days)
+    {
+        hints.push(
+            "hint: this workspace name is also a `wsp recover` subcommand, so\n  \
+             `wsp recover <name>` will list or error instead of restoring it.\n  \
+             Use `wsp recover -- <name>` to restore it.\n  \
+             (suppress: wsp config set advice.reservedName false)",
+        );
+        touch_hint(&hints_dir, "reservedName");
     }
 
     hints
@@ -182,7 +218,7 @@ mod tests {
             hints: Some(false),
             ..Default::default()
         };
-        assert!(evaluate("new", &cfg, paths).is_empty());
+        assert!(evaluate("new", None, &cfg, paths).is_empty());
     }
 
     #[test]
@@ -191,7 +227,7 @@ mod tests {
         let paths = &tp.paths;
         let mut cfg = cfg_with_cooldown(0); // no cooldown so it always fires
         cfg.branch_prefix = None;
-        let hints = evaluate("new", &cfg, paths);
+        let hints = evaluate("new", None, &cfg, paths);
         assert!(
             hints.iter().any(|h| h.contains("branchPrefix")),
             "expected branchPrefix hint, got: {:?}",
@@ -204,7 +240,7 @@ mod tests {
         let tp = make_paths();
         let paths = &tp.paths;
         let cfg = cfg_with_prefix();
-        let hints = evaluate("new", &cfg, paths);
+        let hints = evaluate("new", None, &cfg, paths);
         assert!(
             !hints.iter().any(|h| h.contains("branchPrefix")),
             "branchPrefix hint should not fire when prefix is set"
@@ -223,7 +259,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        let hints = evaluate("new", &cfg, paths);
+        let hints = evaluate("new", None, &cfg, paths);
         assert!(
             !hints.iter().any(|h| h.contains("branchPrefix")),
             "branchPrefix hint should be suppressed by advice key"
@@ -236,7 +272,7 @@ mod tests {
         let paths = &tp.paths;
         let cfg = cfg_with_cooldown(0);
         for cmd in &["new", "repo/add"] {
-            let hints = evaluate(cmd, &cfg, paths);
+            let hints = evaluate(cmd, None, &cfg, paths);
             assert!(
                 hints.iter().any(|h| h.contains("setupCommands")),
                 "expected setupCommands hint for command {:?}, got: {:?}",
@@ -265,7 +301,7 @@ mod tests {
             ..Default::default()
         };
         for cmd in &["new", "repo/add"] {
-            let hints = evaluate(cmd, &cfg, paths);
+            let hints = evaluate(cmd, None, &cfg, paths);
             assert!(
                 !hints.iter().any(|h| h.contains("setupCommands")),
                 "setupCommands hint should not fire when registry already has setup commands ({cmd})"
@@ -283,7 +319,7 @@ mod tests {
             m.insert("setupCommands".into(), false);
             m
         });
-        let hints = evaluate("new", &cfg, paths);
+        let hints = evaluate("new", None, &cfg, paths);
         assert!(
             !hints.iter().any(|h| h.contains("setupCommands")),
             "setupCommands hint should be suppressed by advice key"
@@ -298,14 +334,14 @@ mod tests {
         let cfg = Config::default();
 
         // First call: hint fires and records the marker
-        let hints1 = evaluate("new", &cfg, paths);
+        let hints1 = evaluate("new", None, &cfg, paths);
         assert!(
             hints1.iter().any(|h| h.contains("branchPrefix")),
             "hint should fire on first call"
         );
 
         // Second call (immediate): cooldown suppresses it
-        let hints2 = evaluate("new", &cfg, paths);
+        let hints2 = evaluate("new", None, &cfg, paths);
         assert!(
             !hints2.iter().any(|h| h.contains("branchPrefix")),
             "hint should be suppressed within cooldown window"
@@ -319,8 +355,8 @@ mod tests {
         let cfg = cfg_with_cooldown(0);
 
         // Fire twice in a row; both times it should appear
-        let h1 = evaluate("new", &cfg, paths);
-        let h2 = evaluate("new", &cfg, paths);
+        let h1 = evaluate("new", None, &cfg, paths);
+        let h2 = evaluate("new", None, &cfg, paths);
         assert!(
             h1.iter().any(|h| h.contains("branchPrefix")),
             "first call should show hint"
@@ -343,7 +379,7 @@ mod tests {
         backdate_hint_marker(&hints_dir, "branchPrefix");
 
         // Hint should fire again since the cooldown has expired
-        let hints = evaluate("new", &cfg, paths);
+        let hints = evaluate("new", None, &cfg, paths);
         assert!(
             hints.iter().any(|h| h.contains("branchPrefix")),
             "hint should fire again after cooldown expiry"
@@ -355,7 +391,7 @@ mod tests {
         let tp = make_paths();
         let paths = &tp.paths;
         let cfg = Config::default();
-        let hints = evaluate("ls", &cfg, paths);
+        let hints = evaluate("ls", None, &cfg, paths);
         assert!(hints.is_empty(), "ls should produce no hints");
     }
 
@@ -385,7 +421,7 @@ mod tests {
         let tp = make_paths();
         let paths = &tp.paths;
         let cfg = cfg_with_registry_setup("myrepo");
-        let hints = evaluate("repo/setup-commands/add", &cfg, paths);
+        let hints = evaluate("repo/setup-commands/add", None, &cfg, paths);
         assert!(
             hints.iter().any(|h| h.contains("registrySetupCommands")),
             "expected registrySetupCommands hint for inferred add, got: {hints:?}"
@@ -397,7 +433,7 @@ mod tests {
         let tp = make_paths();
         let paths = &tp.paths;
         let cfg = cfg_with_registry_setup("myrepo");
-        let hints = evaluate("repo/setup-commands/add/registry", &cfg, paths);
+        let hints = evaluate("repo/setup-commands/add/registry", None, &cfg, paths);
         assert!(
             hints.iter().any(|h| h.contains("registrySetupCommands")),
             "expected registrySetupCommands hint for explicit --registry add, got: {hints:?}"
@@ -413,7 +449,7 @@ mod tests {
             "repo/setup-commands/add/workspace",
             "repo/setup-commands/add/repo",
         ] {
-            let hints = evaluate(cmd, &cfg, paths);
+            let hints = evaluate(cmd, None, &cfg, paths);
             assert!(
                 !hints.iter().any(|h| h.contains("registrySetupCommands")),
                 "registrySetupCommands hint should not fire for {cmd:?}, got: {hints:?}"
@@ -427,7 +463,7 @@ mod tests {
         let paths = &tp.paths;
         let cfg = cfg_with_registry_setup("myrepo");
         for cmd in &["repo/setup-commands/rm", "repo/setup-commands/ls", "new"] {
-            let hints = evaluate(cmd, &cfg, paths);
+            let hints = evaluate(cmd, None, &cfg, paths);
             assert!(
                 !hints.iter().any(|h| h.contains("registrySetupCommands")),
                 "registrySetupCommands hint should not fire for {cmd:?}, got: {hints:?}"
@@ -454,7 +490,7 @@ mod tests {
             repos,
             ..Default::default()
         };
-        let hints = evaluate("repo/setup-commands/add", &cfg, paths);
+        let hints = evaluate("repo/setup-commands/add", None, &cfg, paths);
         assert!(
             !hints.iter().any(|h| h.contains("registrySetupCommands")),
             "hint should not fire when registry has no setup commands"
@@ -471,10 +507,78 @@ mod tests {
             m.insert("registrySetupCommands".into(), false);
             m
         });
-        let hints = evaluate("repo/setup-commands/add", &cfg, paths);
+        let hints = evaluate("repo/setup-commands/add", None, &cfg, paths);
         assert!(
             !hints.iter().any(|h| h.contains("registrySetupCommands")),
             "registrySetupCommands hint should be suppressed by advice key"
+        );
+    }
+
+    #[test]
+    fn reserved_name_hint_fires_for_a_recover_subcommand_name() {
+        let tp = make_paths();
+        let cfg = cfg_with_cooldown(0);
+        for name in recover_subcommand_names() {
+            let hints = evaluate("new", Some(&name), &cfg, &tp.paths);
+            assert!(
+                hints.iter().any(|h| h.contains("wsp recover -- ")),
+                "expected the reservedName hint for a workspace called {name:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn reserved_name_hint_silent_for_an_ordinary_name() {
+        let tp = make_paths();
+        let cfg = cfg_with_cooldown(0);
+        for name in ["my-feature", "lsx", "showcase", "LS", ""] {
+            let hints = evaluate("new", Some(name), &cfg, &tp.paths);
+            assert!(
+                !hints.iter().any(|h| h.contains("wsp recover -- ")),
+                "reservedName hint should not fire for {name:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn reserved_name_hint_suppressed_via_advice() {
+        let tp = make_paths();
+        let cfg = Config {
+            hints_cooldown_days: Some(0),
+            advice: Some({
+                let mut m = BTreeMap::new();
+                m.insert("reservedName".into(), false);
+                m
+            }),
+            ..Default::default()
+        };
+        let hints = evaluate("new", Some("ls"), &cfg, &tp.paths);
+        assert!(
+            !hints.iter().any(|h| h.contains("wsp recover -- ")),
+            "reservedName hint should be suppressed by its advice key"
+        );
+    }
+
+    /// The colliding set is derived from clap, so it cannot drift from what
+    /// `recover` actually accepts. If a subcommand is added, this notices.
+    #[test]
+    fn reserved_name_set_matches_recovers_subcommands() {
+        let mut got = recover_subcommand_names();
+        got.retain(|n| n != "help");
+        got.sort();
+        assert_eq!(
+            got,
+            vec!["list".to_string(), "ls".to_string(), "show".to_string()],
+            "recover's subcommands changed — the hint text and recover's long_about \
+             both name ls/list/show and need updating"
+        );
+    }
+
+    #[test]
+    fn reserved_name_key_is_registered() {
+        assert!(
+            KNOWN_ADVICE_KEYS.contains(&"reservedName"),
+            "advice.reservedName must be accepted by `wsp config set`"
         );
     }
 }

--- a/crates/wsp/src/hints.rs
+++ b/crates/wsp/src/hints.rs
@@ -113,7 +113,11 @@ pub fn evaluate(
     // so a workspace named after one of them cannot be restored by name. `ls`
     // silently lists instead; `show` errors about a missing argument. `--` is the
     // escape, and nothing else tells the user they will need it.
-    if command == "new"
+    //
+    // Fires for `rename` as well as `new`: renaming *to* a colliding name leaves
+    // the workspace in exactly the same state as creating one with that name.
+    // MutationOutput carries the new name in both cases.
+    if matches!(command, "new" | "rename")
         && let Some(name) = workspace
         && recover_subcommand_names().iter().any(|n| n == name)
         && hint_enabled(cfg, "reservedName")
@@ -564,7 +568,6 @@ mod tests {
     #[test]
     fn reserved_name_set_matches_recovers_subcommands() {
         let mut got = recover_subcommand_names();
-        got.retain(|n| n != "help");
         got.sort();
         assert_eq!(
             got,
@@ -580,5 +583,34 @@ mod tests {
             KNOWN_ADVICE_KEYS.contains(&"reservedName"),
             "advice.reservedName must be accepted by `wsp config set`"
         );
+    }
+
+    /// `wsp create` is an alias for `new`, and clap dispatch reports the primary
+    /// name — so the hint reaches it without naming the alias anywhere.
+    #[test]
+    fn reserved_name_hint_covers_new_and_rename() {
+        let tp = make_paths();
+        let cfg = cfg_with_cooldown(0);
+        for cmd in ["new", "rename"] {
+            let hints = evaluate(cmd, Some("ls"), &cfg, &tp.paths);
+            assert!(
+                hints.iter().any(|h| h.contains("wsp recover -- ")),
+                "expected the reservedName hint for `{cmd}` with a colliding name"
+            );
+        }
+    }
+
+    /// Commands that do not name a workspace must not trigger it.
+    #[test]
+    fn reserved_name_hint_ignores_unrelated_commands() {
+        let tp = make_paths();
+        let cfg = cfg_with_cooldown(0);
+        for cmd in ["st", "ls", "diff", "repo/add", "recover"] {
+            let hints = evaluate(cmd, Some("ls"), &cfg, &tp.paths);
+            assert!(
+                !hints.iter().any(|h| h.contains("wsp recover -- ")),
+                "reservedName hint should not fire for `{cmd}`"
+            );
+        }
     }
 }

--- a/crates/wsp/src/main.rs
+++ b/crates/wsp/src/main.rs
@@ -81,6 +81,12 @@ fn main() {
     match cli::dispatch(&matches, &paths) {
         Ok(out) => {
             let code = output::exit_code(&out);
+            // Captured before render consumes the output; the reservedName hint
+            // needs to know which workspace was just created.
+            let workspace = match &out {
+                wsp_core::output::Output::Mutation(m) => m.workspace.clone(),
+                _ => None,
+            };
             if let Err(err) = output::render(out, json) {
                 render_error(err, json);
                 process::exit(1);
@@ -93,7 +99,7 @@ fn main() {
             if !json && code == 0 {
                 // One-time upgrade notice (version-gated, independent of cooldown).
                 maybe_print_upgrade_notice(&paths, &cfg, &command);
-                let hints = hints::evaluate(&command, &cfg, &paths);
+                let hints = hints::evaluate(&command, workspace.as_deref(), &cfg, &paths);
                 if !hints.is_empty() {
                     eprintln!();
                 }


### PR DESCRIPTION
Closes #126.

## The problem

clap resolves `recover`'s subcommands before its positional, so a workspace named `ls`, `list` or `show` cannot be restored by name. `ls` is the worst case — it silently lists, showing you the very workspace you asked to restore, with no error:

```
$ wsp new ls --empty
$ wsp rm ls --force --yes
$ wsp recover ls
NAME  BRANCH  REPOS  REMOVED  EXPIRES
ls    ls      0      0m ago   in 6d
```

`show` fails loudly but confusingly (*"required arguments were not provided"*). `--` already works as the escape, and nothing told anyone it existed or that they would need it.

## Warn, don't reject the name

The ambiguity belongs to `recover` alone — `wsp cd ls`, `wsp rm ls`, `wsp st ls`, `wsp rename ls x` are all unambiguous. Banning a name globally to protect one command's parse punishes every other command, and would do nothing for anyone who already has such a workspace.

```
$ wsp new ls --empty
hint: this workspace name is also a `wsp recover` subcommand, so
  `wsp recover <name>` will list or error instead of restoring it.
  Use `wsp recover -- <name>` to restore it.
  (suppress: wsp config set advice.reservedName false)
```

Follows the conventions in AGENTS.md: a branch in `hints::evaluate()` gated on `hint_enabled(cfg, "reservedName")`, state-driven, cooldown'd, and the suppression key documented in the `config` topic in `help.rs`.

## The colliding set derives from clap

`recover_subcommand_names()` reads `recover::cmd()` rather than hardcoding `ls`/`list`/`show`, so it cannot drift. `reserved_name_set_matches_recovers_subcommands` asserts it still matches the three names that the hint text and `recover`'s `long_about` both spell out — if a subcommand is added, that test says so and names what needs updating.

## Signature change

`hints::evaluate` gains the workspace name. main.rs captures it from the `MutationOutput` *before* `render` consumes the output, which is the only point it is available. One call site; the 19 test call sites pass `None`.

## Also

`recover`'s `long_about` now documents `--`, which was the undocumented escape:

> A workspace named after a subcommand (`ls`, `list`, `show`) is resolved as that subcommand. Use `--` to restore one: `wsp recover -- ls`.

## Tests

- hint fires for every derived subcommand name
- silent for ordinary names, and for near-misses (`lsx`, `showcase`, `LS`, empty)
- suppressed by `advice.reservedName`
- the derived set matches `recover`'s actual subcommands
- `reservedName` is registered in `KNOWN_ADVICE_KEYS`, so `wsp config set` accepts it

Verified end-to-end against a real binary: the hint appears for `wsp new ls` and not for `wsp new normal`.

```whatsnew
- `wsp new` now warns when the workspace name is also a `wsp recover` subcommand
  (`ls`, `list`, `show`). Those names cannot be restored with `wsp recover <name>`
  — use `wsp recover -- <name>`.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)