### PR TITLE
docs: make README user-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # wsp
 
-**Ship changes across multiple Git repositories as one workspace.**
+**Ship cross-repo changes faster.**
 
-`wsp` creates an isolated directory of normal Git clones, checks out the same
-feature branch in each one, and gives you a single place to see status, review
-diffs, sync changes, and run commands.
+`wsp` gives every feature or fix one isolated workspace across all the
+repositories it touches, so you can start coding immediately, see the whole
+change at once, and clean up safely when it ships.
 
 ```text
 ~/dev/workspaces/fix-build/
@@ -27,25 +27,28 @@ self-contained context.
 
 ## Get started
 
-Install `wsp` and run its one-time setup:
+Install `wsp`:
 
 **macOS or Linux**
 
 ```bash
 brew install jganoff/tap/wsp
-wsp setup
 ```
 
 **Windows (PowerShell)**
 
 ```powershell
 irm https://github.com/jganoff/wsp/releases/latest/download/wsp-installer.ps1 | iex
-wsp config set branch-prefix YOUR-USERNAME
 ```
 
-`wsp setup` checks that Git is available, configures your branch prefix, and
-offers to enable tab completion and automatic directory changes. Windows users
-configure the branch prefix directly.
+Then run the guided one-time setup:
+
+```bash
+wsp setup
+```
+
+It checks that Git is available, configures your branch prefix, and offers to
+enable tab completion and automatic directory changes when supported.
 
 Register the repositories you work with once, then create a workspace:
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 **Ship cross-repo changes faster.**
 
-`wsp` gives every feature or fix one isolated workspace across all the
-repositories it touches, so you can start coding immediately, see the whole
-change at once, and clean up safely when it ships.
+`wsp` gives developers and coding agents one isolated workspace containing
+every repository a feature or fix touches. Start with complete context, see the
+whole change at once, and clean up safely when it ships.
 
 ```text
 ~/dev/workspaces/fix-build/
@@ -12,12 +12,11 @@ change at once, and clean up safely when it ships.
 └── buildx/     # branch: yourname/fix-build
 ```
 
-Use `wsp` when one change spans several repositories, when you need multiple
-features checked out at once, or when you want to give a coding agent clean,
-self-contained context.
-
 - **Start fast.** Repositories are cloned from local mirrors, so new workspaces
   are quick and can be created offline after the first fetch.
+- **Give agents complete context.** Every workspace tells coding agents which
+  repos belong together, where they live, what branch to use, and how to operate
+  across them.
 - **Work normally.** Every repository is a standard Git clone with its usual
   `origin`. Use Git, your editor, and your existing tools as before.
 - **See the whole change.** Short commands show status and diffs or run a
@@ -27,7 +26,8 @@ self-contained context.
 
 ## Get started
 
-Install `wsp`:
+`wsp` requires Git. Install it with [Homebrew](https://brew.sh/) on macOS or
+Linux, or with the PowerShell installer on Windows:
 
 **macOS or Linux**
 
@@ -41,14 +41,19 @@ brew install jganoff/tap/wsp
 irm https://github.com/jganoff/wsp/releases/latest/download/wsp-installer.ps1 | iex
 ```
 
-Then run the guided one-time setup:
+Verify the install, then run the guided one-time setup:
 
 ```bash
+wsp --version
 wsp setup
 ```
 
-It checks that Git is available, configures your branch prefix, and offers to
-enable tab completion and automatic directory changes when supported.
+Setup checks Git, configures your branch prefix, and offers shell integration
+for zsh, bash, and fish. PowerShell users can enable it after setup:
+
+```powershell
+Invoke-Expression (wsp completion powershell | Out-String)
+```
 
 Register the repositories you work with once, then create a workspace:
 
@@ -57,15 +62,13 @@ wsp registry add https://github.com/docker/compose.git
 wsp registry add https://github.com/docker/buildx.git
 
 wsp new fix-build compose buildx
+wsp st fix-build
 ```
 
-Your workspace is ready at `~/dev/workspaces/fix-build/`, with both repositories
-on the same feature branch. If shell integration is active, `wsp new` takes you
-there automatically. Otherwise, run:
-
-```bash
-wsp cd fix-build
-```
+The first registration downloads a local mirror; future workspaces reuse it.
+`wsp new` creates both clones on the same feature branch and prints the new
+workspace path. With shell integration active, it also takes you there
+automatically. Otherwise, use your shell's `cd` command with the printed path.
 
 ## Your daily workflow
 
@@ -75,7 +78,7 @@ From anywhere inside a workspace, `wsp` detects the workspace automatically:
 wsp st                       # see status across every repo
 wsp diff                     # review the complete change
 wsp sync                     # fetch and rebase every repo
-wsp exec -- go test ./...    # run a command in every repo
+wsp exec -- git status --short --branch  # run a command in every repo
 ```
 
 Status stays readable even when the repositories do not agree:
