### PR TITLE
chore(release): v0.19.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.19.0-rc.4] - 2026-08-26
+
+### Features
+
+- *(hints)* Warn when a workspace name collides with a recover subcommand (#130)
+- *(recover)* Split listing out of recover into wsp ls --removed (#132)
+- *(exec)* Report which signal killed a command (#136)
+- *(doctor)* Warn when clones cannot hardlink to mirrors (#145)
+- *(ls)* Show disk usage with --size, measured once for removed workspaces (#148)
+
+### Bug Fixes
+
+- *(gc)* Only auto-gc after mutating commands, and say what was purged (#131)
+- *(exec)* Exit quietly when the reader of our output goes away (#134)
+- *(exec)* Don't report a child killed by our own reader leaving (#135)
+- *(completion)* Move the shell out of a repo directory that repo rm deletes (#138)
+- *(exec)* Correct the sentinel's rationale and pin the signal table (#141)
+
+### Refactor
+
+- *(cli)* Ask where the user is, not where the process is (#139)
+
+### Documentation
+
+- *(completion)* Write down the wrapper's contract where it will be read (#128)
+- *(agents)* Review your own diff before opening the PR (#143)
+- *(skills)* Move testing and review guidance into a skill (#144)
+- Record the release-note and local-verification rules from 0.19.0 (#146)
+- *(agents)* Put the remaining conventions in git (#151)
+
+### Testing
+
+- Pin the invariants today's changes rely on (#142)
+- *(agents)* Guard that every output field is visible in the contract (#149)
+
+### Build
+
+- *(xtask)* Move release-note drafting into a Rust crate (#137)
+- *(xtask)* Add the cargo alias the docs assume (#140)
+
+### Ci
+
+- *(smoke)* Run the smoke scripts on every PR, and close the coverage gap (#133)
+
 ## [0.19.0-rc.3] - 2026-08-24
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,7 +1540,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wsp"
-version = "0.19.0-rc.3"
+version = "0.19.0-rc.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "wsp-core"
-version = "0.19.0-rc.3"
+version = "0.19.0-rc.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.19.0-rc.3"
+version = "0.19.0-rc.4"
 dependencies = [
  "anyhow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version    = "0.19.0-rc.3"
+version    = "0.19.0-rc.4"
 edition    = "2024"
 license    = "MIT"
 repository = "https://github.com/jganoff/wsp"

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -1,5 +1,82 @@
 # What's New
 
+## [0.19.0-rc.4] - 2026-08-26
+
+### Breaking Changes
+
+#### `wsp recover` no longer lists
+
+`wsp recover` with no arguments used to list what could be restored, and `wsp
+recover show <name>` printed one workspace's details. Both are gone. `wsp ls
+--removed` replaces them:
+
+```
+wsp recover              ->  wsp ls --removed
+wsp recover show <name>  ->  wsp ls --removed --size
+```
+
+`wsp recover <name>` is unchanged, and now works for every name. A workspace
+called `ls` or `show` could not be recovered at all before. Bare `wsp recover`
+tells you how many workspaces are recoverable and points at `wsp ls
+--removed`.
+
+### What's New
+
+#### `wsp ls --removed`
+
+Lists workspaces you removed but can still restore, soonest to expire first,
+with their repos and how long is left. `-t`, `-U` and `-r` sort it.
+
+```
+wsp ls --removed
+```
+
+Plain `wsp ls` now ends with a line counting what is recoverable, and names
+the workspace when it is within a day of being purged for good.
+
+#### `wsp ls --size` shows disk usage
+
+How much disk a workspace is using, for the ones you removed as well as the
+ones you still have. This is what `wsp recover show` used to print.
+
+```
+wsp ls --size
+wsp ls --removed --size
+```
+
+#### `wsp doctor` checks that your workspaces and wsp's data share a disk
+
+When they do not, each workspace keeps its own full copy of every repo's git
+history instead of sharing one, which costs a lot of disk, and removing a
+workspace is no longer a single step, so an interrupted `wsp rm` can leave
+part of it behind. `wsp doctor` now warns, with both paths.
+
+```
+wsp doctor
+```
+
+### Fixes
+
+- `wsp ls`, `wsp st` and other read-only commands no longer delete expired
+  recoverable workspaces as a side effect. Cleanup only happens after a
+  command that changes something, and says what it removed.
+- `wsp repo rm` no longer leaves your shell in the deleted repo's directory.
+  It puts you in the workspace instead. On Windows the removal used to fail
+  outright when you were standing in the repo.
+- `wsp exec`, `wsp fetch` and `wsp sync` no longer crash when you pipe them
+  into something that stops reading early, such as `head` or `grep -q`. They
+  stop quietly, and `wsp exec` no longer reports the interrupted command as a
+  failure.
+- `wsp exec` names the signal that killed a command instead of reporting `exit
+  status -1`. `--json` carries the number in a new `signal` field.
+- `wsp ls` no longer hides the recoverable-workspace notice when you have no
+  active workspaces left, which is exactly when you need it.
+- `wsp rm` tells you the date recovery stops working, instead of a duration
+  you have to count from, and no longer claims a workspace is recoverable when
+  it had no metadata and was deleted outright.
+- `wsp help --json` and `wsp repo setup-commands --json` now appear in the
+  JSON schema reference, alongside output fields that had no example.
+
 ## [0.19.0-rc.3] - 2026-08-24
 
 ### Fixes


### PR DESCRIPTION
Release PR for **v0.19.0-rc.4**. Do not squash-merge differently from the others: the version bump and the notes are one commit, as `RELEASING.md` requires.

## What is in this RC

Everything merged since rc.3 (#128, #131 through #151). The user-facing shape of it:

**Breaking** — `wsp recover` no longer lists. `wsp recover` bare and `wsp recover show <name>` are gone; `wsp ls --removed` replaces them. `wsp recover <name>` is unchanged and now works for every name, including a workspace called `ls` or `show`, which could not be recovered before because the name matched a subcommand.

**New** — `wsp ls --removed`, `wsp ls --size`, `wsp exec` naming the signal that killed a command, and a `wsp doctor` check for workspaces and mirrors landing on different filesystems.

**Fixes** — eight, led by the data-loss one: read-only commands no longer purged recoverable workspaces as a side effect.

## Notes were not taken verbatim from the draft

`just whatsnew-draft` collects the blocks each PR wrote, and two of them described behaviour that no longer exists. Both are excluded:

- the `wsp new` collision hint, whose PR was reverted. `git cliff` still lists it as a feature, because it reads commit subjects, and its note told users to run `wsp recover -- <name>` for names that are now directly recoverable.
- a claim that `wsp exec` reports `128 + signal`, which a later PR replaced with a `signal` field.

This is the case `RELEASING.md` now warns about: a block is written when its PR opens and never revisited, so the draft can carry notes for work that was later reverted or superseded.

## Checks against the format rules

| | |
|---|---|
| em dashes | 0 |
| lines over 78 chars | 0 |
| PR or version numbers in headings | none |
| every `wsp` command verified against `--help` | yes |
| maintainer-only changes excluded | xtask, the `invocation_dir` refactor, the guards, the skill and AGENTS.md docs |

`wsp whatsnew` renders the new section from the compiled binary. `just ci` and the full network smoke suite pass.

## Sequencing note

This branch was rebuilt from current `main` rather than rebased. The first attempt was cut before #148, #149 and #151 landed, so its `CHANGELOG.md` predated all three and its notes documented the loss of per-workspace disk size that `wsp ls --size` restores.

## After merge

`just release-dispatch 0.19.0-rc.4`. Homebrew publish is expected to skip, as it does for every prerelease.

```whatsnew
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
