### PR TITLE
fix(new): copy objects across filesystems

### DIFF
--- a/crates/wsp-core/src/git.rs
+++ b/crates/wsp-core/src/git.rs
@@ -1,3 +1,5 @@
+use std::fs;
+use std::io;
 use std::path::Path;
 use std::process::Command;
 
@@ -278,11 +280,65 @@ pub fn remote_set_url(dir: &Path, remote: &str, url: &str) -> Result<()> {
     Ok(())
 }
 
+/// Clone from a local mirror, copying objects when the destination cannot
+/// hardlink to it.
 pub fn clone_local(mirror_dir: &Path, dest: &Path) -> Result<()> {
+    clone_local_with_probe(mirror_dir, dest, probe_hardlinks)
+}
+
+fn clone_local_with_probe(
+    mirror_dir: &Path,
+    dest: &Path,
+    probe: impl FnOnce(&Path, &Path) -> Result<Hardlinks>,
+) -> Result<()> {
+    let dest_parent = dest
+        .parent()
+        .context("local clone destination has no parent directory")?;
+    let use_hardlinks = matches!(probe(mirror_dir, dest_parent)?, Hardlinks::Supported);
     let src = path_str(mirror_dir)?;
     let dst = path_str(dest)?;
-    run(None, &["clone", "--local", src, dst])?;
+    let mut args = vec!["clone", "--local"];
+    if !use_hardlinks {
+        args.push("--no-hardlinks");
+    }
+    args.extend([src, dst]);
+    run(None, &args)?;
     Ok(())
+}
+
+/// Whether one directory can hold a hardlink to a file in another.
+#[derive(Debug)]
+pub enum Hardlinks {
+    /// A link was created, then removed again.
+    Supported,
+    /// The link attempt failed with the enclosed filesystem error.
+    Unsupported(io::Error),
+}
+
+/// Probe the operation Git uses to share objects in a local clone.
+///
+/// This asks the filesystem directly instead of comparing device identifiers,
+/// which is portable and also detects filesystems that refuse hardlinks for
+/// other reasons. The source is removed on drop; removing a created link is
+/// best-effort.
+pub fn probe_hardlinks(from_dir: &Path, into_dir: &Path) -> Result<Hardlinks> {
+    let src = tempfile::Builder::new()
+        .prefix(".wsp-hardlink-probe")
+        .tempfile_in(from_dir)
+        .with_context(|| format!("creating a probe file in {}", from_dir.display()))?;
+    let name = src
+        .path()
+        .file_name()
+        .expect("tempfile_in always yields a path with a file name");
+    let dest = into_dir.join(format!("{}.link", name.to_string_lossy()));
+
+    match fs::hard_link(src.path(), &dest) {
+        Ok(()) => {
+            let _ = fs::remove_file(&dest);
+            Ok(Hardlinks::Supported)
+        }
+        Err(e) => Ok(Hardlinks::Unsupported(e)),
+    }
 }
 
 // `#[cfg(test)]` (not `any(test, feature = "test-utils")`) is intentional