@@ -100,6 +103,23 @@ Removal is recoverable by default. `wsp` blocks removal when it finds
 uncommitted work or unmerged branches, including squash-merged pull requests.
 Use `wsp ls --removed` to see restorable workspaces and `wsp recover <name>` to
 bring one back.
+
+## Built for coding agents
+
+A coding agent is only as effective as the context it can see. Launch one at
+the workspace root and it can work across the complete change instead of
+discovering one repository at a time or editing the wrong checkout.
+
+Each workspace includes a generated `AGENTS.md` that identifies the workspace
+branch, maps repository names to directories, defines safe workspace
+boundaries, and points agents to per-repo instructions. `wsp` also installs a
+workspace-management skill so supported agents can discover its commands
+without being prompted through the workflow.
+
+Every `wsp` command supports `--json`, giving agents structured workspace and
+Git state instead of making them scrape terminal output. The repositories
+remain normal clones, so agents use the same build tools, tests, and Git
+workflow as developers.
 
 ## Reuse a set of repositories
 
@@ -156,6 +176,11 @@ eval "$(wsp completion bash)"
 
 # fish
 wsp completion fish | source
+```
+
+```powershell
+# PowerShell
+Invoke-Expression (wsp completion powershell | Out-String)
 ```
 
 This enables tab completion, moves into a workspace after `wsp new`, and moves

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ whole change at once, and clean up safely when it ships.
 
 ```text
 ~/dev/workspaces/fix-build/
-├── compose/    # branch: yourname/fix-build
-└── buildx/     # branch: yourname/fix-build
+├── api/    # branch: yourname/fix-build
+└── web/    # branch: yourname/fix-build
 ```
 
 - **Start fast.** Repositories are cloned from local mirrors, so new workspaces
@@ -48,27 +48,30 @@ wsp --version
 wsp setup
 ```
 
-Setup checks Git, configures your branch prefix, and offers shell integration
-for zsh, bash, and fish. PowerShell users can enable it after setup:
-
-```powershell
-Invoke-Expression (wsp completion powershell | Out-String)
-```
-
-Register the repositories you work with once, then create a workspace:
+Setup checks Git and configures your branch prefix. Now register the `wsp`
+repository and create a workspace for your first change:
 
 ```bash
-wsp registry add https://github.com/docker/compose.git
-wsp registry add https://github.com/docker/buildx.git
+wsp registry add https://github.com/jganoff/wsp.git
+wsp new improve-readme wsp
+```
 
-wsp new fix-build compose buildx
-wsp st fix-build
+You now have an isolated clone of `wsp` on the `yourname/improve-readme` branch.
+Open the printed workspace path in your editor and make a change to
+`wsp/README.md`, then review it from anywhere:
+
+```bash
+wsp st improve-readme
+wsp diff improve-readme
 ```
 
 The first registration downloads a local mirror; future workspaces reuse it.
-`wsp new` creates both clones on the same feature branch and prints the new
-workspace path. With shell integration active, it also takes you there
-automatically. Otherwise, use your shell's `cd` command with the printed path.
+Add more repositories to the same workspace whenever a change spans repo
+boundaries.
+
+`wsp new` prints the workspace path. With shell integration active, it also
+takes you there automatically. Otherwise, use your shell's `cd` command with
+the printed path.
 
 ## Your daily workflow
 
@@ -85,18 +88,17 @@ Status stays readable even when the repositories do not agree:
 
 ```text
 $ wsp st
-Workspace: fix-build  Branch: yourname/fix-build
+Workspace: improve-readme  Branch: yourname/improve-readme
 
-Repository  Branch                  Status
-buildx      yourname/fix-build      1 ahead, 2 files changed
-compose     yourname/fix-build      clean
+Repository  Branch                      Status
+wsp         yourname/improve-readme     1 file changed
 ```
 
 Push and open pull requests with your normal Git workflow. When the work is
 done, remove the workspace:
 
 ```bash
-wsp rm fix-build
+wsp rm improve-readme
 ```
 
 Removal is recoverable by default. `wsp` blocks removal when it finds
