### PR TITLE
build(xtask): add the cargo alias the docs assume

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+# Repo automation lives in `crates/xtask`. `cargo xtask <task>` is what the
+# `just` recipes, RELEASING.md and the tool's own usage text all name.
+[alias]
+xtask = "run --quiet --package xtask --"

--- a/Justfile
+++ b/Justfile
@@ -19,7 +19,7 @@ check:
 
 # draft release notes from the whatsnew blocks merged since a tag
 whatsnew-draft rev="":
-    @cargo run --quiet -p xtask -- release-notes "{{rev}}"
+    @cargo xtask release-notes "{{rev}}"
 
 # generate SKILL.md from CLI introspection
 skill: (build-bin "codegen")


### PR DESCRIPTION
Follow-up to #137, which merged before this review finding was applied.

`cargo xtask <task>` is what #137's usage text, `scripts/README.md` and `RELEASING.md` all tell you to run — and on `main` today it is not a command:

```
$ cargo xtask release-notes
error: no such command: `xtask`
```

There was no `.cargo/config.toml`, so the alias every reference assumes did not exist. This adds it, and simplifies the `just` recipe to use it.

Verified: `cargo xtask`, `cargo xtask release-notes <rev>`, and `just whatsnew-draft` all work.

```whatsnew
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
