### PR TITLE
chore(release): v0.19.0-rc.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.19.0-rc.6] - 2026-08-29
+
+### Bug Fixes
+
+- *(new)* Copy objects across filesystems (#161)
+- *(mirror)* Avoid races resolving default branch (#163)
+- *(mirror)* Verify fallback HEAD exactly (#164)
+- Keep multiline workspace list formatting aligned (#162)
+
 ## [0.19.0-rc.5] - 2026-08-27
 
 ### Features
@@ -852,5 +861,4 @@ All notable changes to this project will be documented in this file.
 
 - *(docs)* Remove obsolete Go-era output formatting design doc
 - Apply cargo fmt
-
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,7 +1550,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wsp"
-version = "0.19.0-rc.5"
+version = "0.19.0-rc.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1576,7 +1576,7 @@ dependencies = [
 
 [[package]]
 name = "wsp-core"
-version = "0.19.0-rc.5"
+version = "0.19.0-rc.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.19.0-rc.5"
+version = "0.19.0-rc.6"
 dependencies = [
  "anyhow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version    = "0.19.0-rc.5"
+version    = "0.19.0-rc.6"
 edition    = "2024"
 license    = "MIT"
 repository = "https://github.com/jganoff/wsp"

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -1,5 +1,14 @@
 # What's New
 
+## [0.19.0-rc.6] - 2026-08-29
+
+- `wsp new` now copies Git objects when a workspace and its mirror are on
+  different filesystems, instead of failing when hardlinks are unavailable.
+- `wsp new` no longer creates an empty branch when a populated mirror's default
+  branch is temporarily unreadable.
+- `wsp ls` keeps every workspace row aligned when descriptions contain line
+  breaks, and wraps long descriptions to fit your terminal.
+
 ## [0.19.0-rc.5] - 2026-08-27
 
 - `wsp rename` now keeps you in the equivalent subdirectory of the renamed


### PR DESCRIPTION
## Intent

Package the four fixes merged since RC.5 into a new prerelease for artifact-level validation before the final 0.19.0 release.

RC.6 covers cross-filesystem workspace creation, stable multiline list formatting, and fail-closed mirror default-branch resolution. The release notes describe the user-visible outcomes; the exact-ref follow-up remains an internal reinforcement of the mirror fix.

## Validation

- `just ci`
- 299 wsp tests, 402 wsp-core tests, 8 xtask tests, and doctests
- Windows and Linux cross-compilation checks
- release binary reports `0.19.0-rc.6`
- `wsp whatsnew` renders the RC.6 section
- POSIX offline smoke suite
- post-merge CI for #164 passed on Linux, macOS, and Windows, including both smoke scripts
- `git diff --check`

```whatsnew
NONE
```