@@ -126,15 +128,15 @@ workflow as developers.
 Save repositories as a template when you often work on them together:
 
 ```bash
-wsp template new docker-dev compose buildx
-wsp new my-feature -t docker-dev
+wsp template new product-dev api web
+wsp new my-feature -t product-dev
 ```
 
 Templates are shareable YAML files:
 
 ```bash
-wsp template export docker-dev
-wsp template import docker-dev.wsp.yaml
+wsp template export product-dev
+wsp template import product-dev.wsp.yaml
 ```
 
 ## Set up repositories after cloning
@@ -213,15 +215,13 @@ Every command supports `--json` for scripts and coding agents. See the
 ```text
 ~/.local/share/wsp/
 └── mirrors/
-    └── github.com/docker/
-        ├── compose.git/     # bare mirror; fetched once
-        └── buildx.git/
+    └── github.com/jganoff/
+        └── wsp.git/         # bare mirror; fetched once
 
 ~/dev/workspaces/
-└── fix-build/
+└── improve-readme/
     ├── .wsp.yaml            # workspace metadata
-    ├── compose/             # normal local clone
-    └── buildx/              # normal local clone
+    └── wsp/                 # normal local clone
 ```
 
 Registered repositories have a bare local mirror. Workspace clones reuse its

--- a/README.md
+++ b/README.md
@@ -47,17 +47,20 @@ wsp --version
 wsp setup
 ```
 
-Setup checks Git and configures your branch prefix. Now register the `wsp`
-repository and create a workspace for your first change:
+Setup checks Git and configures your branch prefix. Now start a change without
+stashing or rearranging anything already in progress:
 
 ```bash
 wsp registry add https://github.com/jganoff/wsp.git
 wsp new improve-readme wsp
 ```
 
-You now have an isolated clone of `wsp` on the `yourname/improve-readme` branch.
-Open the printed workspace path in your editor and make a change to
-`wsp/README.md`, then review it from anywhere:
+`wsp new` prints the path to a normal clone on the
+`yourname/improve-readme` branch. Open that path in your editor or coding agent
+and improve `wsp/README.md`. Any checkout you already had stays exactly as you
+left it.
+
+Inspect the task as a single unit:
 
 ```bash
 wsp st improve-readme
@@ -65,12 +68,10 @@ wsp diff improve-readme
 ```
 
 The first registration downloads a local mirror; future workspaces reuse it.
-Add more repositories to the same workspace whenever a change spans repo
-boundaries.
-
-`wsp new` prints the workspace path. With shell integration active, it also
-takes you there automatically. Otherwise, use your shell's `cd` command with
-the printed path.
+If the task grows across repository boundaries, add those repositories to the
+same workspace and keep the whole change together. Once the work ships,
+`wsp rm improve-readme` checks that it is safe to remove and keeps it
+recoverable.
 
 ## Your daily workflow
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 # wsp
 
-**Ship cross-repo changes faster.**
+**Every change, ready to work.**
 
-`wsp` gives developers and coding agents one isolated workspace containing
-every repository a feature or fix touches. Start with complete context, see the
-whole change at once, and clean up safely when it ships.
+`wsp` gives each feature, fix, or coding-agent task its own clean Git workspace.
+Start with one repository, add others when needed, see the whole change, and
+clean up safely without changing how you use Git.
 
-```text
-~/dev/workspaces/fix-build/
-├── api/    # branch: yourname/fix-build
-└── web/    # branch: yourname/fix-build
+```bash
+wsp new improve-readme wsp    # one repository
+wsp new fix-build api web     # or as many as the change needs
 ```
 
 - **Start fast.** Repositories are cloned from local mirrors, so new workspaces

--- a/README.md
+++ b/README.md
@@ -1,68 +1,148 @@
 # wsp
 
-Multi-repo workspace manager. One command to create an isolated workspace
-across multiple repositories, all on the same branch.
+**Ship changes across multiple Git repositories as one workspace.**
 
-## Quick start
+`wsp` creates an isolated directory of normal Git clones, checks out the same
+feature branch in each one, and gives you a single place to see status, review
+diffs, sync changes, and run commands.
 
