### PR TITLE
build(dist): pin the actions dist emits into release.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,12 +10,27 @@ version: 2
 # with extra steps — Dependabot moves a pin, it does not vet what changed.
 #
 # KNOWN INTERACTION WITH release.yml: Dependabot scans every workflow file and
-# cannot be scoped to a subset, so it will also propose bumps to release.yml —
-# which cargo-dist owns and regenerates (it currently uses floating tags such as
-# actions/checkout@v4, the SHA pins added in c81eb93 having been overwritten).
-# A Dependabot PR touching release.yml will fail the `dist plan` freshness check.
-# That failure is loud and self-explanatory: close the PR and bump cargo-dist
-# instead, rather than hand-editing release.yml.
+# cannot be scoped to a subset, so it also sees release.yml — which cargo-dist
+# owns and regenerates. Editing that file by hand fails the `dist plan`
+# freshness check, so such a PR can never merge.
+#
+# The pins in `[dist.github-action-commits]` (dist-workspace.toml) are what
+# keep this quiet. dist otherwise emits floating tags it will never advance, so
+# release.yml is permanently out of date and the hunk rides along with every
+# grouped PR. Pinned to current SHAs there is nothing to propose, and the file
+# finally matches the SHA-pinning the comment above describes.
+#
+# When an action genuinely ships a new version Dependabot will propose it in
+# release.yml too, and that PR still cannot merge. Close it, update the SHA in
+# `[dist.github-action-commits]`, re-run `dist generate`, and take the ci.yml /
+# audit.yml hunks as your own PR.
+#
+# Do not reach for an ignore rule to exclude release.yml — there isn't one.
+# `ignore` filters by dependency (`dependency-name`, `versions`, `update-types`),
+# never by path, and github-actions is directory-scoped to "/". The only
+# dependency-level escape is ignoring the action outright, which would also stop
+# the bumps in ci.yml and audit.yml. Two reviewers proposed the file-level rule
+# independently before checking; it is a dead end, not an oversight.
 #
 # Cargo is deliberately absent. Dependency advisories are covered by
 # .github/workflows/audit.yml (nightly) and by CI's per-push audit, which also

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,28 +9,11 @@ version: 2
 # Reviewing these PRs is the point. Merging them unread re-creates floating tags
 # with extra steps — Dependabot moves a pin, it does not vet what changed.
 #
-# KNOWN INTERACTION WITH release.yml: Dependabot scans every workflow file and
-# cannot be scoped to a subset, so it also sees release.yml — which cargo-dist
-# owns and regenerates. Editing that file by hand fails the `dist plan`
-# freshness check, so such a PR can never merge.
-#
-# The pins in `[dist.github-action-commits]` (dist-workspace.toml) are what
-# keep this quiet. dist otherwise emits floating tags it will never advance, so
-# release.yml is permanently out of date and the hunk rides along with every
-# grouped PR. Pinned to current SHAs there is nothing to propose, and the file
-# finally matches the SHA-pinning the comment above describes.
-#
-# When an action genuinely ships a new version Dependabot will propose it in
-# release.yml too, and that PR still cannot merge. Close it, update the SHA in
-# `[dist.github-action-commits]`, re-run `dist generate`, and take the ci.yml /
-# audit.yml hunks as your own PR.
-#
-# Do not reach for an ignore rule to exclude release.yml — there isn't one.
-# `ignore` filters by dependency (`dependency-name`, `versions`, `update-types`),
-# never by path, and github-actions is directory-scoped to "/". The only
-# dependency-level escape is ignoring the action outright, which would also stop
-# the bumps in ci.yml and audit.yml. Two reviewers proposed the file-level rule
-# independently before checking; it is a dead end, not an oversight.
+# Dependabot also sees release.yml, which cargo-dist owns; a PR touching it
+# cannot merge. AGENTS.md has the procedure. Do not try to scope Dependabot off
+# that file — `ignore` filters by dependency, never by path, and github-actions
+# is directory-scoped to "/". Two reviewers proposed a path rule independently
+# before checking; it does not exist.
 #
 # Cargo is deliberately absent. Dependency advisories are covered by
 # .github/workflows/audit.yml (nightly) and by CI's per-push audit, which also

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
           submodules: recursive
@@ -70,7 +70,7 @@ jobs:
         shell: bash
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/dist
@@ -86,7 +86,7 @@ jobs:
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: artifacts-plan-dist-manifest
           path: plan-dist-manifest.json
