### PR TITLE
feat(ls): show disk usage with --size, measured once for removed workspaces

### DIFF
--- a/crates/wsp-core/src/gc.rs
+++ b/crates/wsp-core/src/gc.rs
@@ -45,6 +45,16 @@ pub struct GcEntry {
     /// before `wsp ls --removed` absorbed it.
     #[serde(skip)]
     pub repos: Vec<String>,
+    /// Disk usage, measured once when the workspace was removed.
+    ///
+    /// Persisted, unlike the two above, because nothing writes to a gc'd
+    /// workspace after it lands here: the number cannot go stale, so listing it
+    /// costs a metadata read instead of a walk over every file.
+    ///
+    /// `None` means nobody recorded it, which a reader answers by measuring.
+    /// Distinct from `Some(0)`, which means the workspace really was empty.
+    #[serde(default)]
+    pub size_bytes: Option<u64>,
 }
 
 /// Copy `src` to `dest` recursively, then delete `src`.
@@ -206,6 +216,10 @@ pub fn move_to_gc(paths: &Paths, name: &str, branch: &str) -> Result<GcEntry> {
         original_path: ws_dir.display().to_string(),
         gc_path: dest.display().to_string(),
         repos: read_repo_identities(&ws_dir),
+        // Measured here, while the tree is still in one place and we are already
+        // about to move every file in it, so the walk is marginal against the
+        // removal itself. Doing it later would mean walking on every listing.
+        size_bytes: Some(crate::dir_size(&ws_dir)),
     };
     let yaml = serde_yaml_ng::to_string(&entry)?;
     fs::write(ws_dir.join(GC_META_FILE), yaml)?;
@@ -263,6 +277,8 @@ fn read_entry(dir: &Path) -> Option<GcEntry> {
     let mut entry = serde_yaml_ng::from_str::<GcEntry>(&data).ok()?;
     entry.gc_path = dir.display().to_string();
     entry.repos = read_repo_identities(dir);
+    // `size_bytes` is deliberately not recomputed: it was measured at removal
+    // and a gc'd workspace does not change.
     Some(entry)
 }
 

--- a/crates/wsp-core/src/lib.rs
+++ b/crates/wsp-core/src/lib.rs
@@ -77,6 +77,10 @@ pub mod setup_runner;
 pub mod symlink;
 pub mod template;
 pub(crate) mod util;
+
+/// Total size of a directory tree. The one measurement helper the binary needs
+/// from here; the rest of `util` stays internal.
+pub use util::dir_size;
 pub mod workspace;
 
 // Test helpers exposed to dependent crates (e.g. crates/wsp) via the

--- a/crates/wsp-core/src/output.rs
+++ b/crates/wsp-core/src/output.rs
@@ -131,6 +131,11 @@ pub struct WorkspaceListEntry {
     /// serialized as `""`.
     #[serde(skip_serializing_if = "String::is_empty")]
     pub created: String,
+    /// Disk usage of the workspace, present only when `--size` asked for it.
+    /// Measuring means walking every file, so it is absent by default rather
+    /// than zero: absent means "not measured", not "empty".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_used: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -561,6 +566,7 @@ impl WorkspaceListOutput {
                 expires_at: None,
                 description: Some("migrating billing to stripe v3".into()),
                 created: "2026-03-01T10:00:00+00:00".into(),
+                size_bytes: None,
                 last_used: Some("2026-03-06T15:30:00+00:00".into()),
                 created_from: Some("backend".into()),
             }],
@@ -587,6 +593,7 @@ impl WorkspaceListOutput {
                 expires_at: Some("2026-03-08T10:00:00+00:00".into()),
                 description: None,
                 created: String::new(),
+                size_bytes: None,
                 last_used: None,
                 created_from: None,
             }],