@@ -846,6 +902,31 @@ mod tests {
         assert!(out.status.success());
 
         (bare, source, bare_tmp, source_tmp)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn local_clone_copies_objects_when_hardlinks_are_unsupported() {
+        use std::os::unix::fs::MetadataExt;
+
+        let (bare, _source, _bt, _st) = setup_bare_repo();
+        let clone_tmp = tempfile::tempdir().unwrap();
+        let clone = clone_tmp.path().join("clone");
+
+        clone_local_with_probe(&bare, &clone, |_, _| {
+            Ok(Hardlinks::Unsupported(io::Error::from_raw_os_error(18)))
+        })
+        .unwrap();
+
+        let head = run(Some(&bare), &["rev-parse", "HEAD"]).unwrap();
+        let object = Path::new("objects").join(&head[..2]).join(&head[2..]);
+        let mirror_meta = fs::metadata(bare.join(&object)).unwrap();
+        let clone_meta = fs::metadata(clone.join(".git").join(&object)).unwrap();
+        assert_ne!(
+            (mirror_meta.dev(), mirror_meta.ino()),
+            (clone_meta.dev(), clone_meta.ino()),
+            "clone object should be a copy, not a hardlink"
+        );
     }
 
     /// Creates a commit on a branch in the source repo with a unique file change.

--- a/crates/wsp-core/src/workspace.rs
+++ b/crates/wsp-core/src/workspace.rs
@@ -2143,7 +2143,8 @@ pub fn list_all(workspaces_dir: &Path) -> Result<Vec<String>> {
 /// Clone a repo into the workspace from its bare mirror.
 ///
 /// Steps:
-///   1. `git clone --local <mirror> <dest>` — hardlinks, origin → mirror path
+///   1. `git clone --local <mirror> <dest>` — shares objects with hardlinks
+///      when supported, otherwise copies them; origin → mirror path
 ///   2. `git remote set-url origin <upstream_url>` — repoint to upstream
 ///   3. Read default branch from mirror
 ///   4. `git fetch <mirror_path> +refs/remotes/origin/*:refs/remotes/origin/*`
@@ -2173,7 +2174,7 @@ fn clone_from_mirror(
     let mirror_dir = mirror::dir(mirrors_dir, &parsed);
     let dest = ws_dir.join(dir_name);
 
-    // 1. Clone from mirror (hardlinks, origin → mirror path)
+    // 1. Clone from mirror (hardlinks when supported, origin → mirror path)
     git::clone_local(&mirror_dir, &dest)?;
 
     // 2. Repoint origin to the real upstream URL

--- a/crates/wsp/src/cli/doctor.rs
+++ b/crates/wsp/src/cli/doctor.rs
@@ -1,15 +1,13 @@
 use std::fs;
-use std::io;
-use std::path::Path;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::{ArgMatches, Command};
 
 use wsp_core::agentmd;
 use wsp_core::config::{self, Paths};
 use wsp_core::filelock;
 use wsp_core::gc;
-use wsp_core::git;
+use wsp_core::git::{self, Hardlinks};
 use wsp_core::giturl;
 use wsp_core::lang;
 use wsp_core::mirror;
@@ -1474,56 +1472,9 @@ fn check_workspaces_dir_exists(
     }
 }
 
-/// Whether one directory can hold a hardlink to a file in another.
-#[derive(Debug)]
-pub(crate) enum Hardlinks {
-    /// A link was created, then removed again.
-    Supported,
-    /// The link attempt failed. The error names the reason: `EXDEV` when the two
-    /// directories sit on different filesystems, `EPERM` on a filesystem that
-    /// refuses hardlinks whatever the source. Both cost wsp the same thing, so
-    /// the check reports what was observed rather than guessing at the cause.
-    Unsupported(io::Error),
-}
-
-/// Probe whether `into_dir` can hold a hardlink to a file in `from_dir`.
-///
-/// Comparing device IDs would answer this without touching the disk, but
-/// `MetadataExt::dev()` does not exist on Windows and the win32 equivalent
-/// (`GetVolumeInformationByHandleW`) needs `unsafe`, which both crates deny.
-/// A probe is portable, and it is the more accurate question anyway: it also
-/// catches a single filesystem that refuses to link.
-///
-/// Both temp files are removed before returning, on every path — the link
-/// target explicitly, the source when the `NamedTempFile` drops. `Err` means
-/// the probe could not be set up, so nothing was learned about `into_dir`.
-pub(crate) fn probe_hardlinks(from_dir: &Path, into_dir: &Path) -> Result<Hardlinks> {
-    let src = tempfile::Builder::new()
-        .prefix(".wsp-hardlink-probe")
-        .tempfile_in(from_dir)
-        .with_context(|| format!("creating a probe file in {}", from_dir.display()))?;
-    // Derive the link name from the source so concurrent probes cannot collide,
-    // and suffix it so the two paths differ even when both dirs are the same one.
-    let name = src
-        .path()
-        .file_name()
-        .expect("tempfile_in always yields a path with a file name");
-    let dest = into_dir.join(format!("{}.link", name.to_string_lossy()));
-
-    match fs::hard_link(src.path(), &dest) {
-        Ok(()) => {
-            // Best effort: unlinking a file just created in the same directory
-            // does not realistically fail, and the probe has its answer either way.
-            let _ = fs::remove_file(&dest);
-            Ok(Hardlinks::Supported)
-        }
-        Err(e) => Ok(Hardlinks::Unsupported(e)),
-    }
-}
-
 /// G12. Clones can hardlink to mirrors.
 ///
-/// `wsp new` clones from the mirror with hardlinked objects, and `wsp rm`
+/// `wsp new` hardlinks clone objects from the mirror when possible, and `wsp rm`
 /// renames into the gc dir; mirrors and gc both live under the data dir, while
 /// `workspaces_dir` is user-configurable. When hardlinks between the two do not
 /// work, every workspace stores a full copy of its git objects and `wsp rm`
@@ -1544,7 +1495,7 @@ fn check_workspaces_hardlinkable(paths: &Paths, checks: &mut Vec<DoctorCheck>) {
         return;
     }
 
-    let (status, message, details) = match probe_hardlinks(data_dir, &paths.workspaces_dir) {
+    let (status, message, details) = match git::probe_hardlinks(data_dir, &paths.workspaces_dir) {
         Ok(Hardlinks::Supported) => {
             eprintln!("  ✓ clones can hardlink to mirrors");
             (
@@ -4100,7 +4051,7 @@ mod tests {
         fs::create_dir_all(&from).unwrap();
         fs::create_dir_all(&into).unwrap();
 
-        match probe_hardlinks(&from, &into).unwrap() {
+        match git::probe_hardlinks(&from, &into).unwrap() {
             Hardlinks::Supported => {}
             Hardlinks::Unsupported(e) => panic!("probe refused within one tempdir: {}", e),
         }
@@ -4120,7 +4071,7 @@ mod tests {
     fn hardlinks_supported_when_both_dirs_are_the_same() {
         let tmp = tempfile::tempdir().unwrap();
 
-        match probe_hardlinks(tmp.path(), tmp.path()).unwrap() {
+        match git::probe_hardlinks(tmp.path(), tmp.path()).unwrap() {
             Hardlinks::Supported => {}
             Hardlinks::Unsupported(e) => panic!("probe refused within one dir: {}", e),
         }
@@ -4136,7 +4087,7 @@ mod tests {
     #[test]
     fn hardlink_probe_errors_when_it_cannot_run() {
         let tmp = tempfile::tempdir().unwrap();
-        let err = probe_hardlinks(&tmp.path().join("nonexistent"), tmp.path()).unwrap_err();
+        let err = git::probe_hardlinks(&tmp.path().join("nonexistent"), tmp.path()).unwrap_err();
         assert!(
             err.to_string().contains("creating a probe file"),
             "unexpected error: {}",
@@ -4151,7 +4102,7 @@ mod tests {
     #[test]
     fn hardlinks_unsupported_when_the_link_cannot_be_created() {
         let tmp = tempfile::tempdir().unwrap();
-        match probe_hardlinks(tmp.path(), &tmp.path().join("nonexistent"))
+        match git::probe_hardlinks(tmp.path(), &tmp.path().join("nonexistent"))
             .expect("a link that cannot be created is an answer, not a probe failure")
         {
             Hardlinks::Unsupported(_) => {}

--- a/crates/wsp/src/hints.rs
+++ b/crates/wsp/src/hints.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use wsp_core::config::{Config, Paths};
+use wsp_core::git::Hardlinks;
 
 /// Default cooldown between repeat appearances of the same hint.
 pub const DEFAULT_HINT_COOLDOWN_DAYS: u32 = 1;
@@ -103,7 +104,7 @@ pub fn evaluate(command: &str, cfg: &Config, paths: &Paths) -> Vec<String> {
         && hint_ready(&hints_dir, "crossDevice", cooldown_days)
         && paths.workspaces_dir.is_dir()
         && paths.data_dir().is_dir()
-        && let Some(hint) = cross_device_hint(paths, crate::cli::doctor::probe_hardlinks)
+        && let Some(hint) = cross_device_hint(paths, wsp_core::git::probe_hardlinks)
     {
         hints.push(hint);
         touch_hint(&hints_dir, "crossDevice");
@@ -114,10 +115,10 @@ pub fn evaluate(command: &str, cfg: &Config, paths: &Paths) -> Vec<String> {
 
 fn cross_device_hint(
     paths: &Paths,
-    probe: impl FnOnce(&Path, &Path) -> anyhow::Result<crate::cli::doctor::Hardlinks>,
+    probe: impl FnOnce(&Path, &Path) -> anyhow::Result<Hardlinks>,
 ) -> Option<String> {
     match probe(paths.data_dir(), &paths.workspaces_dir) {
-        Ok(crate::cli::doctor::Hardlinks::Unsupported(_)) => Some(format!(
+        Ok(Hardlinks::Unsupported(_)) => Some(format!(
             "hint: clones cannot hardlink from the wsp data dir ({}) into \
              workspaces_dir ({}), so each workspace stores a full copy of its git objects.\n  \
              Colocate them on one filesystem to share objects with mirrors.\n  \
@@ -400,9 +401,9 @@ mod tests {
         std::fs::create_dir_all(&tp.paths.workspaces_dir).unwrap();
 
         let hint = cross_device_hint(&tp.paths, |_, _| {
-            Ok(crate::cli::doctor::Hardlinks::Unsupported(
-                std::io::Error::from_raw_os_error(18),
-            ))
+            Ok(Hardlinks::Unsupported(std::io::Error::from_raw_os_error(
+                18,
+            )))
         })
         .unwrap();
 
@@ -414,12 +415,7 @@ mod tests {
     #[test]
     fn cross_device_hint_is_absent_when_hardlinks_work() {
         let tp = make_paths();
-        assert!(
-            cross_device_hint(&tp.paths, |_, _| {
-                Ok(crate::cli::doctor::Hardlinks::Supported)
-            })
-            .is_none()
-        );
+        assert!(cross_device_hint(&tp.paths, |_, _| { Ok(Hardlinks::Supported) }).is_none());
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- probe whether workspace clones can hardlink to their mirrors
- pass `--no-hardlinks` so Git copies objects when the directories are on different filesystems
- share the capability probe with `wsp doctor` and contextual hints

Closes #160.

## Validation

- `just ci`
- exact `/tmp` to `/dev/shm` reproduction from #160
- Unix smoke test, offline and network
- PowerShell smoke test, offline and network
- regression test deliberately inverted and confirmed to fail with `clone object should be a copy, not a hardlink`

```whatsnew
- `wsp new` now creates workspaces across filesystems by copying Git objects when hardlinks are unavailable.
```