### PR TITLE
test: pin the invariants today's changes rely on

### DIFF
--- a/crates/wsp/src/main.rs
+++ b/crates/wsp/src/main.rs
@@ -300,6 +300,10 @@ fn init_platform() {}
 mod tests {
     use super::is_closed_pipe_message;
 
+    /// Written out per platform rather than derived from `CLOSED_PIPE_MARKERS`:
+    /// building the expected message from the constant under test would pass
+    /// even if the constant held the wrong code.
+    #[cfg(unix)]
     #[test]
     fn a_closed_pipe_is_recognised() {
         assert!(is_closed_pipe_message(
@@ -307,12 +311,34 @@ mod tests {
         ));
     }
 
-    /// The numeric code carries the decision, so a translated `strerror` on a
-    /// non-English system still matches.
+    #[cfg(windows)]
+    #[test]
+    fn a_closed_pipe_is_recognised() {
+        // Windows reports one of two codes depending on which end noticed.
+        assert!(is_closed_pipe_message(
+            "failed printing to stdout: The pipe has been ended. (os error 109)"
+        ));
+        assert!(is_closed_pipe_message(
+            "failed printing to stdout: The pipe is being closed. (os error 232)"
+        ));
+    }
+
+    /// The numeric code carries the decision, so a message in another language
+    /// still matches. Both platforms localize: glibc translates `strerror`, and
+    /// Windows `FormatMessage` returns the system language.
+    #[cfg(unix)]
     #[test]
     fn a_translated_message_still_matches_on_the_code() {
         assert!(is_closed_pipe_message(
             "failed printing to stdout: Relais brisé (pipe) (os error 32)"
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn a_translated_message_still_matches_on_the_code() {
+        assert!(is_closed_pipe_message(
+            "failed printing to stdout: Le canal a été fermé. (os error 109)"
         ));
     }
 

--- a/crates/wsp/src/main.rs
+++ b/crates/wsp/src/main.rs
@@ -227,6 +227,16 @@ fn is_closed_pipe_panic(info: &std::panic::PanicHookInfo<'_>) -> bool {
         .map(String::as_str)
         .or_else(|| payload.downcast_ref::<&str>().copied())
         .unwrap_or_default();
+    is_closed_pipe_message(msg)
+}
+
+/// The decision itself, over the panic message alone.
+///
+/// Separate from the hook so the narrowness can be tested. A `PanicHookInfo`
+/// cannot be constructed, so a test of the hook can only prove that a broken
+/// pipe exits quietly — never that anything else still surfaces, which is the
+/// direction that loses data.
+fn is_closed_pipe_message(msg: &str) -> bool {
     msg.starts_with("failed printing to") && CLOSED_PIPE_MARKERS.iter().any(|m| msg.contains(m))
 }
 
@@ -285,3 +295,46 @@ fn init_platform() {
 
 #[cfg(not(windows))]
 fn init_platform() {}
+
+#[cfg(test)]
+mod tests {
+    use super::is_closed_pipe_message;
+
+    #[test]
+    fn a_closed_pipe_is_recognised() {
+        assert!(is_closed_pipe_message(
+            "failed printing to stdout: Broken pipe (os error 32)"
+        ));
+    }
+
+    /// The numeric code carries the decision, so a translated `strerror` on a
+    /// non-English system still matches.
+    #[test]
+    fn a_translated_message_still_matches_on_the_code() {
+        assert!(is_closed_pipe_message(
+            "failed printing to stdout: Relais brisé (pipe) (os error 32)"
+        ));
+    }
+
+    /// The one that matters. Exiting 0 here would report truncated output as
+    /// success, so a full disk must reach the default hook and abort.
+    #[test]
+    fn other_write_failures_are_not_swallowed() {
+        assert!(!is_closed_pipe_message(
+            "failed printing to stdout: No space left on device (os error 28)"
+        ));
+        assert!(!is_closed_pipe_message(
+            "failed printing to stdout: Input/output error (os error 5)"
+        ));
+    }
+
+    #[test]
+    fn unrelated_panics_are_not_swallowed() {
+        assert!(!is_closed_pipe_message(
+            "index out of bounds: the len is 3 but the index is 7"
+        ));
+        assert!(!is_closed_pipe_message(""));
+        // A broken pipe that did not come from a write to our output.
+        assert!(!is_closed_pipe_message("Broken pipe (os error 32)"));
+    }
+}

--- a/crates/wsp/tests/auto_gc.rs
+++ b/crates/wsp/tests/auto_gc.rs
@@ -221,7 +221,9 @@ fn gate_list_contains_only_mutating_commands() {
             "`{readonly}` is read-only and must not trigger auto-gc"
         );
     }
-    for mutating in ["new", "rm", "rename"] {
+    // `recover` restores a workspace, so it belongs here. It was excluded while
+    // its bare form listed, which is the ambiguity `wsp ls --removed` removed.
+    for mutating in ["new", "rm", "rename", "recover"] {
         assert!(
             gate.contains(&format!("\"{mutating}\"")),
             "`{mutating}` mutates workspaces and should be able to trigger auto-gc"

--- a/crates/xtask/src/release_notes.rs
+++ b/crates/xtask/src/release_notes.rs
@@ -190,6 +190,27 @@ mod tests {
         assert_eq!(blocks_in(b), vec!["- a note\n"]);
     }
 
+    /// `blocks_in` returns a `Vec` because a body can hold more than one, and
+    /// keeping only the first would drop a note silently.
+    #[test]
+    fn two_blocks_in_one_body_both_survive() {
+        let b = body(&[
+            "subject",
+            "",
+            "```whatsnew",
+            "- from the first block",
+            "```",
+            "prose in between",
+            "```whatsnew",
+            "- from the second block",
+            "```",
+        ]);
+        assert_eq!(
+            blocks_in(&b),
+            vec!["- from the first block\n", "- from the second block\n"]
+        );
+    }
+
     /// The caller decides what ships, so nothing may be reordered or deduped.
     #[test]
     fn every_block_survives_in_order() {


### PR DESCRIPTION
Tests only. Findings from reviewing what merged today — each pins an invariant the code already relies on but nothing checked.

## The panic hook could be widened without any test noticing

`main.rs` exits 0 when a write fails because nobody is reading. Three tests covered that direction. **None covered the other one.** Dropping the closed-pipe marker and keeping only the `failed printing to` prefix left every test passing — while a full disk was reported as success.

A `PanicHookInfo` cannot be constructed, so a test driving the binary can only show that a broken pipe exits quietly, never that anything else still surfaces. The decision now lives in `is_closed_pipe_message`, over the message alone, where the cases that must *not* match can be stated:

| message | swallowed? |
|---|---|
| `... Broken pipe (os error 32)` | yes |
| `... Relais brisé (pipe) (os error 32)` | yes — the numeric code is why |
| `... No space left on device (os error 28)` | **no** |
| `... Input/output error (os error 5)` | **no** |
| `index out of bounds: ...` | no |
| `Broken pipe (os error 32)` (not from our write) | no |

Verified by widening the matcher and watching `other_write_failures_are_not_swallowed` fail.

## `recover` was not pinned in the auto-gc gate

`recover` was deliberately excluded from the gate while its bare form listed, because the gate keys on the command name and could not tell a read-only `recover ls` from a mutating `recover <name>`. #132 removed that ambiguity and `recover` joined the gate — but `gate_list_contains_only_mutating_commands` kept its old list, so a revert would go unnoticed.

## `xtask` never tested more than one block per body

`blocks_in` returns a `Vec` because a commit body can hold more than one note, and keeping only the first would drop one silently. Every test used a single block. Mutation-verified.

## Testing

`just ci` green, full network smoke green, 11 test binaries green.

```whatsnew
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