@@ -120,7 +120,7 @@ jobs:
       - name: enable windows longpaths
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
           submodules: recursive
@@ -135,7 +135,7 @@ jobs:
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -162,7 +162,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: artifacts-build-local-${{ join(matrix.targets, '_') }}
           path: |
@@ -179,19 +179,19 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -209,7 +209,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: artifacts-build-global
           path: |
@@ -239,19 +239,19 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Fetch artifacts from scratch-storage
       - name: Fetch artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -264,14 +264,14 @@ jobs:
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           # Overwrite the previous copy
           name: artifacts-dist-manifest
           path: dist-manifest.json
       # Create a GitHub Release while uploading all files to it
       - name: "Download GitHub Artifacts"
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           pattern: artifacts-*
           path: artifacts
@@ -304,14 +304,14 @@ jobs:
       GITHUB_EMAIL: "admin+bot@axo.dev"
     if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: true
           repository: "jganoff/homebrew-tap"
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
       # So we have access to the formula
       - name: Fetch homebrew formulae
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           pattern: artifacts-*
           path: Formula/
@@ -351,7 +351,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
           submodules: recursive

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,17 +153,13 @@ Put `NONE` in the block when a user cannot observe the change by running `wsp` �
 
 This works because squash is the only merge method here and the squash body is the PR description verbatim, so the block lands in `main`'s commit body. `just whatsnew-draft` collects them at release time from `git log` alone — no network, no bot, no fragment files. **If merge commits or rebase merging are ever enabled, notes silently stop reaching `main`** and it goes quiet.
 
-**Do not manually edit `release.yml`.** It is fully owned by `cargo-dist` — any hand-edits (e.g. SHA-pinning actions) will be overwritten the next time `dist generate` runs, and the `dist plan` freshness check in CI will fail on every PR until they are reverted.
+**`release.yml` belongs to cargo-dist.** Never hand-edit it — `dist generate` overwrites the change and the `dist plan` gate fails until it is reverted. To change an action, edit `[dist.github-action-commits]` in `dist-workspace.toml` and re-run `dist generate`.
 
-**To change an action in `release.yml`, edit `[dist.github-action-commits]`** in `dist-workspace.toml` and re-run `dist generate`. That table pins each action dist emits to a commit SHA (available since cargo-dist 0.29.0). Editing the workflow directly does not work — `dist generate` overwrites it and `dist plan` fails until it is reverted.
+Keep those pins current. dist otherwise emits floating tags it never advances, so `release.yml` is permanently out of date and its hunk rides along with every grouped Dependabot PR.
 
-The pins are what keep Dependabot quiet. Left to itself dist emits floating tags it will never advance, so `release.yml` is *permanently* out of date, and the hunk rides along with every grouped Dependabot PR — failing `plan` each time, unmergeable each time. Pinned to current SHAs there is nothing to propose.
+**A Dependabot PR touching `release.yml` cannot merge**, and one appears whenever an action ships a new version. Close it, update the SHA in `[dist.github-action-commits]`, re-run `dist generate`, and take the `ci.yml` / `audit.yml` hunks as your own PR.
 
-**A Dependabot PR that touches `release.yml` still cannot be merged**, and one will appear whenever an action genuinely ships a new version. That is now a signal rather than noise: close the PR, update the SHA in `[dist.github-action-commits]`, re-run `dist generate`, and take the `ci.yml` / `audit.yml` hunks as your own PR.
-
-Do not try to exclude `release.yml` from Dependabot. `ignore` filters by dependency, never by path — see the comment in `.github/dependabot.yml`.
-
-Do not reach for `allow-dirty` either. It silences the freshness check, which is the thing that catches genuine hand-edits, and `dist generate` still overwrites the file.
+Two dead ends, both tried: Dependabot's `ignore` filters by dependency and never by path, so `release.yml` cannot be excluded; and `allow-dirty` silences the freshness check that catches genuine hand-edits.
 
 Note Dependabot leaves the trailing `# v4`-style comment stale when it bumps a SHA pin — it will happily put `# v4` beside a v7.0.1 SHA. For a SHA pin that comment is the only human-readable version marker, so correct it by hand; a wrong one is worse than none.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,11 +155,15 @@ This works because squash is the only merge method here and the squash body is t
 
 **Do not manually edit `release.yml`.** It is fully owned by `cargo-dist` — any hand-edits (e.g. SHA-pinning actions) will be overwritten the next time `dist generate` runs, and the `dist plan` freshness check in CI will fail on every PR until they are reverted.
 
