### PR TITLE
refactor(cli): ask where the user is, not where the process is

### DIFF
--- a/crates/wsp/src/cli/add.rs
+++ b/crates/wsp/src/cli/add.rs
@@ -63,7 +63,7 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
         .unwrap_or_default();
     let template_source = matches.get_one::<String>("template");
 
-    let cwd = std::env::current_dir()?;
+    let cwd = crate::shellcd::invocation_dir()?;
     let ws_dir = workspace::detect(&cwd).map_err(|e| {
         // If the user passed a URL, they likely meant `wsp registry add`.
         let looks_like_url = repo_args.iter().any(|a| {

--- a/crates/wsp/src/cli/cfg.rs
+++ b/crates/wsp/src/cli/cfg.rs
@@ -50,7 +50,7 @@ pub fn dispatch(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
     let ws_dir = if global {
         None
     } else {
-        std::env::current_dir()
+        crate::shellcd::invocation_dir()
             .ok()
             .and_then(|cwd| workspace::detect(&cwd).ok())
     };

--- a/crates/wsp/src/cli/completers.rs
+++ b/crates/wsp/src/cli/completers.rs
@@ -48,7 +48,7 @@ fn complete_repos_in(paths: &Paths) -> Vec<CompletionCandidate> {
 
 /// Complete only repos in the current workspace (for `ws repo rm`).
 pub fn complete_workspace_repos() -> Vec<CompletionCandidate> {
-    let Ok(cwd) = std::env::current_dir() else {
+    let Ok(cwd) = crate::shellcd::invocation_dir() else {
         return Vec::new();
     };
     complete_workspace_repos_in(&cwd)
@@ -222,7 +222,7 @@ pub fn complete_repo_setup_commands() -> Vec<CompletionCandidate> {
     let Ok(paths) = Paths::resolve() else {
         return Vec::new();
     };
-    let cwd = std::env::current_dir().ok();
+    let cwd = crate::shellcd::invocation_dir().ok();
     complete_repo_setup_commands_in(&paths, &args, cwd.as_deref()).unwrap_or_default()
 }
 

--- a/crates/wsp/src/cli/completion.rs
+++ b/crates/wsp/src/cli/completion.rs
@@ -313,8 +313,13 @@ fn build_posix_cases() -> Vec<ShellCase> {
                 .to_string(),
         },
         ShellCase {
-            pattern: "rename".to_string(),
-            body: build_posix_rename(),
+            // One body for both. Each steps out before the binary runs, then
+            // returns to where it was if that survived, and otherwise to the
+            // destination the binary reported. Sharing it means the two cannot
+            // drift apart, and the body takes the command from the argv rather
+            // than naming it.
+            pattern: "rename|repo".to_string(),
+            body: build_posix_vacate_and_follow(),
         },
         ShellCase {
             // Both spellings share one body, which always invokes `rm`.
@@ -375,12 +380,13 @@ fn build_posix_recover() -> String {
 /// move. Landing at the new workspace root loses a subdirectory position
 /// (`<ws>/sub` becomes `<ws-new>`); reconstructing the relative subpath is
 /// possible but not worth the shell complexity.
-fn build_posix_rename() -> String {
-    "shift\n\
+fn build_posix_vacate_and_follow() -> String {
+    "local _wsp_sub=\"$1\"\n\
+     \x20     shift\n\
      \x20     local _wsp_prev=\"$PWD\" _wsp_oldpwd=\"$OLDPWD\" _wsp_cd _wsp_rc\n\
      \x20     _wsp_cd=$(mktemp) || return\n\
      \x20     cd \"$wsp_root\" 2>/dev/null || cd \"$HOME\" || return\n\
-     \x20     WSP_PWD=\"$_wsp_prev\" WSP_CD_FILE=\"$_wsp_cd\" command \"$wsp_bin\" rename \"$@\"\n\
+     \x20     WSP_PWD=\"$_wsp_prev\" WSP_CD_FILE=\"$_wsp_cd\" command \"$wsp_bin\" \"$_wsp_sub\" \"$@\"\n\
      \x20     _wsp_rc=$?\n\
      \x20     if [[ -d \"$_wsp_prev\" ]]; then\n\
      \x20       [[ -n \"$_wsp_oldpwd\" && -d \"$_wsp_oldpwd\" ]] && cd \"$_wsp_oldpwd\"\n\
@@ -578,7 +584,8 @@ function wsp\n\
                 printf '%s\\n' $out\n\
             end\n\
 \n\
-        case rename\n\
+        case rename repo\n\
+            set -l sub $argv[1]\n\
             set -l args $argv[2..]\n\
             set -l prev $PWD\n\
             set -l oldpwd \"\"\n\
@@ -587,7 +594,7 @@ function wsp\n\
             end\n\
             set -l cdfile (mktemp)\n\
             cd \"$wsp_root\" 2>/dev/null; or cd $HOME; or return 1\n\
-            WSP_PWD=$prev WSP_CD_FILE=$cdfile command $wsp_bin rename $args\n\
+            WSP_PWD=$prev WSP_CD_FILE=$cdfile command $wsp_bin $sub $args\n\
             set -l rc $status\n\
             if test -d \"$prev\"\n\
                 if test -n \"$oldpwd\" -a -d \"$oldpwd\"\n\
@@ -856,7 +863,10 @@ fn write_powershell(w: &mut dyn Write, bin_str: &str, wsp_root: &str) -> Result<
     // See build_posix_rename: vacate so Windows can rename at all, then follow
     // the workspace to wherever the binary says it went, but only if we were
     // standing in it.
-    writeln!(w, "        'rename' {{")?;
+    // One block for both, as in the POSIX and fish wrappers. `$sub` carries the
+    // command so the body does not name it and the two cannot drift apart.
+    writeln!(w, "        {{ $_ -in 'rename', 'repo' }} {{")?;
+    writeln!(w, "            $sub = $args[0]")?;
     writeln!(
         w,
         "            $restArgs = @($args | Select-Object -Skip 1)"
@@ -876,7 +886,7 @@ fn write_powershell(w: &mut dyn Write, bin_str: &str, wsp_root: &str) -> Result<
         "            catch {{ Set-Location -LiteralPath $HOME -ErrorAction SilentlyContinue }}"
     )?;
     writeln!(w, "            $env:WSP_PWD = $prev")?;
-    writeln!(w, "            & $wspBin rename @restArgs")?;
+    writeln!(w, "            & $wspBin $sub @restArgs")?;
     writeln!(w, "            $rc = $LASTEXITCODE")?;
     writeln!(
         w,
@@ -2136,15 +2146,16 @@ mod tests {
     /// `rename` must check the previous directory before the reported
     /// destination.
     ///
-    /// Both flags are set for `rename`, and the order is load-bearing: rendering
+    /// Both flags are set for `rename` and `repo`, which share one body, and the
+    /// order is load-bearing: rendering
     /// follow-first would teleport someone who ran `wsp rename w new` from
     /// `$HOME` into a workspace they were never in, because `$HOME` survives and
     /// a destination was reported. Nothing else pins this down, since `rename` is
-    /// the only command with both flags.
+    /// are the only commands with both flags.
     #[test]
     fn test_rename_prefers_previous_over_destination() {
         let generated = generated_posix();
-        let body = case_body(&generated, "    rename)", "    rm|remove)");
+        let body = case_body(&generated, "    rename|repo)", "    rm|remove)");
         let prev_at = body
             .find("-d \"$_wsp_prev\"")
             .expect("rename must test the previous directory");

--- a/crates/wsp/src/cli/describe.rs
+++ b/crates/wsp/src/cli/describe.rs
@@ -53,13 +53,13 @@ fn resolve_args(matches: &ArgMatches) -> Result<(String, String)> {
     match (ws_arg, text_args) {
         (Some(ws), Some(parts)) => Ok((ws.clone(), parts.join(" "))),
         (Some(text), None) => {
-            let cwd = std::env::current_dir()?;
+            let cwd = crate::shellcd::invocation_dir()?;
             let ws_dir = workspace::detect(&cwd)?;
             let meta = workspace::load_metadata(&ws_dir)?;
             Ok((meta.name, text.clone()))
         }
         (None, Some(parts)) => {
-            let cwd = std::env::current_dir()?;
+            let cwd = crate::shellcd::invocation_dir()?;
             let ws_dir = workspace::detect(&cwd)?;
             let meta = workspace::load_metadata(&ws_dir)?;
             Ok((meta.name, parts.join(" ")))

--- a/crates/wsp/src/cli/diff.rs
+++ b/crates/wsp/src/cli/diff.rs
@@ -43,7 +43,7 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
     let ws_dir: PathBuf = if let Some(name) = matches.get_one::<String>("workspace") {
         workspace::dir(&paths.workspaces_dir, name)
     } else {
-        let cwd = std::env::current_dir()?;
+        let cwd = crate::shellcd::invocation_dir()?;
         workspace::detect(&cwd)?
     };
 

--- a/crates/wsp/src/cli/doctor.rs
+++ b/crates/wsp/src/cli/doctor.rs
@@ -174,7 +174,7 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
     check_deprecated_config_keys(paths, &cfg, fix, &mut checks, &mut fixed);
 
     // --- Workspace checks (if inside one) ---
-    let cwd = std::env::current_dir()?;
+    let cwd = crate::shellcd::invocation_dir()?;
     if let Ok(ws_dir) = workspace::detect(&cwd) {
         let meta = workspace::load_metadata(&ws_dir)?;
         let ws_scope = format!("workspace/{}", meta.name);

--- a/crates/wsp/src/cli/exec.rs
+++ b/crates/wsp/src/cli/exec.rs
@@ -37,7 +37,7 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
     let ws_dir: PathBuf = if let Some(name) = matches.get_one::<String>("workspace") {
         workspace::dir(&paths.workspaces_dir, name)
     } else {
-        let cwd = std::env::current_dir()?;
+        let cwd = crate::shellcd::invocation_dir()?;
         workspace::detect(&cwd)?
     };
     let meta = workspace::load_metadata(&ws_dir)

--- a/crates/wsp/src/cli/fetch.rs
+++ b/crates/wsp/src/cli/fetch.rs
@@ -81,7 +81,7 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
 
     // Detect current workspace (if not --all)
     let current_ws: Option<(std::path::PathBuf, workspace::Metadata)> = if !all {
-        let cwd = std::env::current_dir()?;
+        let cwd = crate::shellcd::invocation_dir()?;
         match workspace::detect(&cwd) {
             Ok(ws_dir) => {
                 gc::check_workspace(&ws_dir, /* read_only */ false)?;

--- a/crates/wsp/src/cli/init.rs
+++ b/crates/wsp/src/cli/init.rs
@@ -42,7 +42,7 @@ pub fn run(matches: &ArgMatches, _paths: &Paths) -> Result<Output> {
         );
     }
 
-    let cwd = std::env::current_dir()?;
+    let cwd = crate::shellcd::invocation_dir()?;
     check_git_repo(&cwd)?;
 
     let existing =

--- a/crates/wsp/src/cli/log.rs
+++ b/crates/wsp/src/cli/log.rs
@@ -42,7 +42,7 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
     let ws_dir: PathBuf = if let Some(name) = matches.get_one::<String>("workspace") {
         workspace::dir(&paths.workspaces_dir, name)
     } else {
-        let cwd = std::env::current_dir()?;
+        let cwd = crate::shellcd::invocation_dir()?;
         workspace::detect(&cwd)?
     };
 

--- a/crates/wsp/src/cli/mod.rs
+++ b/crates/wsp/src/cli/mod.rs
@@ -215,7 +215,7 @@ pub fn dispatch(matches: &ArgMatches, paths: &Paths) -> anyhow::Result<Output> {
         Some(("generate", m)) => skill::run_generate(m, paths),
         // --- No subcommand: default behavior ---
         None => {
-            let cwd = std::env::current_dir()?;
+            let cwd = crate::shellcd::invocation_dir()?;
             if workspace::detect(&cwd).is_ok() {
                 status::run(matches, paths)
             } else {
@@ -271,6 +271,51 @@ mod tests {
     /// the first positional may be clap-required since at least one arg is
     /// needed, but the runtime treats the single-arg case as
     /// "workspace from CWD + arg is payload." Those are verified separately
+    /// Commands ask where the *user* is, not where this process is.
+    ///
+    /// The wrapper steps the shell out of the way before running commands that
+    /// delete or move the directory it is standing in, and forwards the original
+    /// location in `WSP_PWD`. A command reading `std::env::current_dir()`
+    /// therefore sees the wrapper's scratch stop instead of the user, and
+    /// workspace detection silently resolves to the wrong place or fails.
+    ///
+    /// Which wrapper cases vacate changes over time, so this is not scoped to
+    /// today's set: `shellcd::invocation_dir()` reads `WSP_PWD` and falls back
+    /// to the process cwd, so it is correct everywhere and costs nothing.
+    #[test]
+    fn the_cli_asks_where_the_user_is() {
+        let dir = concat!(env!("CARGO_MANIFEST_DIR"), "/src/cli");
+        let mut offenders = Vec::new();
+        for entry in std::fs::read_dir(dir).expect("read cli dir") {
+            let path = entry.expect("dir entry").path();
+            if path.extension().is_none_or(|e| e != "rs") {
+                continue;
+            }
+            let src = std::fs::read_to_string(&path).expect("read source");
+            // Split so this line does not match itself, and skip comments so
+            // prose about the rule is not mistaken for a breach of it.
+            let needle = concat!("std::env::", "current_dir()");
+            for (n, line) in src.lines().enumerate() {
+                if line.trim_start().starts_with("//") {
+                    continue;
+                }
+                if line.contains(needle) {
+                    offenders.push(format!(
+                        "{}:{}",
+                        path.file_name().unwrap().to_string_lossy(),
+                        n + 1
+                    ));
+                }
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "these read the process cwd instead of the user's directory: {offenders:?}\n  \
+             Use `crate::shellcd::invocation_dir()`, which honours WSP_PWD and \
+             falls back to the process cwd when it is unset."
+        );
+    }
+
     /// in `test_multi_positional_workspace_parses_without_name`.
     #[test]
     fn test_workspace_arg_is_optional() {

--- a/crates/wsp/src/cli/mod.rs
+++ b/crates/wsp/src/cli/mod.rs
@@ -63,11 +63,11 @@ const HELP_CATEGORIES: &[(&str, &[&str])] = &[
 
 pub fn build_cli() -> Command {
     let repo_ws = Command::new("repo")
-        // `repo rm` deletes a repo directory, so a shell standing in it is
-        // stranded. Handling that needs nested dispatch in the wrapper, which
-        // dispatches on $1 only. Declared as a known gap rather than none() so
-        // the declaration does not claim a safety it does not have. See #115.
-        .add(crate::shellnav::ShellNav::unhandled_gap())
+        // `repo rm` deletes a repo directory, so the wrapper steps out before
+        // running the binary and returns afterwards. Which subcommand ran does
+        // not matter to the wrapper: it goes back to where it was if that still
+        // exists, and otherwise to whatever destination the binary reported.
+        .add(crate::shellnav::ShellNav::vacates_and_follows())
         .about("Manage repos in the current workspace")
         .long_about(
             "Manage repos in the current workspace.\n\n\

--- a/crates/wsp/src/cli/new.rs
+++ b/crates/wsp/src/cli/new.rs
@@ -234,7 +234,7 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
         && from_file.is_none()
         && !empty
     {
-        let cwd = std::env::current_dir()?;
+        let cwd = crate::shellcd::invocation_dir()?;
         if let Ok(ws_dir) = workspace::detect(&cwd) {
             let meta = workspace::load_metadata(&ws_dir)?;
             let source_name = &meta.name;

--- a/crates/wsp/src/cli/remove.rs
+++ b/crates/wsp/src/cli/remove.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use anyhow::{Result, bail};
 use clap::{Arg, ArgMatches, Command};
 use clap_complete::engine::ArgValueCandidates;
@@ -41,7 +43,7 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
     let repo_args: Vec<&String> = matches.get_many::<String>("repos").unwrap().collect();
     let force = matches.get_flag("force");
 
-    let cwd = std::env::current_dir()?;
+    let cwd = crate::shellcd::invocation_dir()?;
     let ws_dir = workspace::detect(&cwd)?;
     gc::check_workspace(&ws_dir, /* read_only */ false)?;
 
@@ -67,8 +69,28 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
         resolved.push(id);
     }
 
+    // Where the shell is standing, and which directories are about to go, both
+    // read before the removal: metadata is the only place the mapping lives and
+    // it is gone afterwards.
+    let shell_dir = crate::shellcd::invocation_dir().unwrap_or_default();
+    let doomed: Vec<PathBuf> = workspace::load_metadata(&ws_dir)
+        .map(|meta| {
+            resolved
+                .iter()
+                .filter_map(|id| meta.dir_name(id).ok().map(|dn| ws_dir.join(dn)))
+                .collect()
+        })
+        .unwrap_or_default();
+
     eprintln!("Removing {} repo(s) from workspace...", resolved.len());
     workspace::remove_repos(&paths.mirrors_dir, &ws_dir, &resolved, force)?;
+
+    // Standing in a directory that no longer exists is not somewhere to leave
+    // the shell. Only when it was actually inside one of these: removing a repo
+    // from elsewhere should not move anyone.
+    if doomed.iter().any(|dir| shell_dir.starts_with(dir)) {
+        crate::shellcd::request(&ws_dir);
+    }
 
     let meta_result = workspace::load_metadata(&ws_dir);
     match &meta_result {

--- a/crates/wsp/src/cli/remove.rs
+++ b/crates/wsp/src/cli/remove.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use anyhow::{Result, bail};
 use clap::{Arg, ArgMatches, Command};
 use clap_complete::engine::ArgValueCandidates;
@@ -69,26 +67,15 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
         resolved.push(id);
     }
 
-    // Where the shell is standing, and which directories are about to go, both
-    // read before the removal: metadata is the only place the mapping lives and
-    // it is gone afterwards.
-    let shell_dir = crate::shellcd::invocation_dir().unwrap_or_default();
-    let doomed: Vec<PathBuf> = workspace::load_metadata(&ws_dir)
-        .map(|meta| {
-            resolved
-                .iter()
-                .filter_map(|id| meta.dir_name(id).ok().map(|dn| ws_dir.join(dn)))
-                .collect()
-        })
-        .unwrap_or_default();
-
     eprintln!("Removing {} repo(s) from workspace...", resolved.len());
     workspace::remove_repos(&paths.mirrors_dir, &ws_dir, &resolved, force)?;
 
-    // Standing in a directory that no longer exists is not somewhere to leave
-    // the shell. Only when it was actually inside one of these: removing a repo
-    // from elsewhere should not move anyone.
-    if doomed.iter().any(|dir| shell_dir.starts_with(dir)) {
+    // A directory that no longer exists is not somewhere to leave the shell.
+    // Asking the filesystem beats working out which paths were removed and
+    // comparing them: `ws_dir` was found by walking up from `cwd`, so the shell
+    // is inside the workspace either way, and the workspace root is the nearest
+    // place that certainly survived.
+    if !cwd.exists() {
         crate::shellcd::request(&ws_dir);
     }
 

--- a/crates/wsp/src/cli/repo_list.rs
+++ b/crates/wsp/src/cli/repo_list.rs
@@ -19,7 +19,7 @@ pub fn cmd() -> Command {
 }
 
 pub fn run(_matches: &ArgMatches, _paths: &Paths) -> Result<Output> {
-    let cwd = std::env::current_dir()?;
+    let cwd = crate::shellcd::invocation_dir()?;
     let ws_dir = workspace::detect(&cwd)?;
 
     if let Some(warning) = gc::check_workspace(&ws_dir, /* read_only */ true)? {

--- a/crates/wsp/src/cli/repo_setup.rs
+++ b/crates/wsp/src/cli/repo_setup.rs
@@ -40,7 +40,7 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
         .unwrap_or_default();
     let all = matches.get_flag("all");
 
-    let cwd = std::env::current_dir()?;
+    let cwd = crate::shellcd::invocation_dir()?;
     let ws_dir = workspace::detect(&cwd)?;
     let meta = workspace::load_metadata(&ws_dir)?;
 

--- a/crates/wsp/src/cli/repo_setup_commands.rs
+++ b/crates/wsp/src/cli/repo_setup_commands.rs
@@ -169,7 +169,7 @@ fn resolve_repo_with_cfg(repo_arg: Option<&String>, cfg: &config::Config) -> Res
     }
 
     // No explicit repo — try to infer from CWD.
-    let cwd = std::env::current_dir()?;
+    let cwd = crate::shellcd::invocation_dir()?;
     let ws_dir = workspace::detect(&cwd)
         .map_err(|_| anyhow::anyhow!("not in a workspace; specify a repo name"))?;
     let meta = workspace::load_metadata(&ws_dir)?;
@@ -191,7 +191,7 @@ fn run_ls(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
 }
 
 fn run_list(cfg: &config::Config, identity: &str) -> Result<Output> {
-    let cwd = std::env::current_dir()?;
+    let cwd = crate::shellcd::invocation_dir()?;
     let (meta, ws_dir) = match workspace::detect(&cwd) {
         Ok(ws_dir) => (Some(workspace::load_metadata(&ws_dir)?), Some(ws_dir)),
         Err(_) => (None, None),
@@ -238,7 +238,7 @@ fn run_add(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
         .cloned()
         .collect::<Vec<_>>()
         .join(" ");
-    let cwd = std::env::current_dir()?;
+    let cwd = crate::shellcd::invocation_dir()?;
     let identity = resolve_repo(repo_arg, paths)?;
 
     match resolve_scope(matches, repo_arg.is_none(), &cwd)? {
@@ -260,7 +260,7 @@ fn run_rm(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
         .cloned()
         .collect::<Vec<_>>()
         .join(" ");
-    let cwd = std::env::current_dir()?;
+    let cwd = crate::shellcd::invocation_dir()?;
     let identity = resolve_repo(repo_arg, paths)?;
 
     match resolve_scope(matches, repo_arg.is_none(), &cwd)? {
@@ -277,7 +277,7 @@ fn run_rm(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
 fn run_clear(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
     let repo_arg = matches.get_one::<String>("repo");
     let yes = matches.get_flag("yes");
-    let cwd = std::env::current_dir()?;
+    let cwd = crate::shellcd::invocation_dir()?;
     let identity = resolve_repo(repo_arg, paths)?;
     let scope = resolve_scope(matches, repo_arg.is_none(), &cwd)?;
 
@@ -491,7 +491,7 @@ fn run_registry_clear(paths: &Paths, identity: &str) -> Result<Output> {
 
 fn run_workspace_add(_paths: &Paths, identity: &str, cmd: &str) -> Result<Output> {
     validate_command(cmd)?;
-    let cwd = std::env::current_dir()?;
+    let cwd = crate::shellcd::invocation_dir()?;
     let ws_dir = workspace::detect(&cwd)?;
 
     filelock::with_metadata(&ws_dir, |meta| {
@@ -513,7 +513,7 @@ fn run_workspace_add(_paths: &Paths, identity: &str, cmd: &str) -> Result<Output
 }
 
 fn run_workspace_rm(_paths: &Paths, identity: &str, cmd: &str) -> Result<Output> {
-    let cwd = std::env::current_dir()?;
+    let cwd = crate::shellcd::invocation_dir()?;
     let ws_dir = workspace::detect(&cwd)?;
 
     filelock::with_metadata(&ws_dir, |meta| {
@@ -539,7 +539,7 @@ fn run_workspace_rm(_paths: &Paths, identity: &str, cmd: &str) -> Result<Output>
 }
 
 fn run_workspace_clear(_paths: &Paths, identity: &str) -> Result<Output> {
-    let cwd = std::env::current_dir()?;
+    let cwd = crate::shellcd::invocation_dir()?;
     let ws_dir = workspace::detect(&cwd)?;
 
     filelock::with_metadata(&ws_dir, |meta| {

--- a/crates/wsp/src/cli/status.rs
+++ b/crates/wsp/src/cli/status.rs
@@ -41,7 +41,7 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
         if let Some(name) = matches.try_get_one::<String>("workspace").ok().flatten() {
             workspace::dir(&paths.workspaces_dir, name)
         } else {
-            let cwd = std::env::current_dir()?;
+            let cwd = crate::shellcd::invocation_dir()?;
             workspace::detect(&cwd)?
         };
 

--- a/crates/wsp/src/cli/sync.rs
+++ b/crates/wsp/src/cli/sync.rs
@@ -61,7 +61,7 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
     let ws_dir: PathBuf = if let Some(name) = matches.get_one::<String>("workspace") {
         workspace::dir(&paths.workspaces_dir, name)
     } else {
-        let cwd = std::env::current_dir()?;
+        let cwd = crate::shellcd::invocation_dir()?;
         workspace::detect(&cwd)?
     };
 

--- a/crates/wsp/src/cli/template.rs
+++ b/crates/wsp/src/cli/template.rs
@@ -415,7 +415,7 @@ fn run_export(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
         Ok(Output::None)
     } else {
         let filename = format!("{}.wsp.yaml", name);
-        let dest = std::env::current_dir()?.join(&filename);
+        let dest = crate::shellcd::invocation_dir()?.join(&filename);
         if dest.exists() {
             anyhow::bail!("{:?} already exists", filename);
         }

--- a/crates/wsp/src/shellcd.rs
+++ b/crates/wsp/src/shellcd.rs
@@ -40,9 +40,12 @@ pub fn request(dir: &Path) {
 /// the workspace name as an optional positional and falls back to detecting it
 /// from where the user was standing.
 ///
-/// So the wrapper forwards the original directory in `WSP_PWD`, and commands
-/// that can be invoked behind a vacating wrapper must resolve their cwd through
-/// here rather than calling `current_dir()` directly.
+/// So the wrapper forwards the original directory in `WSP_PWD`, and every
+/// command resolves "where is the user" through here rather than calling
+/// `current_dir()` directly. Not only the ones behind a vacating wrapper case:
+/// which cases vacate changes, and a command that reads the process cwd is
+/// wrong the moment one is added above it. `cli::tests::the_cli_asks_where_the
+/// _user_is` keeps that from happening quietly.
 ///
 /// Falls back to the real cwd when `WSP_PWD` is unset or does not name an
 /// existing directory, so an unwrapped shell and a stale value both behave

--- a/crates/wsp/src/shellnav.rs
+++ b/crates/wsp/src/shellnav.rs
@@ -41,12 +41,10 @@ pub struct ShellNav {
     /// The command *can* strand the shell, but the wrapper does not handle it
     /// yet.
     ///
-    /// This is the third state the old `KNOWN_GAPS` list carried, and it has to
-    /// exist: without it a known-broken command has to be declared `none()`,
-    /// whose contract says the command cannot relocate the shell. That would put
-    /// a false safety claim in the machine-readable declaration and leave a code
-    /// comment as the only record — exactly the failure mode this type exists to
-    /// remove.
+    /// Has to exist: without it a known-broken command has to be declared
+    /// `none()`, whose contract says the command cannot relocate the shell.
+    /// That would put a false safety claim in the machine-readable declaration
+    /// and leave a code comment as the only record.
     pub unhandled_gap: bool,
 }
 
@@ -106,6 +104,10 @@ impl ShellNav {
 
     /// Can strand the shell; wrapper support not written yet. Requires an
     /// issue reference at the call site.
+    ///
+    /// Unused while nothing is broken, which is the intended state. Kept so the
+    /// next gap has somewhere honest to go instead of being declared `none()`.
+    #[allow(dead_code)]
     pub const fn unhandled_gap() -> Self {
         Self {
             vacate: false,

--- a/crates/wsp/tests/shell_cd.rs
+++ b/crates/wsp/tests/shell_cd.rs
@@ -433,6 +433,31 @@ fn apply_env(cmd: &mut Command, env: &Env) {
 
 /// Resolve a `Start` to a real directory, creating the subdirectory when the
 /// case asks to begin deeper than the workspace root.
+/// Register `dir` as a repo of workspace `ws` and create its directory.
+///
+/// Hand-written because `wsp repo add` clones over the network, and the wrapper
+/// behaviour under test does not care whether the directory holds a real clone.
+fn add_repo_fixture(env: &Env, ws: &str, dir: &str) -> String {
+    let ws_dir = env.ws_root.join(ws);
+    std::fs::create_dir_all(ws_dir.join(dir)).expect("create repo dir");
+    let meta_path = ws_dir.join(".wsp.yaml");
+    let meta = std::fs::read_to_string(&meta_path).expect("read metadata");
+    let identity = format!("test.local/u/{dir}");
+    assert!(
+        meta.contains("repos: {}"),
+        "expected an empty repo map to replace, got:\n{meta}"
+    );
+    std::fs::write(
+        &meta_path,
+        meta.replace(
+            "repos: {}\n",
+            &format!("repos:\n  {identity}:\n    upstream_url: git@test.local:u/{dir}.git\n"),
+        ),
+    )
+    .expect("write metadata");
+    identity
+}
+
 fn resolve_start(env: &Env, start: &Start) -> PathBuf {
     match start {
         Start::Root => env.ws_root.clone(),
@@ -1078,4 +1103,63 @@ fn wrapper_preserves_the_previous_directory() {
         }
     }
     assert!(ran > 0, "no shell available to test cd - preservation");
+}
+
+/// `wsp repo rm` deletes a repo directory, so a shell standing in it has to be
+/// moved somewhere that still exists.
+///
+/// Not a `SCENARIOS` row because the fixture needs a hand-written repo entry
+/// rather than a sequence of `wsp` invocations.
+#[test]
+fn repo_rm_moves_the_shell_out_of_the_removed_repo() {
+    for shell in SHELLS {
+        if !is_installed(shell) {
+            continue;
+        }
+        let env = make_env();
+        run_setup(&env, &["new", "w", "--empty"]);
+        let identity = add_repo_fixture(&env, "w", "alpha");
+
+        let start = env.ws_root.join("w").join("alpha");
+        let (ended, stderr) =
+            run_in_shell(shell, &env, &start, &["repo", "rm", &identity, "--force"]);
+
+        assert!(
+            ended.exists(),
+            "shell={} left in a directory that no longer exists: {}\nstderr:\n{stderr}",
+            shell.bin,
+            ended.display()
+        );
+        assert_eq!(
+            canon(&ended),
+            canon(&env.ws_root.join("w")),
+            "shell={} should land in the workspace, not {}\nstderr:\n{stderr}",
+            shell.bin,
+            ended.display()
+        );
+    }
+}
+
+/// The other `repo` subcommands share that wrapper case, so they must be
+/// invisible: same directory, and `cd -` still goes where it did.
+#[test]
+fn other_repo_subcommands_leave_the_shell_alone() {
+    for shell in SHELLS {
+        if !is_installed(shell) {
+            continue;
+        }
+        let env = make_env();
+        run_setup(&env, &["new", "w", "--empty"]);
+        add_repo_fixture(&env, "w", "alpha");
+
+        let start = env.ws_root.join("w").join("alpha");
+        let (ended, stderr) = run_in_shell(shell, &env, &start, &["repo", "ls"]);
+
+        assert_eq!(
+            canon(&ended),
+            canon(&start),
+            "shell={} moved the shell for a read-only subcommand\nstderr:\n{stderr}",
+            shell.bin
+        );
+    }
 }


### PR DESCRIPTION
Stacked on #138 — the guard needs that branch's conversions present. Review the second commit.

## Why

The wrapper steps the shell out of the way before running commands that delete or move the directory it is standing in, and forwards the original location in `WSP_PWD`. A command reading `std::env::current_dir()` sees the wrapper's scratch stop rather than the user, so workspace detection resolves to the wrong place or fails outright.

#138 hit this: making the wrapper vacate for `repo` broke workspace detection in all six `repo` subcommands, because they read the process cwd. That fix converted the 13 sites under `repo`. This converts the other 15.

## Why all of `cli/`, not just the vacating commands

Which wrapper cases vacate changes — `repo` joined them in the previous commit — and a command reading the process cwd becomes wrong the moment a case is added above it. Scoping the rule to today's set means rediscovering the bug next time.

`invocation_dir()` falls back to the process cwd when `WSP_PWD` is unset, so the conversion is behaviour-preserving wherever no wrapper has moved the shell.

The distinction is also narrower than it looks: **wsp never changes its own directory**, so "where the process is" and "where the user is" differ *only* when the wrapper has stepped aside — and there, the user's directory is always the one meant. That includes the two non-detection sites: `wsp init` checks the directory the user is in, and `wsp template export` writes its file there.

## The guard

`cli::tests::the_cli_asks_where_the_user_is` fails on any new `std::env::current_dir()` under `cli/`, naming the file and line:

```
these read the process cwd instead of the user's directory: ["status.rs:44"]
  Use `crate::shellcd::invocation_dir()`, which honours WSP_PWD and falls back
  to the process cwd when it is unset.
```

Two details that matter for a source-scanning test: it splits the needle with `concat!` so it does not match itself, and it skips comment lines so prose about the rule is not mistaken for a breach of it. Mutation-verified by reverting one call site.

## Testing

`just ci` green, `tests/shell_cd.rs` green (8 tests, real shells), full network smoke and offline `smoke.ps1` both pass.

```whatsnew
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
