### PR TITLE
fix(mirror): avoid races resolving default branch

### DIFF
--- a/crates/wsp-core/src/git.rs
+++ b/crates/wsp-core/src/git.rs
@@ -148,12 +148,19 @@ pub fn get_config(dir: &Path, key: &str) -> Result<String> {
 
 pub fn fetch(dir: &Path, prune: bool) -> Result<()> {
     ensure_fetch_refspec(dir)?;
-    let mut args = vec!["fetch", "--all"];
+    let args = fetch_args(prune);
+    run(Some(dir), &args)?;
+    Ok(())
+}
+
+fn fetch_args(prune: bool) -> Vec<&'static str> {
+    // wsp reads mirror refs as soon as fetch returns. Git otherwise detaches
+    // automatic maintenance, allowing it to rewrite those refs concurrently.
+    let mut args = vec!["-c", "maintenance.autoDetach=false", "fetch", "--all"];
     if prune {
         args.push("--prune");
     }
-    run(Some(dir), &args)?;
-    Ok(())
+    args
 }
 
 pub fn default_branch(dir: &Path) -> Result<String> {
@@ -190,15 +197,15 @@ pub fn fetch_from_path(dir: &Path, source_path: &Path, refspec: &str, prune: boo
 /// 3. The mirror's own `HEAD`, for git versions that never create
 ///    `refs/remotes/origin/HEAD` on fetch.
 ///
-/// Returning `Err` is meaningful: callers treat it as "no default branch" and
-/// create an orphan branch, which is correct for an empty repo and wrong for any
-/// other. Both the empty-repo case and the older-git case are covered by tests.
+/// `Ok(None)` authoritatively means the mirror has no branches. Read failures and
+/// inconsistent non-empty mirrors return `Err`; callers must not turn those into
+/// an orphan branch.
 ///
 /// Bare mirrors write `refs/remotes/origin/HEAD` as a symref pointing at
 /// `refs/heads/<branch>`, not `refs/remotes/origin/<branch>`, so the `refs/heads/`
 /// arm of `strip_ref_branch` is load-bearing here and must not be removed.
-pub fn default_branch_from_mirror(mirror_dir: &Path) -> Result<String> {
-    let ref_str = run(
+pub fn default_branch_from_mirror(mirror_dir: &Path) -> Result<Option<String>> {
+    let remote_head = run(
         Some(mirror_dir),
         &["symbolic-ref", "refs/remotes/origin/HEAD"],
     )
@@ -211,29 +218,42 @@ pub fn default_branch_from_mirror(mirror_dir: &Path) -> Result<String> {
             .strip_prefix("ref: ")
             .map(str::to_string)
             .ok_or_else(|| anyhow::anyhow!("not a symref: {}", path.display()))
-    })
-    .or_else(|_| {
-        // Older git does not create refs/remotes/origin/HEAD when fetching into
-        // a bare mirror — observed absent on 2.43 and present on 2.55. The
-        // mirror's own HEAD is set by `git clone --bare` from the upstream
-        // default and is correct on both, so it is the reliable last resort.
-        //
-        // Without this the caller gets None and creates an *orphan* branch
-        // rather than branching from the default: the workspace repo ends up
-        // with no commits, every file staged as added, and `wsp rm` refusing
-        // over "unsaved work" that does not exist.
-        let head = run(Some(mirror_dir), &["symbolic-ref", "HEAD"])?;
-        // An empty mirror also has HEAD, pointing at a branch that does not
-        // exist yet. That must stay an error so the caller still creates an
-        // orphan branch rather than trying to branch from a missing ref.
-        anyhow::ensure!(
-            ref_exists(mirror_dir, &head),
-            "mirror HEAD points at unborn branch {}",
-            head
-        );
-        Ok(head)
-    })?;
-    strip_ref_branch(&ref_str, "origin")
+    });
+    if let Ok(ref_str) = remote_head {
+        return strip_ref_branch(&ref_str, "origin").map(Some);
+    }
+
+    // Older git does not create refs/remotes/origin/HEAD when fetching into a
+    // bare mirror. The mirror's own HEAD is set by `git clone --bare` from the
+    // upstream default and is the reliable fallback.
+    let head = run(Some(mirror_dir), &["symbolic-ref", "HEAD"])?;
+    let head_ref = run(
+        Some(mirror_dir),
+        &["for-each-ref", "--count=1", "--format=%(refname)", &head],
+    )?;
+    // for-each-ref patterns also match at slash boundaries (for example,
+    // refs/heads/main can match refs/heads/main/topic). Compare the returned
+    // ref so an unborn HEAD is not mistaken for an existing branch.
+    if head_ref == head {
+        return strip_ref_branch(&head, "origin").map(Some);
+    }
+
+    let any_branch = run(
+        Some(mirror_dir),
+        &[
+            "for-each-ref",
+            "--count=1",
+            "--format=%(refname)",
+            "refs/heads",
+        ],
+    )?;
+    if any_branch.is_empty() {
+        return Ok(None);
+    }
+    anyhow::bail!(
+        "mirror HEAD points at missing branch {} but the mirror is not empty",
+        head
+    )
 }
 
 /// Strip the remote-tracking or heads prefix from a symbolic-ref output, returning
@@ -1722,8 +1742,96 @@ mod tests {
 
         assert_eq!(
             default_branch_from_mirror(&mirror).unwrap(),
-            "master",
+            Some("master".to_string()),
             "must fall back to the mirror's own HEAD instead of failing"
+        );
+    }
+
+    #[test]
+    fn fetch_waits_for_auto_maintenance() {
+        assert_eq!(
+            fetch_args(false),
+            ["-c", "maintenance.autoDetach=false", "fetch", "--all"]
+        );
+        assert_eq!(
+            fetch_args(true),
+            [
+                "-c",
+                "maintenance.autoDetach=false",
+                "fetch",
+                "--all",
+                "--prune",
+            ]
+        );
+    }
+
+    #[test]
+    fn default_branch_from_empty_mirror_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mirror = tmp.path().join("mirror.git");
+        run(None, &["init", "--bare", mirror.to_str().unwrap()]).unwrap();
+
+        assert_eq!(default_branch_from_mirror(&mirror).unwrap(), None);
+    }
+
+    #[test]
+    fn default_branch_from_nonempty_mirror_with_missing_head_is_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let upstream = tmp.path().join("upstream");
+        std::fs::create_dir_all(&upstream).unwrap();
+        for args in [
+            vec!["init", "--initial-branch=main"],
+            vec!["config", "user.email", "t@t.local"],
+            vec!["config", "user.name", "T"],
+            vec!["config", "commit.gpgsign", "false"],
+            vec!["commit", "--allow-empty", "-m", "initial"],
+        ] {
+            run(Some(&upstream), &args).unwrap();
+        }
+
+        let mirror = tmp.path().join("mirror.git");
+        clone_bare(upstream.to_str().unwrap(), &mirror).unwrap();
+        run(
+            Some(&mirror),
+            &["symbolic-ref", "HEAD", "refs/heads/missing"],
+        )
+        .unwrap();
+
+        let err = default_branch_from_mirror(&mirror).unwrap_err();
+        assert!(
+            err.to_string().contains("mirror is not empty"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn default_branch_from_mirror_requires_exact_head_ref() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mirror = tmp.path().join("mirror.git");
+        run(None, &["init", "--bare", mirror.to_str().unwrap()]).unwrap();
+        let tree = run(Some(&mirror), &["mktree"]).unwrap();
+        let commit = run_with_env(
+            Some(&mirror),
+            &["commit-tree", &tree, "-m", "initial"],
+            &[
+                ("GIT_AUTHOR_NAME", "T"),
+                ("GIT_AUTHOR_EMAIL", "t@t.local"),
+                ("GIT_COMMITTER_NAME", "T"),
+                ("GIT_COMMITTER_EMAIL", "t@t.local"),
+            ],
+        )
+        .unwrap();
+        run(
+            Some(&mirror),
+            &["update-ref", "refs/heads/main/topic", &commit],
+        )
+        .unwrap();
+        run(Some(&mirror), &["symbolic-ref", "HEAD", "refs/heads/main"]).unwrap();
+
+        let err = default_branch_from_mirror(&mirror).unwrap_err();
+        assert!(
+            err.to_string().contains("mirror is not empty"),
+            "unexpected error: {err:#}"
         );
     }
 

--- a/crates/wsp-core/src/workspace.rs
+++ b/crates/wsp-core/src/workspace.rs
@@ -601,7 +601,16 @@ fn propagate_mirror_refs(mirrors_dir: &Path, dest: &Path, identity: &str) -> Res
         return Ok(());
     }
 
