### PR TITLE
chore(release): v0.19.0-rc.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.19.0-rc.5] - 2026-08-27
+
+### Features
+
+- *(hints)* Warn when mirrors cannot hardlink (#157)
+
+### Bug Fixes
+
+- *(rename)* Preserve shell subdirectory position (#156)
+
+### Documentation
+
+- *(skills)* Add release notes drafting workflow (#155)
+
 ## [0.19.0-rc.4] - 2026-08-26
 
 ### Features
@@ -41,6 +55,7 @@ All notable changes to this project will be documented in this file.
 
 - *(xtask)* Move release-note drafting into a Rust crate (#137)
 - *(xtask)* Add the cargo alias the docs assume (#140)
+- *(dist)* Pin the actions dist emits into release.yml (#154)
 
 ### Ci
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,7 +1540,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wsp"
-version = "0.19.0-rc.4"
+version = "0.19.0-rc.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "wsp-core"
-version = "0.19.0-rc.4"
+version = "0.19.0-rc.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.19.0-rc.4"
+version = "0.19.0-rc.5"
 dependencies = [
  "anyhow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version    = "0.19.0-rc.4"
+version    = "0.19.0-rc.5"
 edition    = "2024"
 license    = "MIT"
 repository = "https://github.com/jganoff/wsp"

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -1,5 +1,13 @@
 # What's New
 
+## [0.19.0-rc.5] - 2026-08-27
+
+- `wsp rename` now keeps you in the equivalent subdirectory of the renamed
+  workspace instead of moving you to its root.
+- `wsp new` now warns when your workspace location causes Git data to be
+  duplicated, increasing disk usage. It shows which directories to move onto
+  the same filesystem.
+
 ## [0.19.0-rc.4] - 2026-08-26
 
 ### Breaking Changes


### PR DESCRIPTION
Release PR for **v0.19.0-rc.5**. Keep the version bump and release notes as one commit, as `RELEASING.md` requires.

## What is in this RC

Two user-facing changes merged after rc.4:

- `wsp rename` preserves your position inside a workspace subdirectory.
- `wsp new` warns when the workspace location causes Git data to be duplicated and shows which directories should share a filesystem.

The third merged change adds the maintainer-only `/wsp-release-notes` skill and is intentionally absent from `WHATSNEW.md`.

## Notes review

The two runtime notes collected by `just whatsnew-draft v0.19.0-rc.4` still describe the behavior that shipped. They were ordered by impact and the cross-filesystem note was rewritten to lead with disk usage rather than hardlink implementation detail. Every mentioned command was verified against the built CLI.

`git-cliff` also adds #154 to rc.4’s internal documentation section. That PR merged before the rc.4 tag but was absent from the changelog generated on the earlier release branch.

## Verification

- `just fix`
- `just ci`
- Built binary reports `wsp 0.19.0-rc.5`
- `wsp whatsnew` renders the approved rc.5 section
- Release diff reviewed end to end

## After merge

Run `just release-dispatch 0.19.0-rc.5`. Homebrew publishing is expected to skip because this is a prerelease.

```whatsnew
NONE
```