-**macOS / Linux:**
+```text
+~/dev/workspaces/fix-build/
+├── compose/    # branch: yourname/fix-build
+└── buildx/     # branch: yourname/fix-build
+```
+
+Use `wsp` when one change spans several repositories, when you need multiple
+features checked out at once, or when you want to give a coding agent clean,
+self-contained context.
+
+- **Start fast.** Repositories are cloned from local mirrors, so new workspaces
+  are quick and can be created offline after the first fetch.
+- **Work normally.** Every repository is a standard Git clone with its usual
+  `origin`. Use Git, your editor, and your existing tools as before.
+- **See the whole change.** Short commands show status and diffs or run a
+  command across every repository.
+- **Clean up safely.** `wsp rm` protects uncommitted and unmerged work, and
+  removed workspaces can be recovered.
+
+## Get started
+
+Install `wsp` and run its one-time setup:
+
+**macOS or Linux**
+
 ```bash
 brew install jganoff/tap/wsp
 wsp setup
 ```
 
-**Windows (PowerShell):**
+**Windows (PowerShell)**
+
 ```powershell
 irm https://github.com/jganoff/wsp/releases/latest/download/wsp-installer.ps1 | iex
 wsp config set branch-prefix YOUR-USERNAME
 ```
 
-Then register repos and create a workspace:
+`wsp setup` checks that Git is available, configures your branch prefix, and
+offers to enable tab completion and automatic directory changes. Windows users
+configure the branch prefix directly.
+
+Register the repositories you work with once, then create a workspace:
 
 ```bash
-# register repos once (creates local mirrors so future clones are instant)
 wsp registry add https://github.com/docker/compose.git
 wsp registry add https://github.com/docker/buildx.git
 
-# create a workspace
 wsp new fix-build compose buildx
 ```
 
-That's it. You now have `~/dev/workspaces/fix-build/` with both repos cloned
-on the `fix-build` branch. Jump in with `wsp cd fix-build`.
-
-## Working in a workspace
+Your workspace is ready at `~/dev/workspaces/fix-build/`, with both repositories
+on the same feature branch. If shell integration is active, `wsp new` takes you
+there automatically. Otherwise, run:
 
 ```bash
-wsp st                                # status across all repos
-wsp diff                              # diff across all repos
-wsp sync                              # fetch and rebase all repos
-wsp exec fix-build -- go test ./...   # run a command in every repo
-wsp rm fix-build                      # clean up when done
+wsp cd fix-build
 ```
 
-Status at a glance:
+## Your daily workflow
 
+From anywhere inside a workspace, `wsp` detects the workspace automatically:
+
+```bash
+wsp st                       # see status across every repo
+wsp diff                     # review the complete change
+wsp sync                     # fetch and rebase every repo
+wsp exec -- go test ./...    # run a command in every repo
 ```
+
+Status stays readable even when the repositories do not agree:
+
+```text
 $ wsp st
-Workspace: fix-build  Branch: fix-build
+Workspace: fix-build  Branch: yourname/fix-build
 
-Repository  Branch     Status
-buildx      fix-build  1 ahead, 2 files changed
-compose     fix-build  clean
+Repository  Branch                  Status
+buildx      yourname/fix-build      1 ahead, 2 files changed
+compose     yourname/fix-build      clean
 ```
 
-When you're ready to ship, it's just git — `git push` and open a PR like you
-normally would. Or ask your agent to do it: "submit a PR for my changes" works
-out of the box since each repo is a standard git clone.
+Push and open pull requests with your normal Git workflow. When the work is
+done, remove the workspace:
 
-`wsp rm` is safe — it blocks if any repo has uncommitted work or unmerged
-branches (including squash-merged PRs). Removed workspaces are recoverable
-with `wsp recover <name>`; `wsp ls --removed` shows what is still restorable.
+```bash
+wsp rm fix-build
+```
+
+Removal is recoverable by default. `wsp` blocks removal when it finds
+uncommitted work or unmerged branches, including squash-merged pull requests.
+Use `wsp ls --removed` to see restorable workspaces and `wsp recover <name>` to
+bring one back.
+
+## Reuse a set of repositories
+
+Save repositories as a template when you often work on them together:
+
+```bash
+wsp template new docker-dev compose buildx
+wsp new my-feature -t docker-dev
+```
+
+Templates are shareable YAML files:
+
+```bash
+wsp template export docker-dev
+wsp template import docker-dev.wsp.yaml
+```
+
+## Set up repositories after cloning
+
+A repository can declare trusted post-clone setup commands in a `.wsp.yaml` at
+its root:
+
+```yaml
+setup_commands:
+  - task setup
+  - lefthook install
+```
+
+When `wsp` creates a workspace or adds a repository, it displays these commands
+and asks before running them. Approval is remembered and requested again if the
+commands change.
+
+```text
+Setup commands for github.com/acme/api-gateway:
+  task setup
+  lefthook install
+Run these commands? [y/N] y
+```
+
+Run them again with `wsp repo setup`. If a repository was cloned before its
+commands were approved, `wsp doctor --fix` can finish the setup.
 
 ## Shell integration
 
