### PR TITLE
chore(release): v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,30 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.19.0-rc.6] - 2026-08-29
-
-### Bug Fixes
-
-- *(new)* Copy objects across filesystems (#161)
-- *(mirror)* Avoid races resolving default branch (#163)
-- *(mirror)* Verify fallback HEAD exactly (#164)
-- Keep multiline workspace list formatting aligned (#162)
-
-## [0.19.0-rc.5] - 2026-08-27
-
-### Features
-
-- *(hints)* Warn when mirrors cannot hardlink (#157)
-
-### Bug Fixes
-
-- *(rename)* Preserve shell subdirectory position (#156)
-
-### Documentation
-
-- *(skills)* Add release notes drafting workflow (#155)
-
-## [0.19.0-rc.4] - 2026-08-26
+## [0.19.0] - 2026-08-30
 
 ### Features
 
@@ -34,43 +11,7 @@ All notable changes to this project will be documented in this file.
 - *(exec)* Report which signal killed a command (#136)
 - *(doctor)* Warn when clones cannot hardlink to mirrors (#145)
 - *(ls)* Show disk usage with --size, measured once for removed workspaces (#148)
-
-### Bug Fixes
-
-- *(gc)* Only auto-gc after mutating commands, and say what was purged (#131)
-- *(exec)* Exit quietly when the reader of our output goes away (#134)
-- *(exec)* Don't report a child killed by our own reader leaving (#135)
-- *(completion)* Move the shell out of a repo directory that repo rm deletes (#138)
-- *(exec)* Correct the sentinel's rationale and pin the signal table (#141)
-
-### Refactor
-
-- *(cli)* Ask where the user is, not where the process is (#139)
-
-### Documentation
-
-- *(completion)* Write down the wrapper's contract where it will be read (#128)
-- *(agents)* Review your own diff before opening the PR (#143)
-- *(skills)* Move testing and review guidance into a skill (#144)
-- Record the release-note and local-verification rules from 0.19.0 (#146)
-- *(agents)* Put the remaining conventions in git (#151)
-
-### Testing
-
-- Pin the invariants today's changes rely on (#142)
-- *(agents)* Guard that every output field is visible in the contract (#149)
-
-### Build
-
-- *(xtask)* Move release-note drafting into a Rust crate (#137)
-- *(xtask)* Add the cargo alias the docs assume (#140)
-- *(dist)* Pin the actions dist emits into release.yml (#154)
-
-### Ci
-
-- *(smoke)* Run the smoke scripts on every PR, and close the coverage gap (#133)
-
-## [0.19.0-rc.3] - 2026-08-24
+- *(hints)* Warn when mirrors cannot hardlink (#157)
 
 ### Bug Fixes
 
@@ -82,12 +23,22 @@ All notable changes to this project will be documented in this file.
 - *(completion)* Follow the workspace on rename, and guard the class (#121)
 - *(completion)* Stop the wrapper cd'ing into `--json` output (#127)
 - *(completion)* Keep `cd -` working after rm and rename (#124)
+- *(gc)* Only auto-gc after mutating commands, and say what was purged (#131)
+- *(exec)* Exit quietly when the reader of our output goes away (#134)
+- *(exec)* Don't report a child killed by our own reader leaving (#135)
+- *(completion)* Move the shell out of a repo directory that repo rm deletes (#138)
+- *(exec)* Correct the sentinel's rationale and pin the signal table (#141)
+- *(rename)* Preserve shell subdirectory position (#156)
+- *(new)* Copy objects across filesystems (#161)
+- *(mirror)* Avoid races resolving default branch (#163)
+- *(mirror)* Verify fallback HEAD exactly (#164)
 
 ### Refactor
 
 - *(completers)* Read ambient state only in the clap wrapper (#104)
 - *(config)* One constructor for Paths (#107)
 - *(completion)* Declare shell navigation on the command itself (#122)
+- *(cli)* Ask where the user is, not where the process is (#139)
 
 ### Documentation
 
@@ -97,6 +48,12 @@ All notable changes to this project will be documented in this file.
 - *(removal-safety)* Drop a note about a parameter that no longer exists (#119)
 - *(completers)* The unsafe_code guard is narrower than claimed (#120)
 - *(ci)* State the constraint, not the incident (#117)
+- *(completion)* Write down the wrapper's contract where it will be read (#128)
+- *(agents)* Review your own diff before opening the PR (#143)
+- *(skills)* Move testing and review guidance into a skill (#144)
+- Record the release-note and local-verification rules from 0.19.0 (#146)
+- *(agents)* Put the remaining conventions in git (#151)
+- *(skills)* Add release notes drafting workflow (#155)
 
 ### Performance
 
@@ -106,10 +63,19 @@ All notable changes to this project will be documented in this file.
 
 - *(completion)* Assert wrapper cd behavior in real shells (#108)
 - *(completion)* Guard the assumptions behind recover's argv scan (#114)
+- Pin the invariants today's changes rely on (#142)
+- *(agents)* Guard that every output field is visible in the contract (#149)
+
+### Build
+
+- *(xtask)* Move release-note drafting into a Rust crate (#137)
+- *(xtask)* Add the cargo alias the docs assume (#140)
+- *(dist)* Pin the actions dist emits into release.yml (#154)
 
 ### Ci
 
 - Require a whatsnew block in every PR description (#116)
+- *(smoke)* Run the smoke scripts on every PR, and close the coverage gap (#133)
 
 ## [0.19.0-rc.2] - 2026-08-23
 
@@ -861,4 +827,5 @@ All notable changes to this project will be documented in this file.
 
 - *(docs)* Remove obsolete Go-era output formatting design doc
 - Apply cargo fmt
+
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,7 +1550,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wsp"
-version = "0.19.0-rc.6"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1576,7 +1576,7 @@ dependencies = [
 
 [[package]]
 name = "wsp-core"
-version = "0.19.0-rc.6"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.19.0-rc.6"
+version = "0.19.0"
 dependencies = [
  "anyhow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version    = "0.19.0-rc.6"
+version    = "0.19.0"
 edition    = "2024"
 license    = "MIT"
 repository = "https://github.com/jganoff/wsp"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -103,18 +103,51 @@ Leave out:
   internal APIs. If a user can't observe it by running `wsp`, it isn't a note.
   Expect to drop most of the changelog — that's the full record, this is the
   useful subset.
+- Fixes nobody was blocked by. The bar for the Fixes list is "could a user
+  have noticed this *before* it was fixed, and been annoyed?" A command that
+  failed, output that was wrong, work that looked lost. Not a skipped step that
+  now explains itself, an error message that got more precise, or a field that
+  gained a schema example. Those are true, and belong in the generated
+  changelog only.
 - Proof of work: "passes its full test suite", "now has 600 tests".
 - Implementation detail. Not "cloned from whatever the mirror last saw" but
   "gave you whatever was last fetched, which could be weeks old".
 - Install instructions, including for prereleases.
 - Why the release exists ("cut to validate the pipeline").
 
-Structure, omitting what doesn't apply: **Breaking Changes** (first; what to
-do, before/after) → **Highlights** (only for 3+ features; one paragraph) →
-**What's New** (`###` per user-facing theme, 1-2 sentences + a command to try;
-themes need 2+ entries; under 3 features use a flat list) → **Fixes** (flat,
+Structure, omitting what doesn't apply: anything breaking first, then one
+`###` per user-facing theme, most noticeable first, 1-2 sentences plus a
+command to try (under 3 features, use a flat list instead) → **Fixes** (flat,
 most impactful first, each starting with the command) → **Internal** (only
 removals or deprecations a user could hit).
+
+Name a breaking change after the change and prefix it: `### Breaking: `wsp
+recover` no longer lists`. Say what to do, with before/after. Not a
+`Breaking Changes` category heading: every other heading names a specific
+thing, so a category label reads as a peer of the features beside it, leaves a
+scanner unable to tell which heading is the breaking one, and is plural for
+what is usually a single change. Two breaking changes means two named
+headings.
+
+No summary paragraph, and no `### What's New` wrapper around the themes. The
+theme headings are the skim layer, and ordering them by impact already says
+what matters most; a paragraph naming the same three things makes the reader
+read the release twice. Every entry from 0.15.0 on goes straight from the
+version heading to `###` themes — follow them, not a template.
+
+Close the section with a link to the release, since the Fixes list is a
+deliberate subset:
+
+```
+Full commit log: https://github.com/jganoff/wsp/releases/tag/vX.Y.Z
+```
+
+Do not answer a long Fixes list by promoting the whole thing to that link. The
+generated changelog is commit subjects (`fix(completion): make rm vacate
+unconditionally`) where the note reads "`wsp rm` no longer strands you in a
+directory that is gone". Someone who hit the bug is searching for the second,
+and that gap is the reason this file exists. A long list usually means a large
+release, not padding.
 
 Format: ATX headings; fenced blocks with no language tag (`wsp whatsnew` dims
 them, so don't rely on column alignment); backtick commands, flags, files; no

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -1,27 +1,8 @@
 # What's New
 
-## [0.19.0-rc.6] - 2026-08-29
+## [0.19.0] - 2026-08-29
 
-- `wsp new` now copies Git objects when a workspace and its mirror are on
-  different filesystems, instead of failing when hardlinks are unavailable.
-- `wsp new` no longer creates an empty branch when a populated mirror's default
-  branch is temporarily unreadable.
-- `wsp ls` keeps every workspace row aligned when descriptions contain line
-  breaks, and wraps long descriptions to fit your terminal.
-
-## [0.19.0-rc.5] - 2026-08-27
-
-- `wsp rename` now keeps you in the equivalent subdirectory of the renamed
-  workspace instead of moving you to its root.
-- `wsp new` now warns when your workspace location causes Git data to be
-  duplicated, increasing disk usage. It shows which directories to move onto
-  the same filesystem.
-
-## [0.19.0-rc.4] - 2026-08-26
-
-### Breaking Changes
-
-#### `wsp recover` no longer lists
+### Breaking: `wsp recover` no longer lists
 
 `wsp recover` with no arguments used to list what could be restored, and `wsp
 recover show <name>` printed one workspace's details. Both are gone. `wsp ls
@@ -37,81 +18,47 @@ called `ls` or `show` could not be recovered at all before. Bare `wsp recover`
 tells you how many workspaces are recoverable and points at `wsp ls
 --removed`.
 
-### What's New
+### PowerShell shell integration
 
-#### `wsp ls --removed`
+`wsp completion powershell` sets up tab completion and the `wsp cd` wrapper.
 
-Lists workspaces you removed but can still restore, soonest to expire first,
-with their repos and how long is left. `-t`, `-U` and `-r` sort it.
+```
+wsp completion powershell
+```
+
+### Removed workspaces show up in `wsp ls`
+
+`wsp ls --removed` lists what you removed but can still restore, soonest to
+expire first, with their repos and how long is left. `-t`, `-U` and `-r` sort
+it.
 
 ```
 wsp ls --removed
 ```
 
-Plain `wsp ls` now ends with a line counting what is recoverable, and names
-the workspace when it is within a day of being purged for good.
+Plain `wsp ls` now ends with a line counting what is recoverable, and names the
+workspace when it is within a day of being purged for good.
 
-#### `wsp ls --size` shows disk usage
+### `wsp ls --size` shows disk usage
 
 How much disk a workspace is using, for the ones you removed as well as the
-ones you still have. This is what `wsp recover show` used to print.
+ones you still have.
 
 ```
 wsp ls --size
 wsp ls --removed --size
 ```
 
-#### `wsp doctor` checks that your workspaces and wsp's data share a disk
+### wsp tells you when git data is being duplicated
 
-When they do not, each workspace keeps its own full copy of every repo's git
-history instead of sharing one, which costs a lot of disk, and removing a
-workspace is no longer a single step, so an interrupted `wsp rm` can leave
-part of it behind. `wsp doctor` now warns, with both paths.
+If your workspaces and wsp's data are on different filesystems, each workspace
+keeps its own full copy of every repo's history instead of sharing one, and
+removing a workspace stops being a single atomic step. `wsp new` warns when it
+happens and `wsp doctor` checks for it, both naming the directories to move.
 
 ```
 wsp doctor
 ```
-
-### Fixes
-
-- `wsp ls`, `wsp st` and other read-only commands no longer delete expired
-  recoverable workspaces as a side effect. Cleanup only happens after a
-  command that changes something, and says what it removed.
-- `wsp repo rm` no longer leaves your shell in the deleted repo's directory.
-  It puts you in the workspace instead. On Windows the removal used to fail
-  outright when you were standing in the repo.
-- `wsp exec`, `wsp fetch` and `wsp sync` no longer crash when you pipe them
-  into something that stops reading early, such as `head` or `grep -q`. They
-  stop quietly, and `wsp exec` no longer reports the interrupted command as a
-  failure.
-- `wsp exec` names the signal that killed a command instead of reporting `exit
-  status -1`. `--json` carries the number in a new `signal` field.
-- `wsp ls` no longer hides the recoverable-workspace notice when you have no
-  active workspaces left, which is exactly when you need it.
-- `wsp rm` tells you the date recovery stops working, instead of a duration
-  you have to count from, and no longer claims a workspace is recoverable when
-  it had no metadata and was deleted outright.
-- `wsp help --json` and `wsp repo setup-commands --json` now appear in the
-  JSON schema reference, alongside output fields that had no example.
-
-## [0.19.0-rc.3] - 2026-08-24
-
-### Fixes
-
-Shell integration only — these need `eval "$(wsp completion <shell>)"` in
-your shell startup, and all of them go back to v0.14.0.
-
-- `wsp new` and `wsp create` now always change into the new workspace. Before,
-  that only worked when you put the name first: `wsp new --empty my-ws` left
-  you where you were, and on PowerShell `wsp new -w other my-ws` could drop
-  you into the wrong workspace entirely.
-- `wsp rm` and `wsp rename` now work from inside the workspace you are acting
-  on. On Windows they failed outright.
-- `wsp rm` and `wsp rename` no longer break `cd -`. It takes you back where
-  you came from, not to your workspaces directory.
-- `wsp cd <workspace> --json` no longer fails.
-
-## [0.19.0-rc.2] - 2026-08-22
 
 ### `wsp create`
 
@@ -123,42 +70,65 @@ wsp create my-feature github.com/acme/api
 
 ### Fixes
 
+Shell integration (these need `eval "$(wsp completion <shell>)"` in your
+shell startup), and all of them go back to v0.14.0:
+
+- `wsp new` and `wsp create` now always change into the new workspace. Before,
+  that only worked when you put the name first: `wsp new --empty my-ws` left
+  you where you were, and on PowerShell `wsp new -w other my-ws` could drop
+  you into the wrong workspace entirely.
+- `wsp rm`, `wsp rename` and `wsp repo rm` now work from inside the workspace
+  or repo you are acting on. On Windows they failed outright.
+- `wsp rm` and `wsp rename` no longer break `cd -`. It takes you back where
+  you came from, not to your workspaces directory.
+- `wsp rename` keeps you in the equivalent subdirectory of the renamed
+  workspace instead of moving you to its root.
+- `wsp cd <workspace> --json` no longer fails.
+
+Everything else:
+
 - `wsp new` no longer leaves a repo with no commits when its default branch is
   not `main`. On some versions of git the workspace branch was created from
   nothing, so every file showed as staged and `wsp rm` refused with "unsaved
   work" that did not exist.
+- `wsp new` and `wsp repo add` work with repos whose default branch is not
+  `main`, including branch names containing slashes.
+- `wsp new` no longer fails when a workspace and its mirror are on different
+  filesystems and hardlinks are unavailable; it copies the git objects instead.
+- `wsp new` no longer creates an empty branch when a populated mirror's default
+  branch is temporarily unreadable.
+- `wsp repo add` now fetches before cloning. Adding a repo you had added before
+  gave you whatever was last fetched, which could be weeks old. It also made a
+  branch you had just pushed look missing, so the repo quietly started a new
+  branch instead of tracking yours. Pass `--no-fetch` to skip the fetch.
+- Per-repo setup commands now run on Windows. They were invoked through `sh`,
+  which is not there by default, so they failed.
+- If Windows will not let `wsp` create symlinks (Developer Mode off, and not
+  running elevated), it keeps going instead of failing. The `CLAUDE.md` link is
+  skipped, and `wsp doctor` tells you what to turn on.
+- `wsp ls`, `wsp st` and other read-only commands no longer delete expired
+  recoverable workspaces as a side effect. Cleanup only happens after a command
+  that changes something, and says what it removed.
+- `wsp ls` no longer hides the recoverable-workspace notice when you have no
+  active workspaces left, which is exactly when you need it.
+- `wsp ls` keeps every workspace row aligned when descriptions contain line
+  breaks, and wraps long descriptions to fit your terminal.
+- `wsp rm` tells you the date recovery stops working, instead of a duration you
+  have to count from, and no longer claims a workspace is recoverable when it
+  had no metadata and was deleted outright.
 - `wsp rm` no longer blocks on linked worktrees that git has already marked
   prunable. Live worktrees still block, since removing the workspace would
   orphan them.
-
-## [0.19.0-rc.1] - 2026-08-22
-
-### PowerShell shell integration
-
-`wsp completion powershell` sets up tab completion and the `wsp cd` wrapper,
-bringing PowerShell in line with zsh, bash, and fish.
-
-```
-wsp completion powershell
-```
-
-### Fixes
-
-- Per-repo setup commands now run on Windows. They were invoked through `sh`,
-  which is not there by default, so they failed.
-- If Windows will not let `wsp` create symlinks — Developer Mode off, and not
-  running elevated — it keeps going instead of failing. The `CLAUDE.md` link
-  is skipped, and `wsp doctor` tells you what to turn on.
-- `wsp repo add` now fetches before cloning. Adding a repo you had added
-  before gave you whatever was last fetched, which could be weeks old. It also
-  made a branch you had just pushed look missing, so the repo quietly started a
-  new branch instead of tracking yours. Pass `--no-fetch` to skip the fetch.
+- `wsp st` and `wsp rm` now say when they are fetching pull requests. With
+  `pr.source = github` set, a large workspace looked like a hung terminal.
+- `wsp exec`, `wsp repo fetch` and `wsp sync` no longer crash when you pipe them
+  into something that stops reading early, such as `head` or `grep -q`. They
+  stop quietly, and `wsp exec` no longer reports the interrupted command as a
+  failure.
 - `wsp doctor --fix` no longer warns that a repo's origin URL differs from the
   registry right after registering that repo itself.
-- `wsp new` and `wsp repo add` work with repos whose default branch is not
-  `main`, including branch names containing slashes.
-- `wsp repo fetch` now says why it skipped propagating refs instead of staying
-  silent.
+
+Full commit log: https://github.com/jganoff/wsp/releases/tag/v0.19.0
 
 ## [0.18.0] - 2026-05-29
 


### PR DESCRIPTION
```whatsnew
NONE
```

Bumps `0.19.0-rc.6` to `0.19.0`, regenerates `CHANGELOG.md`, replaces the six rc sections in `WHATSNEW.md` with one `## [0.19.0]`, and adds three rules to `RELEASING.md` for writing that section.

## The notes

```
### Breaking: `wsp recover` no longer lists
### PowerShell shell integration
### Removed workspaces show up in `wsp ls`
### `wsp ls --size` shows disk usage
### wsp tells you when git data is being duplicated
### `wsp create`
### Fixes                              (20 bullets)
Full commit log: <release URL>
```

One release, ordered by impact. Where several changes fixed one thing, they are one entry: the "works from inside what you're acting on" fix covers `wsp rm`, `wsp rename` and `wsp repo rm` in a single bullet; the cross-filesystem `wsp doctor` check and `wsp new` warning share a section.

The Fixes list is a deliberate subset. Three changes no user was blocked by are in the generated changelog only, and the section closes with a link to it.

## `RELEASING.md`

Three rules, each matching what this section does:

- Name a breaking change after the change, prefixed `Breaking:`. Not a `Breaking Changes` category heading, which reads as a peer of the feature headings beside it and is plural for a single change.
- No summary paragraph and no `### What's New` wrapper. The theme headings are the skim layer and impact-ordering conveys priority.
- Exclude fixes nobody was blocked by. The bar is whether a user could have noticed it before it was fixed.

## Validation

- `just check`, `cargo test --workspace`, `just smoke`
- Every `wsp <cmd>` in the notes checked against `wsp --help`
- `whatsnew` gate: `## [0.19.0]` present for the bumped version
- release-notes extraction: 127 lines, opens on the breaking-change heading, stops before `0.18.0`
- No `0.19.0-rc` reference remains in `WHATSNEW.md`
- Built binary renders the section, breaking change first
- `publish = false` in `release.toml`, so nothing reaches crates.io

Upgrade from 0.18.0, which no CI job covers: using the published rc.6 artifact against a workspace created by the published 0.18.0 binary, `st`, `ls`, `repo ls`, `st --json`, `ls --removed` and `rm` all work, and the removed workspace shows as recoverable. A `.wsp.yaml` written by 0.18.0 reads without migration.

## Before dispatching

`publish-homebrew-formula` skips on prereleases, so it has not run since 0.18.0 on 2026-05-29, and `HOMEBREW_TAP_TOKEN` dates from 2026-02-13. Confirm the PAT has not expired first: the job runs after `host`, so a failure leaves a published, tagged 0.19.0 with the tap still on 0.18.0 and `announce` failed behind it. Re-runnable, but better avoided.

The tap formula currently reads `version "0.18.0"`; check it moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
