### PR TITLE
docs(skills): add release notes drafting workflow

### DIFF
--- a/.claude/skills/wsp-release-notes/SKILL.md
+++ b/.claude/skills/wsp-release-notes/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: wsp-release-notes
+description: Draft wsp release notes from merged PR whatsnew blocks, removing stale notes and shaping the result for users. Use when preparing WHATSNEW.md for a wsp release, separately from dispatching the release.
+user_invocable: true
+---
+
+# Draft wsp release notes
+
+Read `RELEASING.md`, especially "Writing release notes", before editing. It is
+the source of truth for content, structure, and formatting.
+
+Run `just whatsnew-draft`, optionally passing the specific previous tag supplied
+by the user. Treat the result as raw material rather than text to paste.
+
+Before drafting:
+
+- Compare every note with the commits that followed it. Delete work that was
+  reverted and replace descriptions superseded by later behavior.
+- Combine multiple symptoms of one cause into one user-facing note and order
+  notes by impact.
+- Check recent `WHATSNEW.md` entries so the draft does not re-announce work that
+  already shipped.
+- Verify every mentioned command and flag against `wsp --help` and the relevant
+  subcommand help.
+
+Write the new section in `WHATSNEW.md` using the post-bump version and current
+date. Follow all format rules in `RELEASING.md`, including the ban on em dashes.
+Do not dispatch a release, push, tag, or open a pull request unless the user
+separately asks for that action.

--- a/.claude/skills/wsp-release/SKILL.md
+++ b/.claude/skills/wsp-release/SKILL.md
@@ -15,15 +15,10 @@ version.
 1. Stop if the tree is dirty. Run `just build` so later checks use current code.
 2. `just changelog`, show the user the unreleased entries, and confirm the bump
    level matches them.
-3. Run `just whatsnew-draft` to collect the notes each PR wrote for
-   itself, then shape them into the `WHATSNEW.md` section per the rules in
-   `RELEASING.md`. Prefer those notes over re-deriving prose from the
-   changelog — the author had the context. **Show the draft and wait for
-   approval** before continuing; the user may rewrite it.
+3. Use `/wsp-release-notes` to draft the `WHATSNEW.md` section. **Show the
+   draft and wait for approval** before continuing; the user may rewrite it.
 4. Work through the flow in `RELEASING.md`. Do not merge the release PR
    yourself.
 5. After it merges, run `just release-dispatch <version>` and report each job.
    Say plainly whether `publish-homebrew-formula` ran or skipped. The release
    body is filled in automatically; no manual edit.
-Verify every `wsp <cmd>` in the notes against `wsp --help` before showing the
-draft — do not rely on memory for command names.


### PR DESCRIPTION
Part of #147.

Add a dedicated `/wsp-release-notes` maintainer skill that turns `just whatsnew-draft` output into release notes. It explicitly checks for reverted or superseded behavior, consolidates related notes, checks recent releases, and verifies mentioned commands.

Update `/wsp-release` to delegate note drafting to the new sibling skill, keeping drafting and release dispatch as separate workflows.

Validation:
- Reviewed against `RELEASING.md`
- Confirmed it follows the existing repo-local Claude skill schema and invocation convention
- Confirmed no `agentmd` registration is appropriate because this is a repo maintainer skill, not a skill installed into user workspaces
- `git diff --check`
- `just ci` as part of the complete issue review

```whatsnew
NONE
```