-Tab completion and auto-cd after `wsp new`:
+`wsp setup` can configure shell integration for you. To configure it manually,
+add the matching line to your shell's startup file:
 
 ```bash
 # zsh
@@ -75,152 +155,98 @@ eval "$(wsp completion bash)"
 wsp completion fish | source
 ```
 
-## Templates
+This enables tab completion, moves into a workspace after `wsp new`, and moves
+out safely when removing the workspace you are currently in.
 
-Save a set of repos so you don't have to remember them every time:
+## Command overview
 
-```bash
-wsp template new docker-dev compose buildx
-wsp new my-feature -t docker-dev
-```
+| Goal | Command |
+|------|---------|
+| Create a workspace | `wsp new <name> [repos...] [-t template]` |
+| List workspaces | `wsp ls` |
+| Enter a workspace | `wsp cd <workspace>` |
+| See status across repos | `wsp st [workspace]` |
+| Review changes across repos | `wsp diff [workspace] [-- args]` |
+| View history across repos | `wsp log [workspace] [-- args]` |
+| Fetch and rebase repos | `wsp sync [workspace]` |
+| Run a command across repos | `wsp exec [workspace] -- <command>` |
+| Add or remove repos | `wsp repo add/rm` |
+| Remove a workspace | `wsp rm [workspace]` |
+| Recover a removed workspace | `wsp recover <workspace>` |
+| Manage registered repos | `wsp registry add/ls/rm` |
+| Manage templates | `wsp template new/import/ls/show/rm/export` |
+| Manage settings | `wsp config ls/get/set/unset` |
 
-Share templates by checking them into a repo or passing the file around:
-
-```bash
-wsp template export docker-dev       # writes docker-dev.wsp.yaml
-wsp template import docker-dev.wsp.yaml   # import on another machine
-```
-
-## Per-repo setup
-
-Repos can declare post-clone setup commands in their own `.wsp.yaml`:
-
-```yaml
-# checked into the repo root
-setup_commands:
-  - task setup
-  - lefthook install
-```
-
-When you create or add a workspace, `wsp` shows the commands and asks for
-approval before running anything (like `direnv allow`). Saying yes records the
-approval so future clones skip the prompt; it re-prompts if the commands change.
-
-```
-Setup commands for github.com/acme/api-gateway:
-  task setup
-  lefthook install
-Run these commands? [y/N] y
-```
-
-Re-run at any time with `wsp repo setup`. `wsp doctor --fix` handles repos that
-were cloned without approval.
-
-## Configuration
-
-Prepend your name to all workspace branches:
-
-```bash
-wsp config set branch-prefix myname
-# wsp new fix-build → creates branch myname/fix-build
-```
-
-## Commands
-
-**Workspace lifecycle:**
-
-| Command | Description |
-|---------|-------------|
-| `wsp new <name> [repos...] [-t template]` | Create a workspace |
-| `wsp rm [workspace] [-f]` | Remove (recoverable by default) |
-| `wsp ls --removed` | List removed workspaces still restorable |
-| `wsp ls` | List workspaces |
-| `wsp cd <workspace>` | Jump into a workspace |
-| `wsp recover <workspace>` | Restore a removed workspace |
-| `wsp rename <old> <new>` | Rename a workspace |
-
-**Daily workflow:**
-
-| Command | Description |
-|---------|-------------|
-| `wsp st [workspace]` | Git status across repos |
-| `wsp diff [workspace] [-- args]` | Git diff across repos |
-| `wsp log [workspace] [-- args]` | Git log across repos |
-| `wsp sync [workspace]` | Fetch and rebase all repos |
-| `wsp exec <workspace> -- <cmd>` | Run a command in each repo |
-
-**Repo and admin:**
-
-| Command | Description |
-|---------|-------------|
-| `wsp repo add/rm/ls/fetch` | Manage repos in current workspace |
-| `wsp repo setup [repos] [--force]` | Run per-repo setup commands with approval prompt |
-| `wsp registry add/ls/rm` | Manage registered repositories |
-| `wsp template new/import/ls/show/rm/export` | Manage workspace templates |
-| `wsp config ls/get/set/unset` | Manage settings |
-
-All commands support `--json` for scripting and AI agents.
-See [docs/usage.md](docs/usage.md) for the full reference.
+Every command supports `--json` for scripts and coding agents. See the
+[full usage guide](docs/usage.md) or run `wsp help <command>` for details.
 
 ## How it works
 