-    let mirror_default_br = git::default_branch_from_mirror(&mirror_dir).ok();
+    let mirror_default_br = match git::default_branch_from_mirror(&mirror_dir) {
+        Ok(branch) => branch,
+        Err(e) => {
+            eprintln!(
+                "  warning: cannot read default branch from mirror for {}: {}",
+                identity, e
+            );
+            None
+        }
+    };
 
     // Populate origin/* refs from mirror (local fetch, no network)
     let _ = git::fetch_from_path(dest, &mirror_dir, MIRROR_PROPAGATE_REFSPEC, false);
@@ -731,7 +740,7 @@ pub fn add_repos(
             prompt_branch_for_adopt(&dest, clone_branch)?;
             eprintln!("  adopted existing directory {}/", dn);
         } else {
-            clone_from_mirror(
+            if let Err(clone_err) = clone_from_mirror(
                 mirrors_dir,
                 ws_dir,
                 identity,
@@ -739,8 +748,20 @@ pub fn add_repos(
                 clone_branch,
                 upstream,
                 clone_branch_tracks_remote,
-            )
-            .map_err(|e| anyhow::anyhow!("cloning repo {}: {}", identity, e))?;
+            ) {
+                if dest.exists()
+                    && let Err(cleanup_err) = fs::remove_dir_all(&dest)
+                {
+                    return Err(anyhow::anyhow!(
+                        "cloning repo {}: {}; also failed to remove partial clone {}: {}",
+                        identity,
+                        clone_err,
+                        dest.display(),
+                        cleanup_err
+                    ));
+                }
+                return Err(anyhow::anyhow!("cloning repo {}: {}", identity, clone_err));
+            }
         }
 
         clones.push(CloneInfo {
@@ -2183,7 +2204,8 @@ fn clone_from_mirror(
     }
 
     // 3. Read default branch from mirror
-    let mirror_default_br = git::default_branch_from_mirror(&mirror_dir).ok();
+    let mirror_default_br = git::default_branch_from_mirror(&mirror_dir)
+        .with_context(|| format!("reading default branch from mirror for {}", identity))?;
 
     // 4. Populate origin/* refs from mirror (local fetch, no network).
     // Note: bare mirrors have refs/remotes/origin/* only after their first
@@ -2828,6 +2850,46 @@ mod tests {
         let clone_dir = ws_dir.join(meta.dir_name(&identity).unwrap());
         let head = git::run(Some(&clone_dir), &["symbolic-ref", "--short", "HEAD"]).unwrap();
         assert_eq!(head, "jganoff/empty-ws");
+    }
+
+    #[test]
+    fn test_create_fails_closed_when_nonempty_mirror_head_is_missing() {
+        let (paths, _data, _source, identity, upstream_urls) = setup_test_env();
+        let parsed = parse_identity(&identity).unwrap();
+        let mirror_dir = mirror::dir(&paths.mirrors_dir, &parsed);
+        git::run(
+            Some(&mirror_dir),
+            &["symbolic-ref", "--delete", "refs/remotes/origin/HEAD"],
+        )
+        .unwrap();
+        git::run(
+            Some(&mirror_dir),
+            &["symbolic-ref", "HEAD", "refs/heads/missing"],
+        )
+        .unwrap();
+
+        let refs = BTreeMap::from([(identity, String::new())]);
+        let err = create(
+            &paths,
+            "broken-head",
+            &refs,
+            Some("jganoff"),
+            None,
+            &upstream_urls,
+            None,
+            None,
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("reading default branch from mirror"),
+            "unexpected error: {err:#}"
+        );
+        assert!(
+            !dir(&paths.workspaces_dir, "broken-head").exists(),
+            "failed creation must clean up the partial workspace"
+        );
     }
 
     fn setup_non_main_mirror(
@@ -4265,6 +4327,69 @@ mod tests {
 
         let meta = load_metadata(&ws_dir).unwrap();
         assert_eq!(meta.repos.len(), 1);
+    }
+
+    #[test]
+    fn test_add_repos_cleans_partial_clone_when_mirror_head_is_missing() {
+        let (paths, _d, source_repo, identity1, mut upstream_urls) = setup_test_env();
+        let refs = BTreeMap::from([(identity1.clone(), String::new())]);
+        create(
+            &paths,
+            "add-broken-head",
+            &refs,
+            None,
+            None,
+            &upstream_urls,
+            None,
+            None,
+        )
+        .unwrap();
+        let ws_dir = dir(&paths.workspaces_dir, "add-broken-head");
+
+        let (identity2, urls2) = add_mirror_with_owner(
+            &paths,
+            source_repo.path(),
+            "test.local",
+            "other",
+            "broken-repo",
+        );
+        upstream_urls.extend(urls2);
+        let parsed = parse_identity(&identity2).unwrap();
+        let mirror_dir = mirror::dir(&paths.mirrors_dir, &parsed);
+        git::run(
+            Some(&mirror_dir),
+            &["symbolic-ref", "--delete", "refs/remotes/origin/HEAD"],
+        )
+        .unwrap();
+        git::run(
+            Some(&mirror_dir),
+            &["symbolic-ref", "HEAD", "refs/heads/missing"],
+        )
+        .unwrap();
+
+        let add_refs = BTreeMap::from([(identity2.clone(), String::new())]);
+        let err = add_repos(
+            &paths.mirrors_dir,
+            &ws_dir,
+            &add_refs,
+            &upstream_urls,
+            false,
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("reading default branch from mirror"),
+            "unexpected error: {err:#}"
+        );
+        assert!(
+            !ws_dir.join("broken-repo").exists(),
+            "failed addition must remove its partial clone"
+        );
+        let meta = load_metadata(&ws_dir).unwrap();
+        assert_eq!(meta.repos.len(), 1);
+        assert!(meta.repos.contains_key(&identity1));
+        assert!(!meta.repos.contains_key(&identity2));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #158.

## Intent

Prevent `wsp new` from silently creating an unborn workspace branch when a non-empty mirror's default branch cannot be read reliably.

Git may start detached automatic maintenance after `fetch` returns. That maintenance can rewrite mirror refs while wsp immediately reads them. The resulting lookup failure was previously discarded and treated exactly like an empty repository, so wsp created an orphan branch even though the mirror contained history.

## Changes

- Run fetch-triggered automatic maintenance synchronously with `maintenance.autoDetach=false`, so ref maintenance finishes before wsp reads the mirror.
- Distinguish an actually empty mirror from a non-empty mirror with missing or inconsistent default-branch refs.
- Fail closed during new clones instead of converting mirror lookup errors into orphan branches.
- Preserve best-effort ref propagation for already-existing clones, with a visible warning.
- Remove partial clones when `wsp repo add` fails default-branch validation.
- Require exact mirror HEAD ref matches, including when slash-containing branch names are present.

Synchronous maintenance is intentional: disabling automatic maintenance would avoid this race but allow mirror maintenance debt to accumulate. Waiting retains Git's maintenance behavior while making the subsequent read safe.

## Validation

- `just fix`
- `just ci`
- 299 wsp tests, 400 wsp-core tests, 8 xtask tests, and doctests
- formatting, Clippy, cross-platform checks, audit, release build, and SKILL freshness
- targeted mutation checks proving the fail-closed and synchronous-maintenance regressions fail without their fixes
- Git 2.43 compatibility validation on Ubuntu 24.04
- `git diff --check`

```whatsnew
- `wsp new` no longer creates an empty, unborn branch when a populated repository mirror's default branch is temporarily unreadable.
```
