### PR TITLE
fix(exec): correct the sentinel's rationale and pin the signal table

### DIFF
--- a/crates/wsp-core/src/output.rs
+++ b/crates/wsp-core/src/output.rs
@@ -294,10 +294,11 @@ pub struct ExecRepoResult {
     /// signal killed it, or it could not be run at all. `signal` and `error`
     /// say which.
     ///
-    /// `-1` is safe as a sentinel because no process can exit with it: unix
-    /// exit codes are 0-255. That is what makes it preferable to the shell's
-    /// `128 + signal`, which cannot be told apart from a process that genuinely
-    /// called `exit(141)`.
+    /// Preferable to the shell's `128 + signal`, which cannot be told apart
+    /// from a process that genuinely called `exit(141)`. On unix `-1` cannot
+    /// collide at all, since exit codes there are 0-255. On Windows they are
+    /// 32-bit and `exit(-1)` does yield `-1`, but `signal` is never set there,
+    /// so the two cases mean the same thing: no signal, and that is the code.
     pub exit_code: i32,
     /// The signal that killed the process, absent if it exited normally.
     ///

--- a/crates/wsp/src/cli/exec.rs
+++ b/crates/wsp/src/cli/exec.rs
@@ -136,18 +136,17 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
 /// else falls back to the number, which is still better than nothing and does
 /// not pretend to a name that varies by platform.
 fn signal_name(signal: i32) -> String {
-    let name = match signal {
-        1 => "SIGHUP",
-        2 => "SIGINT",
-        3 => "SIGQUIT",
-        6 => "SIGABRT",
-        9 => "SIGKILL",
-        11 => "SIGSEGV",
-        13 => "SIGPIPE",
-        15 => "SIGTERM",
-        _ => return format!("signal {}", signal),
-    };
-    name.to_string()
+    match signal {
+        1 => "SIGHUP".to_string(),
+        2 => "SIGINT".to_string(),
+        3 => "SIGQUIT".to_string(),
+        6 => "SIGABRT".to_string(),
+        9 => "SIGKILL".to_string(),
+        11 => "SIGSEGV".to_string(),
+        13 => "SIGPIPE".to_string(),
+        15 => "SIGTERM".to_string(),
+        other => format!("signal {other}"),
+    }
 }
 
 /// The signal that killed a child, if one did.
@@ -268,6 +267,17 @@ fn run_command(
 
 #[cfg(test)]
 mod tests {
+    /// The numbers are a table, and a typo in a table is invisible.
+    #[test]
+    fn signal_names_match_their_numbers() {
+        assert_eq!(signal_name(2), "SIGINT");
+        assert_eq!(signal_name(9), "SIGKILL");
+        assert_eq!(signal_name(13), "SIGPIPE");
+        assert_eq!(signal_name(15), "SIGTERM");
+        // Anything unlisted still says something useful.
+        assert_eq!(signal_name(31), "signal 31");
+    }
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
Follow-up to #136, which merged before these review findings were applied.

## A doc claim that is wrong on Windows

#136's doc for `exit_code` says `-1` "is safe as a sentinel because no process can exit with it: unix exit codes are 0-255".

True on unix. **Windows exit codes are 32-bit**, and `exit(-1)` — very common in C and C++ — yields `0xFFFFFFFF`, which `ExitStatus::code()` hands back as `-1`. So the sentinel and a real exit code do collide there.

Not a behavioural problem: `signal` is never set on Windows, so both cases mean the same thing — no signal, and that is the code. But the stated rationale was false, and a false rationale in a doc is worse than none, because the next person reasons from it.

## The signal table had no test

The numbers are a table, and a typo in a table is invisible — `9 => "SIGKILL"` transposed to `11` would ship. Now tested, including the fallback for anything unlisted.

`signal_name` also drops an early `return` out of the middle of its `match`, which read worse than plain arms.

```whatsnew
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