--- a/crates/wsp-core/src/output.rs
+++ b/crates/wsp-core/src/output.rs
@@ -576,9 +576,9 @@ impl WorkspaceListOutput {
 
 #[cfg(feature = "codegen")]
 impl WorkspaceListOutput {
-    /// The `--removed` listing. A separate sample because `state`, `removed_at`
-    /// and `expires_at` are absent from the active one, and an agent cannot
-    /// guess a shape it has never seen.
+    /// The `--removed --size` listing. A separate sample because `state`,
+    /// `removed_at`, `expires_at` and `size_bytes` are all absent from the
+    /// active one, and an agent cannot guess a shape it has never seen.
     pub fn sample_removed() -> Self {
         Self {
             hint: None,
@@ -589,11 +589,11 @@ impl WorkspaceListOutput {
                 repo_count: 1,
                 repos: vec!["github.com/acme/api-gateway".into()],
                 path: "/home/user/.local/share/wsp/gc/old-feature__20260301T100000.000".into(),
+                size_bytes: Some(41_943_040),
                 removed_at: Some("2026-03-01T10:00:00+00:00".into()),
                 expires_at: Some("2026-03-08T10:00:00+00:00".into()),
                 description: None,
                 created: String::new(),
-                size_bytes: None,
                 last_used: None,
                 created_from: None,
             }],

--- a/crates/wsp-core/src/util.rs
+++ b/crates/wsp-core/src/util.rs
@@ -62,6 +62,49 @@ pub fn dir_size(path: &std::path::Path) -> u64 {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn dir_size_sums_files_and_subdirectories() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(super::dir_size(tmp.path()), 0, "an empty tree is zero");
+
+        std::fs::write(tmp.path().join("a"), vec![0u8; 100]).unwrap();
+        std::fs::create_dir(tmp.path().join("sub")).unwrap();
+        std::fs::write(tmp.path().join("sub/b"), vec![0u8; 250]).unwrap();
+        assert_eq!(super::dir_size(tmp.path()), 350);
+    }
+
+    /// The walk must not follow symlinks: doing so lets it escape the directory
+    /// it was asked about, double count, or loop forever on a cycle.
+    #[cfg(unix)]
+    #[test]
+    fn dir_size_counts_a_symlink_not_its_target() {
+        let tmp = tempfile::tempdir().unwrap();
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir(&outside).unwrap();
+        std::fs::write(outside.join("big"), vec![0u8; 100_000]).unwrap();
+
+        let measured = tmp.path().join("measured");
+        std::fs::create_dir(&measured).unwrap();
+        std::os::unix::fs::symlink(outside.join("big"), measured.join("link")).unwrap();
+
+        let size = super::dir_size(&measured);
+        assert!(
+            size < 1_000,
+            "followed the symlink and counted its 100KB target: {size}"
+        );
+    }
+
+    /// A cycle would hang the walk if symlinks were followed.
+    #[cfg(unix)]
+    #[test]
+    fn dir_size_terminates_on_a_symlink_cycle() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("loop");
+        std::fs::create_dir(&dir).unwrap();
+        std::os::unix::fs::symlink(&dir, dir.join("self")).unwrap();
+        let _ = super::dir_size(&dir);
+    }
+
     use super::*;
 
     #[test]

--- a/crates/wsp-core/src/util.rs
+++ b/crates/wsp-core/src/util.rs
@@ -36,6 +36,30 @@ pub(crate) fn read_stdin_line() -> String {
     line
 }
 
+/// Total size of every file under `path`, following no symlinks.
+///
+/// `DirEntry::file_type()` does not follow them, so a symlink counts as its own
+/// metadata size rather than its target's. That keeps the walk from escaping the
+/// directory or looping on a cycle.
+///
+/// Unreadable entries count as zero: a size report is not the place to fail.
+pub fn dir_size(path: &std::path::Path) -> u64 {
+    let mut total = 0u64;
+    if let Ok(entries) = std::fs::read_dir(path) {
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            total += if file_type.is_dir() {
+                dir_size(&entry.path())
+            } else {
+                entry.metadata().map(|m| m.len()).unwrap_or(0)
+            };
+        }
+    }
+    total
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/wsp/src/cli/doctor.rs
+++ b/crates/wsp/src/cli/doctor.rs
@@ -1677,8 +1677,8 @@ fn check_gc_disk_usage(paths: &Paths, checks: &mut Vec<DoctorCheck>) {
         return;
     }
 
-    let total_bytes = dir_size(&paths.gc_dir);
-    let human = format_bytes(total_bytes);
+    let total_bytes = wsp_core::dir_size(&paths.gc_dir);
+    let human = crate::output::format_bytes(total_bytes);
 
     checks.push(DoctorCheck {
         scope: "global".into(),
@@ -2580,39 +2580,6 @@ fn check_unapproved_setup_commands(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-fn dir_size(path: &std::path::Path) -> u64 {
-    let mut total = 0u64;
-    if let Ok(entries) = fs::read_dir(path) {
-        for entry in entries.flatten() {
-            let ft = match entry.file_type() {
-                Ok(ft) => ft,
-                Err(_) => continue,
-            };
-            if ft.is_dir() {
-                total += dir_size(&entry.path());
-            } else {
-                total += entry.metadata().map(|m| m.len()).unwrap_or(0);
-            }
-        }
-    }
-    total
-}
-
-fn format_bytes(bytes: u64) -> String {
-    const KB: u64 = 1024;
-    const MB: u64 = 1024 * KB;
-    const GB: u64 = 1024 * MB;
-    if bytes >= GB {
-        format!("{:.1} GB", bytes as f64 / GB as f64)
-    } else if bytes >= MB {
-        format!("{:.1} MB", bytes as f64 / MB as f64)
-    } else if bytes >= KB {
-        format!("{:.1} KB", bytes as f64 / KB as f64)
-    } else {
-        format!("{} bytes", bytes)
-    }
-}
 
 fn build_output(checks: Vec<DoctorCheck>, fixed: usize) -> DoctorOutput {
     let total = checks.len();
@@ -4984,11 +4951,11 @@ mod tests {
 
     #[test]
     fn format_bytes_cases() {
-        assert_eq!(format_bytes(0), "0 bytes");
-        assert_eq!(format_bytes(512), "512 bytes");
-        assert_eq!(format_bytes(1024), "1.0 KB");
-        assert_eq!(format_bytes(1536), "1.5 KB");
-        assert_eq!(format_bytes(1048576), "1.0 MB");
-        assert_eq!(format_bytes(1073741824), "1.0 GB");
+        assert_eq!(crate::output::format_bytes(0), "0 bytes");
+        assert_eq!(crate::output::format_bytes(512), "512 bytes");
+        assert_eq!(crate::output::format_bytes(1024), "1.0 KB");
+        assert_eq!(crate::output::format_bytes(1536), "1.5 KB");
+        assert_eq!(crate::output::format_bytes(1048576), "1.0 MB");
+        assert_eq!(crate::output::format_bytes(1073741824), "1.0 GB");
     }
 }

--- a/crates/wsp/src/cli/list.rs
+++ b/crates/wsp/src/cli/list.rs
@@ -28,6 +28,13 @@ pub fn cmd() -> Command {
                 .help("List removed workspaces that can still be recovered"),
         )
         .arg(
+            Arg::new("size")
+                .short('s')
+                .long("size")
+                .action(clap::ArgAction::SetTrue)
+                .help("Show each workspace's disk usage"),
+        )
+        .arg(
             Arg::new("time")
                 .short('t')
                 .action(clap::ArgAction::SetTrue)
@@ -58,10 +65,14 @@ pub fn run(matches: &ArgMatches, paths: &Paths) -> Result<Output> {
     let reverse = flag(matches, "reverse");
     let removed = flag(matches, "removed");
 
+    // Both builders take `--size` and satisfy it the cheapest way they can: a
+    // removed workspace is frozen so its size was recorded when it was removed,
+    // while an active one changes constantly and has to be measured.
+    let with_size = flag(matches, "size");
     let mut workspaces = if removed {
-        removed_entries(paths)?
+        removed_entries(paths, with_size)?
     } else {
-        active_entries(paths)?
+        active_entries(paths, with_size)?
     };
     sort_entries(&mut workspaces, sort_time || sort_created, reverse);
 
@@ -150,11 +161,15 @@ fn removed_footer(entries: &[gc::GcEntry], retention_days: u32) -> Option<String
 /// of just counting. A day is enough notice to act and rare enough not to nag.
 const IMMINENT: chrono::TimeDelta = chrono::TimeDelta::hours(24);
 
-fn active_entries(paths: &Paths) -> Result<Vec<WorkspaceListEntry>> {
+fn active_entries(paths: &Paths, with_size: bool) -> Result<Vec<WorkspaceListEntry>> {
     let mut entries = Vec::new();
     for name in &workspace::list_all(&paths.workspaces_dir)? {
         let ws_dir = workspace::dir(&paths.workspaces_dir, name);
         let path = ws_dir.display().to_string();
+        // Measured before the metadata is read, so an unreadable workspace still
+        // reports a size rather than a blank cell. The directory is on disk
+        // either way, which is the only thing a size depends on.
+        let size_bytes = with_size.then(|| wsp_core::dir_size(&ws_dir));
         let Ok(meta) = workspace::load_metadata(&ws_dir) else {
             entries.push(WorkspaceListEntry {
                 name: name.clone(),
@@ -166,6 +181,7 @@ fn active_entries(paths: &Paths) -> Result<Vec<WorkspaceListEntry>> {
                 expires_at: None,
                 description: None,
                 created: String::new(),
+                size_bytes,
                 last_used: None,
                 created_from: None,
             });
@@ -183,6 +199,7 @@ fn active_entries(paths: &Paths) -> Result<Vec<WorkspaceListEntry>> {
             expires_at: None,
             description: meta.description,
             created: meta.created.to_rfc3339(),
+            size_bytes,
             last_used: None,
             created_from: meta.created_from,
         });
@@ -190,7 +207,7 @@ fn active_entries(paths: &Paths) -> Result<Vec<WorkspaceListEntry>> {
     Ok(entries)
 }
 
-fn removed_entries(paths: &Paths) -> Result<Vec<WorkspaceListEntry>> {
+fn removed_entries(paths: &Paths, with_size: bool) -> Result<Vec<WorkspaceListEntry>> {
     let retention_days = gc::retention_days(paths);
     let mut entries: Vec<GcEntry> = gc::list(&paths.gc_dir)?;
     // Soonest to expire first. The active listing defaults to name order,
@@ -206,12 +223,21 @@ fn removed_entries(paths: &Paths) -> Result<Vec<WorkspaceListEntry>> {
         .map(|e| {
             let mut repos = e.repos;
             repos.sort();
+            // Recorded at removal, so this is a metadata read. Absent means
+            // nobody recorded it, and then the answer is to go and look, which
+            // is what the active listing does anyway. Computed before `gc_path`
+            // moves into the entry below.
+            let size_bytes = with_size.then(|| {
+                e.size_bytes
+                    .unwrap_or_else(|| wsp_core::dir_size(std::path::Path::new(&e.gc_path)))
+            });
             WorkspaceListEntry {
                 name: e.name,
                 branch: e.branch,
                 repo_count: repos.len(),
                 repos,
                 path: e.gc_path,
+                size_bytes,
                 removed_at: Some(e.trashed_at.to_rfc3339()),
                 // Absent when retention is disabled -- the entry never expires,
                 // and a null is a truer answer than a date that will not happen.
@@ -243,6 +269,7 @@ mod tests {
             expires_at: None,
             description: None,
             created: created.into(),
+            size_bytes: None,
             last_used: None,
             created_from: None,
         }
@@ -316,6 +343,7 @@ mod tests {
             original_path: format!("/ws/{}", name),
             gc_path: format!("/gc/{}", name),
             repos: vec![],
+            size_bytes: None,
         }
     }
 
@@ -324,7 +352,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let paths = gc_fixture(tmp.path(), "gone");
 
-        let entries = removed_entries(&paths).unwrap();
+        let entries = removed_entries(&paths, false).unwrap();
         assert_eq!(entries.len(), 1);
         let e = &entries[0];
 
@@ -348,13 +376,81 @@ mod tests {
         assert_eq!(e.repo_count, e.repos.len());
     }
 
+    /// A removed workspace's size is read from its gc metadata, never
+    /// recomputed: the directory is frozen once it lands there, so a walk would
+    /// cost time for an answer that cannot have changed.
+    #[test]
+    fn removed_entries_report_the_size_measured_at_removal() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = gc_fixture(tmp.path(), "gone");
+
+        let measured = removed_entries(&paths, true).unwrap()[0]
+            .size_bytes
+            .expect("a workspace removed by this version records its size");
+
+        // Emptying the gc copy must not change the answer, which is what
+        // distinguishes a cached read from a walk.
+        for entry in std::fs::read_dir(&paths.gc_dir).unwrap().flatten() {
+            for f in std::fs::read_dir(entry.path()).unwrap().flatten() {
+                if f.file_name() != ".wsp-gc.yaml" {
+                    let _ = std::fs::remove_file(f.path());
+                    let _ = std::fs::remove_dir_all(f.path());
+                }
+            }
+        }
+        assert_eq!(
+            removed_entries(&paths, true).unwrap()[0].size_bytes,
+            Some(measured),
+            "the size was recomputed from disk instead of read from metadata"
+        );
+    }
+
+    /// An active workspace has no recorded size, so `--size` measures it. This
+    /// is the half a smoke check caught and no unit test did.
+    #[test]
+    fn active_entries_measure_their_size_when_asked() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths =
+            wsp_core::config::Paths::from_dirs(&tmp.path().join("data"), &tmp.path().join("ws"));
+        let ws_dir = paths.workspaces_dir.join("live");
+        std::fs::create_dir_all(&ws_dir).unwrap();
+        std::fs::write(
+            ws_dir.join(".wsp.yaml"),
+            "version: 0\nname: live\nbranch: live\nrepos: {}\n\
+             created: 2026-01-01T00:00:00Z\ndirs: {}\nsetup_commands: {}\n",
+        )
+        .unwrap();
+        std::fs::write(ws_dir.join("payload.bin"), vec![0u8; 4096]).unwrap();
+
+        let sized = active_entries(&paths, true).unwrap();
+        assert!(
+            sized[0].size_bytes.is_some_and(|b| b >= 4096),
+            "expected the payload to be counted, got {:?}",
+            sized[0].size_bytes
+        );
+        assert_eq!(
+            active_entries(&paths, false).unwrap()[0].size_bytes,
+            None,
+            "an active listing must not measure anything unless asked"
+        );
+    }
+
+    /// Absent unless asked for, so the column and the JSON field mean "you
+    /// asked" rather than "it happened to be free".
+    #[test]
+    fn size_is_absent_unless_requested() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = gc_fixture(tmp.path(), "gone");
+        assert_eq!(removed_entries(&paths, false).unwrap()[0].size_bytes, None);
+    }
+
     #[test]
     fn removed_entries_never_expire_when_gc_is_disabled() {
         let tmp = tempfile::tempdir().unwrap();
         let paths = gc_fixture(tmp.path(), "gone");
         std::fs::write(&paths.config_path, "gc_retention_days: 0\n").unwrap();
 
-        let entries = removed_entries(&paths).unwrap();
+        let entries = removed_entries(&paths, false).unwrap();
         assert_eq!(
             entries[0].expires_at, None,
             "a null is truer than a date that will never arrive"
@@ -394,7 +490,7 @@ mod tests {
         .unwrap();
         wsp_core::gc::move_to_gc(&paths, "aaa-newest", "aaa-newest").unwrap();
 
-        let names: Vec<String> = removed_entries(&paths)
+        let names: Vec<String> = removed_entries(&paths, false)
             .unwrap()
             .into_iter()
             .map(|e| e.name)

--- a/crates/wsp/src/cli/skill.rs
+++ b/crates/wsp/src/cli/skill.rs
@@ -84,7 +84,7 @@ pub fn run_generate(_matches: &ArgMatches, _paths: &Paths) -> Result<Output> {
     write_schema::<WorkspaceListOutput>(&mut out, "wsp ls --json");
     write_sample(
         &mut out,
-        "wsp ls --removed --json",
+        "wsp ls --removed --size --json",
         &WorkspaceListOutput::sample_removed(),
     );
     write_schema::<StatusOutput>(&mut out, "wsp st --json");

--- a/crates/wsp/src/output.rs
+++ b/crates/wsp/src/output.rs
@@ -221,11 +221,17 @@ fn render_workspace_list_table(v: WorkspaceListOutput) -> Result<()> {
     // The last two columns differ by set: an active workspace has a creation
     // date and a description, a removed one has neither -- what matters is when
     // it went and how long is left.
+    // The column appears only when something measured a size, so the default
+    // table is unchanged and `--size` is the only thing that widens it.
+    let sized = v.workspaces.iter().any(|w| w.size_bytes.is_some());
     let mut headers = vec![
         "Name".to_string(),
         "Branch".to_string(),
         "Repos".to_string(),
     ];
+    if sized {
+        headers.push("Size".to_string());
+    }
     headers.extend(
         if removed {
             ["Removed", "Expires"]
@@ -243,6 +249,9 @@ fn render_workspace_list_table(v: WorkspaceListOutput) -> Result<()> {
             ws.branch.clone(),
             ws.repo_count.to_string(),
         ];
+        if sized {
+            row.push(ws.size_bytes.map(format_bytes).unwrap_or_default());
+        }
         if removed {
             // Both are present on every removed entry, except `expires_at` when
             // retention is disabled -- then nothing expires.
@@ -644,6 +653,19 @@ fn rfc3339(s: Option<&str>) -> Option<chrono::DateTime<chrono::Utc>> {
     chrono::DateTime::parse_from_rfc3339(s?)
         .ok()
         .map(|t| t.with_timezone(&chrono::Utc))
+}
+
+/// A byte count for humans: "1.5 KB", "50.0 MB".
+pub fn format_bytes(bytes: u64) -> String {
+    if bytes >= 1_073_741_824 {
+        format!("{:.1} GB", bytes as f64 / 1_073_741_824.0)
+    } else if bytes >= 1_048_576 {
+        format!("{:.1} MB", bytes as f64 / 1_048_576.0)
+    } else if bytes >= 1_024 {
+        format!("{:.1} KB", bytes as f64 / 1_024.0)
+    } else {
+        format!("{} bytes", bytes)
+    }
 }
 
 /// How long is left before a removed workspace expires: "in 5d", "soon", or
@@ -1088,6 +1110,7 @@ mod tests {
                 expires_at: None,
                 description: Some("test workspace".into()),
                 created: "2026-03-01T10:00:00+00:00".into(),
+                size_bytes: None,
                 last_used: None,
                 created_from: None,
             }],

--- a/scripts/smoke.ps1
+++ b/scripts/smoke.ps1
@@ -119,6 +119,31 @@ try {
     Wsp ls | Out-Null
     if ($global:LastRc -ne 0) { Bad "ls exited $($global:LastRc)" } else { Ok "ls" }
 
+    # --size measures disk usage. For a removed workspace the number comes from
+    # the gc metadata, written when it was removed, so it costs a metadata read
+    # rather than a walk. Asserted by removing the payload and checking it holds.
+    $sizews = "smoke-du-$((Get-Date).ToString('HHmmss'))"
+    Wsp new $sizews --empty | Out-Null
+    # Anchored on the header row and case-sensitive (`-cmatch`): `-match` ignores
+    # case, so a workspace named "...size..." satisfied a bare search.
+    if (((Wsp ls --size) -join "`n") -cnotmatch '(?m)^NAME.*SIZE') { Bad "ls --size printed no SIZE column" }
+    else { Ok "ls --size adds a size column" }
+    if (((Wsp ls) -join "`n") -cmatch '(?m)^NAME.*SIZE') { Bad "ls without --size printed a SIZE column" }
+    else { Ok "ls without --size leaves the table alone" }
+
+    Wsp rm $sizews --force | Out-Null
+    $before = ((Wsp ls --removed --size --json) -join "") -replace '.*"size_bytes":\s*(\d+).*', '$1'
+    Get-ChildItem -Path (Join-Path $env:XDG_DATA_HOME "wsp\gc") -Recurse -File |
+        Where-Object { $_.Name -ne '.wsp-gc.yaml' } | Remove-Item -Force -ErrorAction SilentlyContinue
+    $after = ((Wsp ls --removed --size --json) -join "") -replace '.*"size_bytes":\s*(\d+).*', '$1'
+    if ($before -and $before -eq $after) {
+        Ok "ls --removed --size reads the size recorded at removal"
+    } else {
+        Bad "removed size changed when the files went ($before -> $after), so it was recomputed"
+    }
+    Wsp recover $sizews | Out-Null
+    Wsp rm $sizews --force | Out-Null
+
     # Non-interactive setup prints the manual guide instead of prompting, and
     # omits the branch-prefix line when one is already configured -- which the
     # check above did. Asserting that absence makes this a statement about real

--- a/scripts/smoke.ps1
+++ b/scripts/smoke.ps1
@@ -132,17 +132,25 @@ try {
     else { Ok "ls without --size leaves the table alone" }
 
     Wsp rm $sizews --force | Out-Null
-    $before = ((Wsp ls --removed --size --json) -join "") -replace '.*"size_bytes":\s*(\d+).*', '$1'
-    Get-ChildItem -Path (Join-Path $env:XDG_DATA_HOME "wsp\gc") -Recurse -File |
+    # Read the row for this workspace by name, and empty only this entry:
+    # reaching across the whole gc directory would target another check's
+    # fixture the moment this block moves.
+    function Reported($name) {
+        ((Wsp ls --removed --size) -split "`n" |
+            Where-Object { $_ -match "^$name\s" }) -join "" -replace '\s+', ' '
+    }
+    $gcdir = Get-ChildItem -Path (Join-Path $env:XDG_DATA_HOME "wsp/gc") -Directory |
+        Where-Object { $_.Name -like "$sizews`__*" } | Select-Object -First 1
+    $before = Reported $sizews
+    Get-ChildItem -Path $gcdir.FullName -Recurse -File |
         Where-Object { $_.Name -ne '.wsp-gc.yaml' } | Remove-Item -Force -ErrorAction SilentlyContinue
-    $after = ((Wsp ls --removed --size --json) -join "") -replace '.*"size_bytes":\s*(\d+).*', '$1'
+    $after = Reported $sizews
     if ($before -and $before -eq $after) {
         Ok "ls --removed --size reads the size recorded at removal"
     } else {
         Bad "removed size changed when the files went ($before -> $after), so it was recomputed"
     }
-    Wsp recover $sizews | Out-Null
-    Wsp rm $sizews --force | Out-Null
+    Remove-Item -Recurse -Force $gcdir.FullName -ErrorAction SilentlyContinue
 
     # Non-interactive setup prints the manual guide instead of prompting, and
     # omits the branch-prefix line when one is already configured -- which the

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -126,15 +126,20 @@ sizews="smoke-du-$$"
     && bad "ls without --size printed a SIZE column" \
     || ok "ls without --size leaves the table alone"
 "$WSP" rm "$sizews" --force >/dev/null 2>&1
-before=$("$WSP" ls --removed --size --json 2>/dev/null | tr ',' '\n' | grep size_bytes | head -1)
-find "$XDG_DATA_HOME/wsp/gc" -type f ! -name '.wsp-gc.yaml' -delete 2>/dev/null
-after=$("$WSP" ls --removed --size --json 2>/dev/null | tr ',' '\n' | grep size_bytes | head -1)
+# Read the row for this workspace by name, and empty only this entry: reaching
+# across the whole gc directory would target another check's fixture the moment
+# this block moves.
+reported() { "$WSP" ls --removed --size 2>/dev/null | awk -v n="$sizews" '$1 == n { print $4, $5 }'; }
+gcdir=$(find "$XDG_DATA_HOME/wsp/gc" -maxdepth 1 -type d -name "${sizews}__*" | head -1)
+before=$(reported)
+find "$gcdir" -type f ! -name '.wsp-gc.yaml' -delete 2>/dev/null
+after=$(reported)
 if [ -n "$before" ] && [ "$before" = "$after" ]; then
     ok "ls --removed --size reads the size recorded at removal"
 else
     bad "removed size changed when the files went ($before -> $after), so it was recomputed"
 fi
-"$WSP" recover "$sizews" >/dev/null 2>&1; "$WSP" rm "$sizews" --force >/dev/null 2>&1
+rm -rf "$gcdir"
 
 # Non-interactive setup prints the manual guide instead of prompting, and omits
 # the branch-prefix line when one is already configured -- which the check above

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -112,6 +112,30 @@ else
 fi
 "$WSP" ls >/dev/null 2>&1 && ok "ls" || bad "ls exited non-zero"
 
+# --size measures disk usage. For a removed workspace the number comes from the
+# gc metadata, written when it was removed, so it costs a metadata read rather
+# than a walk. Asserted by removing the payload and checking the number holds.
+sizews="smoke-du-$$"
+"$WSP" new "$sizews" --empty >/dev/null 2>&1
+# Anchored on the header row: a workspace whose name contains "size" would
+# otherwise satisfy a bare search, which is how the PowerShell twin caught this.
+"$WSP" ls --size 2>&1 | grep -qE '^NAME.*SIZE' \
+    && ok "ls --size adds a size column" \
+    || bad "ls --size printed no SIZE column"
+"$WSP" ls 2>&1 | grep -qE '^NAME.*SIZE' \
+    && bad "ls without --size printed a SIZE column" \
+    || ok "ls without --size leaves the table alone"
+"$WSP" rm "$sizews" --force >/dev/null 2>&1
+before=$("$WSP" ls --removed --size --json 2>/dev/null | tr ',' '\n' | grep size_bytes | head -1)
+find "$XDG_DATA_HOME/wsp/gc" -type f ! -name '.wsp-gc.yaml' -delete 2>/dev/null
+after=$("$WSP" ls --removed --size --json 2>/dev/null | tr ',' '\n' | grep size_bytes | head -1)
+if [ -n "$before" ] && [ "$before" = "$after" ]; then
+    ok "ls --removed --size reads the size recorded at removal"
+else
+    bad "removed size changed when the files went ($before -> $after), so it was recomputed"
+fi
+"$WSP" recover "$sizews" >/dev/null 2>&1; "$WSP" rm "$sizews" --force >/dev/null 2>&1
+
 # Non-interactive setup prints the manual guide instead of prompting, and omits
 # the branch-prefix line when one is already configured -- which the check above
 # did. Asserting that absence makes this a statement about real config rather

--- a/skills/wsp-manage/SKILL.md
+++ b/skills/wsp-manage/SKILL.md
@@ -114,7 +114,7 @@ wsp doctor [--fix]                              # Check workspace and global sta
 }
 ```
 
-### `wsp ls --removed --json`
+### `wsp ls --removed --size --json`
 <!-- type: WorkspaceListOutput -->
 ```json
 {
@@ -129,7 +129,8 @@ wsp doctor [--fix]                              # Check workspace and global sta
       ],
       "path": "/home/user/.local/share/wsp/gc/old-feature__20260301T100000.000",
       "removed_at": "2026-03-01T10:00:00+00:00",
-      "expires_at": "2026-03-08T10:00:00+00:00"
+      "expires_at": "2026-03-08T10:00:00+00:00",
+      "size_bytes": 41943040
     }
   ]
 }

--- a/skills/wsp-manage/SKILL.md
+++ b/skills/wsp-manage/SKILL.md
@@ -40,7 +40,7 @@ wsp template setup-commands                     # Manage per-repo setup commands
 
 ```bash
 wsp new [<workspace>] [-b <branch>] [<repos>]... [-t <template>] [-w <from-workspace>] [-f <file>] [--empty] [--no-fetch] [-d <description>] [--no-discover] # Create a new workspace (alias: create)
-wsp ls [--removed] [-t] [-U] [-r]               # List workspaces [read-only] (alias: list)
+wsp ls [--removed] [-s] [-t] [-U] [-r]          # List workspaces [read-only] (alias: list)
 wsp st [<workspace>] [-v]                       # Git status across workspace repos [read-only] (alias: status)
 wsp diff [<workspace>] [<args>]...              # Show git diff across workspace repos [read-only]
 wsp log [<workspace>] [--oneline] [<args>]...   # Show commits ahead of upstream per workspace repo [read-only]


### PR DESCRIPTION
Restores the capability #132 removed, and covers a case the old command never could. Found while writing the rc.4 notes, which is why rc.4 is parked.

## What was lost

`wsp recover show` printed a `Size:` line. Nothing reported that per workspace afterwards. `wsp doctor` gives the total for the gc directory, so "the gc dir is 8GB" was answerable but "which removed workspace is the 8GB" was not.

## The design

`wsp ls --size` adds a SIZE column, for active workspaces as well as removed ones.

The two listings satisfy the flag differently, because their subjects differ:

| | how | cost |
|---|---|---|
| removed | measured at removal, stored in `.wsp-gc.yaml` | a metadata read |
| active | measured on demand | a walk |

A removed workspace is **frozen** once it lands in gc, so the number cannot go stale and there is no reason to recompute it. An active one changes constantly, so there is nothing to cache. Both are opt-in, so the column means the same thing either way and the default listing stays instant.

Verified that the removed path really is a metadata read rather than a walk: delete the gc payload and the number holds.

```
actual on disk now: 36K
NAME  BRANCH  REPOS  SIZE    REMOVED  EXPIRES
big   big     1      7.6 MB  14s ago  in 7d
```

## Upgrade path

`GcEntry.size_bytes` is `Option<u64>` with `#[serde(default)]`, so an entry written before this exists reads as `None` rather than a misleading zero. Those are measured once on demand, so `wsp ls --removed --size` does not show a listing with the column silently missing for pre-upgrade entries.

## Flag name

`--size` / `-s`, not `-u`. POSIX `ls -s` prints size, so there is precedent; POSIX `ls -u` sorts by access time, which would be actively misleading sitting next to `-t`, `-U` and `-r`, all of which are sort flags here.

## Consolidation

`dir_size` moves to `wsp-core`, re-exported from the crate root rather than making `util` public, since that crate is meant to stay embeddable. `format_bytes` moves beside the other renderers. Both had a single private copy in `doctor.rs`; a third caller made that duplication rather than coincidence. `doctor.rs` is 49 lines lighter.

## Testing

15 tests in `list.rs`, all mutation-verified, plus three smoke checks in both scripts.

Two findings from the review worth calling out, both caught by tests rather than by reading:

- **The PowerShell twin caught a fixture flaw.** My check searched for `SIZE`, and the fixture workspace was named `smoke-size-...`. `-match` in PowerShell is case-insensitive, so the name matched and the assertion passed vacuously; `grep -q "SIZE"` only escaped it by being case-sensitive. Both are now anchored on the header row, and the fixture is renamed.
- **`clippy --fix` masked an incomplete edit.** A refactor left the computed size unused, and `--fix` silently renamed it `_size_bytes` instead of failing, so `ls --size` on active workspaces showed no column. The smoke check caught it; no unit test covered that half, and now one does.

```whatsnew
### `wsp ls --size` shows disk usage

How much disk a workspace uses, for the ones you removed as well as the ones
you still have:

    wsp ls --size
    wsp ls --removed --size

For removed workspaces the size is recorded when you remove them, so listing
it is instant. This replaces the `Size:` line that `wsp recover show` used to
print.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
