### PR TITLE
fix(gc): only auto-gc after mutating commands, and say what was purged

### DIFF
--- a/crates/wsp-core/src/gc.rs
+++ b/crates/wsp-core/src/gc.rs
@@ -372,13 +372,18 @@ pub fn restore(paths: &Paths, name: &str) -> Result<()> {
 
 /// Purge gc entries older than the retention period.
 /// A `retention_days` of 0 means "never purge" — all entries are kept indefinitely.
-pub fn purge(gc_dir: &Path, retention_days: u32) -> Result<u32> {
+/// Permanently delete gc entries past the retention window.
+///
+/// Returns the names removed rather than a count, so callers can say *what*
+/// they deleted. A purge that reports only a number cannot be audited by the
+/// person whose work it deleted.
+pub fn purge(gc_dir: &Path, retention_days: u32) -> Result<Vec<String>> {
     if retention_days == 0 || !gc_dir.exists() {
-        return Ok(0);
+        return Ok(Vec::new());
     }
 
     let cutoff = Utc::now() - chrono::Duration::days(retention_days as i64);
-    let mut removed = 0;
+    let mut removed = Vec::new();
 
     for item in fs::read_dir(gc_dir)? {
         let item = item?;
@@ -402,7 +407,7 @@ pub fn purge(gc_dir: &Path, retention_days: u32) -> Result<u32> {
             if let Err(e) = fs::remove_dir_all(&path) {
                 eprintln!("  warning: gc purge failed for {}: {}", entry.name, e);
             } else {
-                removed += 1;
+                removed.push(entry.name.clone());
             }
         }
     }
@@ -432,8 +437,20 @@ pub fn maybe_run(paths: &Paths, retention_days: Option<u32>) {
     if days == 0 {
         return; // never purge
     }
-    if let Err(e) = purge(&paths.gc_dir, days) {
-        eprintln!("  warning: gc failed: {}", e);
+    // Say what was deleted. git is not silent about auto-gc either, and unlike
+    // git's — which mostly repacks — every byte this does is destructive, so
+    // silence would leave no record that recoverable work is gone.
+    match purge(&paths.gc_dir, days) {
+        Ok(removed) if !removed.is_empty() => {
+            eprintln!(
+                "gc: purged {} expired workspace{} ({})",
+                removed.len(),
+                if removed.len() == 1 { "" } else { "s" },
+                removed.join(", ")
+            );
+        }
+        Ok(_) => {}
+        Err(e) => eprintln!("  warning: gc failed: {}", e),
     }
 
     // Touch the marker file
@@ -543,7 +560,7 @@ mod tests {
         backdate_gc_entries(&paths.gc_dir, 10);
 
         let removed = purge(&paths.gc_dir, 7).unwrap();
-        assert_eq!(removed, 1);
+        assert_eq!(removed.len(), 1);
 
         let entries = list(&paths.gc_dir).unwrap();
         assert_eq!(entries.len(), 0);
@@ -558,7 +575,7 @@ mod tests {
         move_to_gc(&paths, "new-ws", "test/new-ws").unwrap();
 
         let removed = purge(&paths.gc_dir, 7).unwrap();
-        assert_eq!(removed, 0);
+        assert_eq!(removed.len(), 0);
 
         let entries = list(&paths.gc_dir).unwrap();
         assert_eq!(entries.len(), 1);
@@ -813,7 +830,7 @@ mod tests {
         backdate_gc_entries(&paths.gc_dir, 365); // backdate to a year ago
 
         let removed = purge(&paths.gc_dir, 0).unwrap();
-        assert_eq!(removed, 0, "retention_days=0 should never purge");
+        assert!(removed.is_empty(), "retention_days=0 should never purge");
 
         let entries = list(&paths.gc_dir).unwrap();
         assert_eq!(entries.len(), 1);

--- a/crates/wsp/src/cli/doctor.rs
+++ b/crates/wsp/src/cli/doctor.rs
@@ -793,6 +793,7 @@ fn check_gc_stale_entries(
         if fix {
             match gc::purge(&paths.gc_dir, retention_days) {
                 Ok(removed) => {
+                    let removed = removed.len();
                     checks.push(DoctorCheck {
                         scope: "global".into(),
                         check: "gc-stale-entries".into(),

--- a/crates/wsp/src/main.rs
+++ b/crates/wsp/src/main.rs
@@ -93,8 +93,27 @@ fn main() {
             }
             // Load config once for gc and hints
             let cfg = wsp_core::config::Config::load_from(&paths.config_path).unwrap_or_default();
-            // Opportunistic gc -- runs at most once per hour
-            wsp_core::gc::maybe_run(&paths, cfg.gc_retention_days);
+            // Opportunistic gc, modelled on `git gc --auto`: no daemon, runs at
+            // most once per hour, piggybacking on commands the user already ran.
+            //
+            // Gated to workspace-mutating commands, which is what git does too --
+            // it triggers auto-gc from commit/merge/rebase/fetch, never from
+            // status/log/diff. Without the gate a read-only `wsp ls` could
+            // permanently delete recoverable workspaces, which is both surprising
+            // and against "no silent mutations hiding inside read commands".
+            //
+            // Nothing is lost by gating: gc entries are only created by `wsp rm`
+            // (the sole caller of workspace::remove), which is in the set. The
+            // worst case is an expired entry lingering until the next mutation --
+            // the opposite of data loss, and `wsp doctor` reports it.
+            //
+            // `recover` is deliberately absent. Bare `wsp recover` lists, so it is
+            // read-only in that form, and the gate cannot tell it apart from
+            // `wsp recover <name>` -- it sees only the command name. Including it
+            // would reintroduce exactly the bug this gate closes.
+            if matches!(command.as_str(), "new" | "rm" | "rename") {
+                wsp_core::gc::maybe_run(&paths, cfg.gc_retention_days);
+            }
             // Contextual hints (git-style advice.*) -- only on success
             if !json && code == 0 {
                 // One-time upgrade notice (version-gated, independent of cooldown).

--- a/crates/wsp/tests/auto_gc.rs
+++ b/crates/wsp/tests/auto_gc.rs
@@ -1,0 +1,230 @@
+//! Auto-gc is modelled on `git gc --auto`: no daemon, piggybacking on commands
+//! the user already ran. Two properties make that safe, and neither held before:
+//!
+//! 1. It only fires from workspace-mutating commands. git triggers auto-gc from
+//!    commit/merge/rebase/fetch and never from status/log/diff; wsp fired it
+//!    after *every* command, so a read-only `wsp ls` could permanently delete
+//!    recoverable workspaces.
+//! 2. It says what it deleted. `purge` returned a count that the caller
+//!    discarded, so a purge of three workspaces printed nothing at all.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const WSP: &str = env!("CARGO_BIN_EXE_wsp");
+
+struct Env {
+    _tmp: tempfile::TempDir,
+    data: PathBuf,
+    ws_root: PathBuf,
+}
+
+fn make_env() -> Env {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let data = tmp.path().join("data");
+    let ws_root = tmp.path().join("ws");
+    std::fs::create_dir_all(data.join("wsp")).expect("data dir");
+    std::fs::create_dir_all(&ws_root).expect("ws root");
+    std::fs::write(
+        data.join("wsp").join("config.yaml"),
+        format!("workspaces_dir: '{}'\n", ws_root.display()),
+    )
+    .expect("config");
+    Env {
+        _tmp: tmp,
+        data,
+        ws_root,
+    }
+}
+
+fn wsp(env: &Env, args: &[&str]) -> std::process::Output {
+    let mut c = Command::new(WSP);
+    c.env("XDG_DATA_HOME", &env.data)
+        .env("HOME", env._tmp.path())
+        .env("USERPROFILE", env._tmp.path())
+        .args(args)
+        .current_dir(&env.ws_root);
+    c.output().expect("spawn wsp")
+}
+
+fn gc_dir(env: &Env) -> PathBuf {
+    env.data.join("wsp").join("gc")
+}
+
+/// Age every gc entry past the retention window, and clear the hourly cooldown
+/// so the next eligible command will actually attempt a purge.
+fn make_everything_expired(env: &Env) {
+    let dir = gc_dir(env);
+    for item in std::fs::read_dir(&dir).expect("read gc dir") {
+        let p = item.expect("entry").path();
+        let meta = p.join(".wsp-gc.yaml");
+        if let Ok(s) = std::fs::read_to_string(&meta) {
+            let aged: String = s
+                .lines()
+                .map(|l| {
+                    if l.starts_with("trashed_at:") {
+                        "trashed_at: 2000-01-01T00:00:00Z".to_string()
+                    } else {
+                        l.to_string()
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            std::fs::write(&meta, aged).expect("write aged meta");
+        }
+    }
+    let _ = std::fs::remove_file(dir.join(".gc-last"));
+}
+
+fn gc_entry_count(env: &Env) -> usize {
+    std::fs::read_dir(gc_dir(env))
+        .map(|rd| {
+            rd.filter_map(Result::ok)
+                .filter(|e| e.path().is_dir())
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+fn seed_expired_entry(env: &Env, name: &str) {
+    assert!(
+        wsp(env, &["new", name, "--empty"]).status.success(),
+        "seed: creating {name} failed"
+    );
+    assert!(
+        wsp(env, &["rm", name, "--force", "--yes"]).status.success(),
+        "seed: removing {name} failed"
+    );
+    make_everything_expired(env);
+    assert_eq!(gc_entry_count(env), 1, "seed should leave one gc entry");
+}
+
+/// Read-only commands must not delete recoverable workspaces.
+///
+/// This is the regression: `wsp ls` printed "No workspaces." and destroyed a
+/// recoverable workspace in the same breath.
+#[test]
+fn read_only_commands_do_not_purge() {
+    for cmd in [
+        &["ls"][..],
+        &["st"][..],
+        &["diff"][..],
+        &["log"][..],
+        // bare `wsp recover` lists, so it is read-only too
+        &["recover"][..],
+    ] {
+        let env = make_env();
+        seed_expired_entry(&env, "precious");
+
+        let out = wsp(&env, cmd);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+
+        assert_eq!(
+            gc_entry_count(&env),
+            1,
+            "`wsp {}` purged an expired workspace; read-only commands must not \
+             delete recoverable work\nstderr: {stderr}",
+            cmd.join(" ")
+        );
+    }
+}
+
+/// A mutating command may purge — and must say so, naming what it deleted.
+#[test]
+fn mutating_commands_purge_and_announce() {
+    let env = make_env();
+    seed_expired_entry(&env, "precious");
+
+    let out = wsp(&env, &["new", "trigger", "--empty"]);
+    assert!(out.status.success(), "wsp new should succeed");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert_eq!(
+        gc_entry_count(&env),
+        0,
+        "a mutating command should purge the expired entry\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("gc: purged") && stderr.contains("precious"),
+        "the purge must name what it deleted, or there is no record that \
+         recoverable work is gone\nstderr: {stderr}"
+    );
+}
+
+/// Nothing expired means nothing said. The announcement is state reporting, so
+/// it must be silent exactly when there is nothing to report.
+#[test]
+fn nothing_expired_says_nothing() {
+    let env = make_env();
+    assert!(wsp(&env, &["new", "keep", "--empty"]).status.success());
+    assert!(
+        wsp(&env, &["rm", "keep", "--force", "--yes"])
+            .status
+            .success()
+    );
+    let _ = std::fs::remove_file(gc_dir(&env).join(".gc-last"));
+
+    let out = wsp(&env, &["new", "another", "--empty"]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("gc: purged"),
+        "a fresh entry is not expired, so nothing should be announced\nstderr: {stderr}"
+    );
+    assert_eq!(gc_entry_count(&env), 1, "the fresh entry must survive");
+}
+
+/// `gc.retention-days = 0` means keep forever, so nothing is ever purged even
+/// from a mutating command.
+#[test]
+fn retention_zero_never_purges() {
+    let env = make_env();
+    std::fs::write(
+        env.data.join("wsp").join("config.yaml"),
+        format!(
+            "workspaces_dir: '{}'\ngc_retention_days: 0\n",
+            env.ws_root.display()
+        ),
+    )
+    .expect("config");
+
+    seed_expired_entry(&env, "forever");
+    let out = wsp(&env, &["new", "trigger", "--empty"]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert_eq!(
+        gc_entry_count(&env),
+        1,
+        "retention 0 means keep indefinitely\nstderr: {stderr}"
+    );
+}
+
+/// Guard the gate itself: if a command is added to the allowlist, it must be one
+/// that mutates workspace state. Reading the list from the source keeps this
+/// honest without duplicating it.
+#[test]
+fn gate_list_contains_only_mutating_commands() {
+    let src = std::fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src")
+            .join("main.rs"),
+    )
+    .expect("read main.rs");
+    let gate = src
+        .split("command.as_str(),")
+        .nth(1)
+        .and_then(|s| s.split(')').next())
+        .expect("could not find the gc gate in main.rs");
+
+    for readonly in ["ls", "st", "diff", "log", "config", "doctor", "completion"] {
+        assert!(
+            !gate.contains(&format!("\"{readonly}\"")),
+            "`{readonly}` is read-only and must not trigger auto-gc"
+        );
+    }
+    for mutating in ["new", "rm", "rename"] {
+        assert!(
+            gate.contains(&format!("\"{mutating}\"")),
+            "`{mutating}` mutates workspaces and should be able to trigger auto-gc"
+        );
+    }
+}


### PR DESCRIPTION
## The bug

```
$ wsp ls
No workspaces.
```

That command permanently deleted a recoverable workspace. `wsp ls` is read-only.

Reproduced: create a workspace, `wsp rm` it, age the gc entry past retention, run `wsp ls` — the entry is gone from disk and nothing was printed about it.

## Why

Auto-gc here is modelled on `git gc --auto`: no daemon, piggybacking on commands the user already ran, at most once an hour. **That model is right.** Two details drifted from the thing it was mimicking:

| | git | wsp before |
|---|---|---|
| Triggered by | object-*creating* commands (`commit`, `merge`, `rebase`, `fetch`) — never `status`/`log`/`diff` | **every** command, including reads |
| Says anything | yes — *"Auto packing the repository…"* | nothing on success |

`gc::maybe_run` was called unconditionally after every successful command (`main.rs`), and `purge` returned a count the caller discarded (`if let Err(e) = purge(..)`) — so it only ever spoke up when it *failed* to delete something.

The asymmetry matters: `git gc --auto` mostly repacks, which is a performance operation. `maybe_run` is marker check → cooldown → purge → touch marker. Every byte of it is `fs::remove_dir_all`. Silence is a worse choice for a destructive-only job than for a mostly-safe one.

Two tenets, unambiguously:

> **Human Use 5.** *"No silent mutations hiding inside read commands."*
> **Safety 3.** *"Surface hidden state… Silent 'clean' status that hides at-risk work is a bug."*

## The fix

**Gate to `new` / `rm` / `rename`.** Nothing is lost — gc entries are created only by `wsp rm`, the sole caller of `workspace::remove`, and it's in the set. Worst case is an expired entry lingering until the next mutation, which is the *opposite* of data loss, and `wsp doctor` already reports gc disk usage.

**Announce what was deleted.** `purge` returns names instead of a count:

```
gc: purged 2 expired workspaces (old-fix, tmp-spike)
```

## `recover` is deliberately not in the gate

Finding that out was useful. Bare `wsp recover` *lists*, so it's read-only in that form — but the gate sees only the command name and can't tell it from `wsp recover <name>`. Including it reintroduced the exact bug being fixed, caught by the new test.

That's a second, independent symptom of `recover` being both a query and an action, which is being addressed separately.

## Tests

`tests/auto_gc.rs`, both properties mutation-verified:

- read-only commands (`ls`, `st`, `diff`, `log`, bare `recover`) don't purge — **removing the gate makes `wsp ls` purge again**
- a mutating command purges *and* names what it deleted — **silencing the announcement is caught by name**
- nothing expired → nothing announced (state reporting must be silent when there's nothing to report)
- `gc_retention_days = 0` never purges
- the gate list contains no read-only command, read from `main.rs` so it can't drift

```whatsnew
- Read-only commands like `wsp ls` and `wsp st` no longer delete expired
  recoverable workspaces as a side effect. Cleanup now happens only after `wsp
  new`, `wsp rm`, or `wsp rename`, and says what it removed.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)