-```
+```text
 ~/.local/share/wsp/
-  mirrors/
-    github.com/docker/
-      compose.git/           bare mirror (one network clone)
-      buildx.git/            bare mirror
+└── mirrors/
+    └── github.com/docker/
+        ├── compose.git/     # bare mirror; fetched once
+        └── buildx.git/
 
 ~/dev/workspaces/
-  fix-build/
-    .wsp.yaml                workspace metadata
-    compose/                 local clone (branch: fix-build)
-    buildx/                  local clone (branch: fix-build)
+└── fix-build/
+    ├── .wsp.yaml            # workspace metadata
+    ├── compose/             # normal local clone
+    └── buildx/              # normal local clone
 ```
 
-Each repo is registered once as a bare mirror. Workspaces are directories of
-local clones (via `git clone --local` hardlinks) that share a branch name.
-Each clone has a single `origin` remote pointing to the real upstream — no
-wsp-specific remotes or config leak into your repos.
+Registered repositories have a bare local mirror. Workspace clones reuse its
+Git objects through local hardlinks, while each clone keeps a single `origin`
+pointing to the real upstream. No `wsp`-specific remotes or Git configuration
+leak into your repositories.
 
-## Other install methods
+## Other installation methods
 
 <details>
-<summary>Binary download</summary>
+<summary>Download a binary</summary>
 
-Download a pre-built binary from the [latest release](https://github.com/jganoff/wsp/releases/latest):
+Download a prebuilt archive from the
+[latest release](https://github.com/jganoff/wsp/releases/latest):
 
-- **Windows**: `wsp-x86_64-pc-windows-msvc.zip` or `wsp-aarch64-pc-windows-msvc.zip`
-- **macOS**: `wsp-aarch64-apple-darwin.tar.xz`
-- **Linux**: `wsp-x86_64-unknown-linux-gnu.tar.xz` or `wsp-aarch64-unknown-linux-gnu.tar.xz`
+- **Windows:** `wsp-x86_64-pc-windows-msvc.zip` or
+  `wsp-aarch64-pc-windows-msvc.zip`
+- **macOS:** `wsp-aarch64-apple-darwin.tar.xz`
+- **Linux:** `wsp-x86_64-unknown-linux-gnu.tar.xz` or
+  `wsp-aarch64-unknown-linux-gnu.tar.xz`
 
-Extract and add the binary to your `PATH`.
+Extract the archive and add the binary to your `PATH`.
+
 </details>
 
 <details>
-<summary>Build from source (requires Rust)</summary>
+<summary>Build from source</summary>
 
-```
+Requires [Rust](https://www.rust-lang.org/tools/install).
+
+```bash
 cargo install --git https://github.com/jganoff/wsp.git
 ```
 
-To install from a local clone:
+From a local clone:
 
-```
+```bash
 cargo install --path crates/wsp
 ```
+
 </details>
 
-## Development
+## Contributing
 
-Requires [Rust](https://www.rust-lang.org/tools/install) (stable) and
-[just](https://github.com/casey/just).
+Development requires [Rust](https://www.rust-lang.org/tools/install) (stable)
+and [just](https://github.com/casey/just).
 
-```
-just          # check (fmt + clippy)
-just build    # build release binary
+```bash
+just setup    # install the pre-commit hook once
+just          # format and lint checks
+just build    # build a release binary
 just test     # run all tests
-just ci       # full CI pipeline
+just ci       # run the full CI pipeline
 ```
 
 ## License


### PR DESCRIPTION
```whatsnew
NONE
```

## What

Rework the README around a first-time reader's path from value proposition to first workspace and daily workflow. Preserve advanced guidance while moving templates, setup hooks, internals, and contributor details behind the core onboarding flow.

## Why

New users should understand what wsp solves, why it is useful, and how to become productive within the first 30 seconds.

## Verification

- `git diff --check`
- Verified relative README links resolve
- Checked documented commands against the current CLI implementation
- Full tests not run (documentation-only change)