-**To update the actions in `release.yml`, bump cargo-dist** in `dist-workspace.toml` and re-run `dist generate`. That is the only supported path; Dependabot cannot do it (see below).
+**To change an action in `release.yml`, edit `[dist.github-action-commits]`** in `dist-workspace.toml` and re-run `dist generate`. That table pins each action dist emits to a commit SHA (available since cargo-dist 0.29.0). Editing the workflow directly does not work — `dist generate` overwrites it and `dist plan` fails until it is reverted.
 
-**Dependabot PRs that touch `release.yml` cannot be merged — close them.** Dependabot cannot be scoped to a subset of workflow files, so its grouped actions PR always includes `release.yml`, always fails `plan`, and is blocked. Those hunks are futile regardless: the next `dist generate` overwrites them. Take the `ci.yml` / `audit.yml` changes as your own PR and drop the rest.
+The pins are what keep Dependabot quiet. Left to itself dist emits floating tags it will never advance, so `release.yml` is *permanently* out of date, and the hunk rides along with every grouped Dependabot PR — failing `plan` each time, unmergeable each time. Pinned to current SHAs there is nothing to propose.
 
-This gap is inherent, not version lag — dist pins what it pins while Dependabot chases latest, so no cargo-dist version closes it (0.32.0 emits `checkout@v6` against Dependabot's `v7`). It only recurs when an action ships a new major, since closing a Dependabot PR suppresses that version until a newer one appears.
+**A Dependabot PR that touches `release.yml` still cannot be merged**, and one will appear whenever an action genuinely ships a new version. That is now a signal rather than noise: close the PR, update the SHA in `[dist.github-action-commits]`, re-run `dist generate`, and take the `ci.yml` / `audit.yml` hunks as your own PR.
+
+Do not try to exclude `release.yml` from Dependabot. `ignore` filters by dependency, never by path — see the comment in `.github/dependabot.yml`.
+
+Do not reach for `allow-dirty` either. It silences the freshness check, which is the thing that catches genuine hand-edits, and `dist generate` still overwrites the file.
 
 Note Dependabot leaves the trailing `# v4`-style comment stale when it bumps a SHA pin — it will happily put `# v4` beside a v7.0.1 SHA. For a SHA pin that comment is the only human-readable version marker, so correct it by hand; a wrong one is worse than none.
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -45,20 +45,3 @@ formula = "wsp"
 "actions/checkout" = "3d3c42e5aac5ba805825da76410c181273ba90b1"          # v7.0.1
 "actions/upload-artifact" = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"   # v7
 "actions/download-artifact" = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" # v8
-
-# Pin the actions dist emits into release.yml, matching how every hand-written
-# workflow here is pinned: a moved tag cannot then swap in different code.
-#
-# Without this dist emits floating tags (checkout@v6, upload-artifact@v7,
-# download-artifact@v8), which is both a supply-chain gap and the reason
-# Dependabot keeps opening PRs against release.yml that can never merge — a
-# floating tag dist will not advance is permanently out of date, so the hunk
-# rides along with every grouped update and fails `dist plan` each time.
-#
-# dist writes bare SHAs with no trailing version comment, so this table is the
-# only human-readable record of which version each SHA is. Keep the comments
-# accurate, and re-run `dist generate` after editing.
-[dist.github-action-commits]
-"actions/checkout" = "3d3c42e5aac5ba805825da76410c181273ba90b1"          # v7.0.1
-"actions/upload-artifact" = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"   # v7
-"actions/download-artifact" = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" # v8

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -28,3 +28,37 @@ publish-jobs = ["homebrew"]
 tap = "jganoff/homebrew-tap"
 # Homebrew formula name
 formula = "wsp"
+
+# Pin the actions dist emits into release.yml, matching how every hand-written
+# workflow here is pinned: a moved tag cannot then swap in different code.
+#
+# Without this dist emits floating tags (checkout@v6, upload-artifact@v7,
+# download-artifact@v8), which is both a supply-chain gap and the reason
+# Dependabot keeps opening PRs against release.yml that can never merge — a
+# floating tag dist will not advance is permanently out of date, so the hunk
+# rides along with every grouped update and fails `dist plan` each time.
+#
+# dist writes bare SHAs with no trailing version comment, so this table is the
+# only human-readable record of which version each SHA is. Keep the comments
+# accurate, and re-run `dist generate` after editing.
+[dist.github-action-commits]
+"actions/checkout" = "3d3c42e5aac5ba805825da76410c181273ba90b1"          # v7.0.1
+"actions/upload-artifact" = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"   # v7
+"actions/download-artifact" = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" # v8
+
+# Pin the actions dist emits into release.yml, matching how every hand-written
+# workflow here is pinned: a moved tag cannot then swap in different code.
+#
+# Without this dist emits floating tags (checkout@v6, upload-artifact@v7,
+# download-artifact@v8), which is both a supply-chain gap and the reason
+# Dependabot keeps opening PRs against release.yml that can never merge — a
+# floating tag dist will not advance is permanently out of date, so the hunk
+# rides along with every grouped update and fails `dist plan` each time.
+#
+# dist writes bare SHAs with no trailing version comment, so this table is the
+# only human-readable record of which version each SHA is. Keep the comments
+# accurate, and re-run `dist generate` after editing.
+[dist.github-action-commits]
+"actions/checkout" = "3d3c42e5aac5ba805825da76410c181273ba90b1"          # v7.0.1
+"actions/upload-artifact" = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"   # v7
+"actions/download-artifact" = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" # v8


### PR DESCRIPTION
```whatsnew
NONE
```

## What

`release.yml` used floating tags — `checkout@v6`, `upload-artifact@v7`, `download-artifact@v8` — while every hand-written workflow in the repo is pinned to a commit SHA. This pins them through dist's own config.

```toml
[dist.github-action-commits]
"actions/checkout" = "3d3c42e5aac5ba805825da76410c181273ba90b1"          # v7.0.1
"actions/upload-artifact" = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"   # v7
"actions/download-artifact" = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" # v8
```

## Why this is the answer to #150

I first wrote this up as "close Dependabot PRs forever, the gap is inherent." That was wrong, and #150 is what exposed it.

A floating tag **dist will never advance** is *permanently* out of date. So the `release.yml` hunk doesn't wait for a new `checkout` major — it rides along with every grouped Dependabot PR, fails `dist plan` every time, and can never merge. That's not an inherent gap; it's a config we hadn't set.

cargo-dist **0.29.0** added `[dist.github-action-commits]` for precisely this. We're on **0.32.0** — the feature landed three releases before the one we pin. It was version lag after all, just not in the direction the docs assumed.

Pinned to current SHAs, Dependabot has nothing to propose against `release.yml`.

## Being clear about what this does not fix

**Dependabot PRs touching `release.yml` still can't merge.** Nothing short of dist not owning the file changes that. When an action genuinely ships a new version, Dependabot will propose it there too and `plan` will fail.

What changes is the character of it: from permanent noise with no action available, to a once-per-release signal with a supported response — close the PR, update the SHA here, re-run `dist generate`.

## Also a supply-chain fix

`release.yml` was the one place a moved tag could swap in different code. The `dependabot.yml` comment already complained about this — *"the SHA pins added in c81eb93 having been overwritten"* — and it's no longer true.

Where they overlap, the SHAs match what the repo already pins: `checkout@v7.0.1` is the same SHA as `ci.yml`, `download-artifact@v8` the same as `smoke.yml`.

## Ruled out, so nobody retries them

- **Excluding `release.yml` via Dependabot `ignore`** — doesn't exist. `ignore` filters by `dependency-name` / `versions` / `update-types`, never by path; `github-actions` is directory-scoped to `/`. Two reviewers proposed this independently before checking, so it's now written down as a dead end.
- **Ignoring `actions/checkout` outright** — also kills the `ci.yml` and `audit.yml` bumps, which are the ones worth having.
- **`allow-dirty`** — dist suggests it in the failure text. It silences the freshness check that catches genuine hand-edits, and `dist generate` overwrites the file regardless.
- **Upstream doing it for us** — cargo-dist's own `dependabot.yml` has no special handling at all, so there's no pattern to copy from the tool's authors.

## Verification

Against the installed dist 0.32.0, not the docs:

- [x] `dist generate` emits all three SHAs into `release.yml`
- [x] `dist generate --check` exits 0 — the `plan` gate will pass
- [x] `release.yml` parses; all 7 jobs intact
- [x] SHAs resolved via `gh api repos/<action>/commits/<tag>`

Docs corrected: `AGENTS.md` and `.github/dependabot.yml` both said "close them forever, the gap is inherent."

Closes the question behind #153. #150 should be closed — the bump it wants is now already in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
